### PR TITLE
Tidy up genetic map IDs and docs.

### DIFF
--- a/docs/_ext/speciescatalog.py
+++ b/docs/_ext/speciescatalog.py
@@ -246,7 +246,9 @@ class SpeciesCatalogDirective(SphinxDirective):
         target = self.get_target(map_id)
         section = nodes.section(ids=[map_id])
         section += nodes.title(text=genetic_map.id)
-        section += nodes.paragraph(text=genetic_map.description)
+        section += nodes.paragraph(text=genetic_map.long_description)
+        section += nodes.rubric(text="Citations")
+        section += self.citation_list(genetic_map)
         return [target, section]
 
     def genetic_maps_table(self, species):
@@ -271,7 +273,7 @@ class SpeciesCatalogDirective(SphinxDirective):
         entry += nodes.paragraph(text="Year")
         row += entry
         entry = nodes.entry()
-        entry += nodes.paragraph(text="Reference")
+        entry += nodes.paragraph(text="Description")
         row += entry
 
         thead.append(row)
@@ -294,9 +296,7 @@ class SpeciesCatalogDirective(SphinxDirective):
 
             entry = nodes.entry()
             para = nodes.paragraph()
-            doi = genetic_map.citations[0].doi
-            para += nodes.reference(internal=False, refuri=doi, text=doi)
-            entry += para
+            entry += nodes.paragraph(text=genetic_map.description)
             row += entry
 
         tbody = nodes.tbody()

--- a/stdpopsim/catalog/arabidopsis_thaliana.py
+++ b/stdpopsim/catalog/arabidopsis_thaliana.py
@@ -67,19 +67,23 @@ stdpopsim.register_species(_species)
 
 _gm = stdpopsim.GeneticMap(
     species=_species,
-    id="Salome2012_TAIR7",
-    description="Salome map FIXME",
-    long_description=(
-        "Genetic map from Salome 2012 averaged across population crosses. "
-        "Please see this repo for details on how this was done: "
-        "https://github.com/LohmuellerLab/arabidopsis_recomb_maps"),
+    id="SalomeAveraged_TAIR7",
+    description="Crossover frequency map averaged over 17 populations",
+    long_description="""
+        This map is based on the study of crossover frequencies in over 7000
+        plants in 17 F2 populations derived from crosses between 18 A. thaliana
+        accessions. Salomé et al provide genetic maps for each of these
+        populations. To get a single map for each chromosome, the Haldane map function
+        distances were converted to recombination rates (cM/Mb) for each cross
+        and then averaged across the 17 populations using loess.
+        """,
     url=(
         "http://www.eeb.ucla.edu/Faculty/Lohmueller/data/"
         "uploads/salome2012_maps.tar.gz"),
-    file_pattern="arab_{name}_map_loess.txt",
+    file_pattern="arab_{id}_map_loess.txt",
     citations=[stdpopsim.Citation(
         doi="https://doi.org/10.1038/hdy.2011.95",
-        author="Salome et al.",
+        author="Salomé et al.",
         year=2012,
         reasons={stdpopsim.CiteReason.GEN_MAP})]
     )

--- a/stdpopsim/catalog/drosophila_melanogaster.py
+++ b/stdpopsim/catalog/drosophila_melanogaster.py
@@ -79,15 +79,20 @@ stdpopsim.register_species(_species)
 
 _gm = stdpopsim.GeneticMap(
     species=_species,
-    id="Comeron2012_dm6",
-    description="Comeron",
-    long_description=(
-        # TODO more detail
-        "Comeron et al. (2012) maps (lifted over to dm6)."),
+    id="ComeronCrossover_dm6",
+    description="Crossover map from meioses products of 8 lab crosses",
+    long_description="""
+        The crossover map from a study of 8 crosses of 12 highly
+        inbred lines of D. melanogaster. This is based on the
+        products of 5,860 female meioses from whole genome sequencing data.
+        Recombination rates were calculated from the density of individual
+        recombination events that were detected in crosses. This map was
+        subsequently lifted over to the dm6 assembly.
+        """,
     url=(
         "http://sesame.uoregon.edu/~adkern/dmel_recombination_map/"
         "comeron2012_maps.tar.gz"),
-    file_pattern="genetic_map_comeron2012_dm6_{name}.txt",
+    file_pattern="genetic_map_comeron2012_dm6_{id}.txt",
     citations=[stdpopsim.Citation(
         author="Comeron et al",
         doi="https://doi.org/10.1371/journal.pgen.1002905",

--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -112,21 +112,28 @@ stdpopsim.register_species(_species)
 
 _gm = stdpopsim.GeneticMap(
     species=_species,
-    id="HapmapII_GRCh37",
-    description="Hapmap Phase II",
-    long_description=(
-        "The Phase II HapMap Genetic map (lifted over to GRCh37) used in "
-        "1000 Genomes. Please see the README for more details."),
+    id="HapMapII_GRCh37",
+    description="HapMap Phase II lifted over to GRCh37",
+    long_description="""
+        This genetic map is from the Phase II Hapmap project
+        and based on 3.1 million genotyped SNPs
+        from 270 individuals across four populations (YRI, CEU, CHB and JPT).
+        Genome wide recombination rates were estimated using LDHat.
+        This version of the HapMap genetic map was lifted over to GRCh37
+        (and adjusted in regions where the genome assembly had rearranged)
+        for use in the 1000 Genomes project. Please see the README file on
+        the 1000 Genomes download site for details of these adjustments.
+        """,
     url=(
         "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/"
         "20110106_recombination_hotspots/"
         "HapmapII_GRCh37_RecombinationHotspots.tar.gz"),
-    file_pattern="genetic_map_GRCh37_{name}.txt",
+    file_pattern="genetic_map_GRCh37_{id}.txt",
     citations=[
         stdpopsim.Citation(
             doi="https://doi.org/10.1038/nature06258",
             year=2007,
-            author="1000 Genomes Project consortium",
+            author="The International HapMap Consortium",
             reasons={stdpopsim.CiteReason.GEN_MAP}),
         ]
     )
@@ -134,16 +141,20 @@ _species.add_genetic_map(_gm)
 
 _gm = stdpopsim.GeneticMap(
     species=_species,
-    id="Decode2010_GRCh36",
-    description="Decode sex-averaged",
-    # TODO need more detail here. Which map did we choose, carrier or non-carrier?
-    long_description=(
-        "Decode sex-averaged genetic map."
-        "See https://www.decode.com/addendum/ for more details"),
+    id="DeCodeSexAveraged_GRCh36",
+    description="Sex averaged map from deCode family study",
+    long_description="""
+        This genetic map is from the deCode study of recombination
+        events in 15,257 parent-offspring pairs from Iceland.
+        289,658 phased autosomal SNPs were used to call recombinations
+        within these families, and recombination rates computed from the
+        density of these events. This is the combined male and female
+        (sex averaged) map. See
+        https://www.decode.com/addendum/ for more details.""",
     url=(
         "http://sesame.uoregon.edu/~adkern/stdpopsim/decode/"
         "decode_2010_sex-averaged_map.tar.gz"),
-    file_pattern="genetic_map_decode_2010_sex-averaged_{name}.txt",
+    file_pattern="genetic_map_decode_2010_sex-averaged_{id}.txt",
     citations=[
         stdpopsim.Citation(
             year=2010,

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -92,7 +92,7 @@ def get_models_help(species_id, model_id):
     for model_id in models:
         model = get_model_wrapper(species, model_id)
         models_text += f"{model.id}: {model.description}\n"
-        models_text += wrapper.fill(textwrap.dedent(model.description))
+        models_text += wrapper.fill(textwrap.dedent(model.long_description))
         models_text += "\n\n"
 
         models_text += indent + "Populations:\n"
@@ -133,9 +133,9 @@ def get_genetic_maps_help(species_id, genetic_map_id):
     indent = " " * 4
     wrapper = textwrap.TextWrapper(initial_indent=indent, subsequent_indent=indent)
     for map_id in maps:
-        map = get_genetic_map_wrapper(species, map_id)
-        maps_text += f"{map.id}\n"
-        maps_text += wrapper.fill(textwrap.dedent(map.description))
+        gmap = get_genetic_map_wrapper(species, map_id)
+        maps_text += f"{gmap.id}\n"
+        maps_text += wrapper.fill(textwrap.dedent(gmap.long_description))
         maps_text += "\n\n"
 
     return maps_text

--- a/stdpopsim/genetic_maps.py
+++ b/stdpopsim/genetic_maps.py
@@ -136,18 +136,18 @@ class GeneticMap(object):
                     "Error occured renaming map directory. Are several threads/processes"
                     "downloading this map at the same time?")
 
-    def get_chromosome_map(self, name):
+    def get_chromosome_map(self, id):
         """
-        Returns the genetic map for the chromosome with the specified name.
+        Returns the genetic map for the chromosome with the specified id.
         """
-        chrom = self.species.genome.get_chromosome(name)
+        chrom = self.species.genome.get_chromosome(id)
         if not self.is_cached():
             self.download()
         # We assume that if the map file does not exist this is a property of the
         # map itself and not a download error. If a failure occurs reading the map
         # this is propagated to the user, as this indicates a corrupted map which
         # needs to be redownloaded.
-        map_file = os.path.join(self.map_cache_dir, self.file_pattern.format(name=name))
+        map_file = os.path.join(self.map_cache_dir, self.file_pattern.format(id=id))
         if os.path.exists(map_file):
             ret = msprime.RecombinationMap.read_hapmap(map_file)
         else:
@@ -155,7 +155,7 @@ class GeneticMap(object):
                 "Warning: recombination map not found for chromosome: '{}'"
                 " on map: '{}', substituting a flat map with chromosome "
                 "recombination rate {}".format(
-                    name, self.id, chrom.recombination_rate))
+                    id, self.id, chrom.recombination_rate))
             ret = msprime.RecombinationMap.uniform_map(
                     chrom.length, chrom.recombination_rate)
         return ret

--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -15,6 +15,17 @@ def is_valid_demographic_model_id(model_id):
     return regex.fullmatch(model_id) is not None
 
 
+def is_valid_genetic_map_id(gmap_id):
+    """
+    Returns True if the specified string is a valid genetic map ID. This must
+    be a string with the following pattern:
+
+    {CamelCaseName}_{assembly ID}
+    """
+    regex = re.compile(r"[A-Z][A-Za-z0-9]*_\w+")
+    return regex.fullmatch(gmap_id) is not None
+
+
 def is_valid_species_id(species_id):
     """
     Returns True if the specified string is a valid species ID. This must

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -435,7 +435,7 @@ class TestHelp(unittest.TestCase):
 
     def test_homsap_genetic_maps_help(self):
         self.run_stdpopsim("HomSap --help-genetic-maps")
-        self.run_stdpopsim("HomSap --help-genetic-maps HapmapII_GRCh37")
+        self.run_stdpopsim("HomSap --help-genetic-maps HapMapII_GRCh37")
 
     def test_all_species_genetic_maps_help(self):
         for species in stdpopsim.all_species():
@@ -466,7 +466,7 @@ class TestWriteBibtex(unittest.TestCase):
     def test_number_of_calls(self):
         # Test that genetic map citations are converted.
         species = stdpopsim.get_species("HomSap")
-        genetic_map = species.get_genetic_map("HapmapII_GRCh37")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
         contig = species.get_contig("chr22", genetic_map=genetic_map.id)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         engine = stdpopsim.get_default_engine()
@@ -507,7 +507,7 @@ class TestWriteCitations(unittest.TestCase):
 
     def test_genetic_map_citations(self):
         species = stdpopsim.get_species("HomSap")
-        genetic_map = species.get_genetic_map("HapmapII_GRCh37")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
         contig = species.get_contig("chr22", genetic_map=genetic_map.id)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         engine = stdpopsim.get_default_engine()

--- a/tests/test_genetic_maps.py
+++ b/tests/test_genetic_maps.py
@@ -14,6 +14,7 @@ import msprime
 
 import stdpopsim
 from stdpopsim import genetic_maps
+from stdpopsim import utils
 import tests
 
 
@@ -249,13 +250,18 @@ class TestAllGeneticMaps(tests.CacheReadingTest):
         for gm in stdpopsim.all_genetic_maps():
             self.assertIsInstance(gm, genetic_maps.GeneticMap)
 
+    def test_ids(self):
+        for gm in stdpopsim.all_genetic_maps():
+            self.assertIsInstance(gm.id, str)
+            self.assertTrue(utils.is_valid_genetic_map_id(gm.id))
+
 
 class TestGetChromosomeMap(tests.CacheReadingTest):
     """
-    Tests if we get chromosome maps using the HapmapII_GRCh37 human map.
+    Tests if we get chromosome maps using the HapMapII_GRCh37 human map.
     """
     species = stdpopsim.get_species("HomSap")
-    genetic_map = species.get_genetic_map("HapmapII_GRCh37")
+    genetic_map = species.get_genetic_map("HapMapII_GRCh37")
 
     def test_warning_from_no_mapped_chromosome(self):
         chrom = self.species.genome.get_chromosome("chrY")

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -55,9 +55,9 @@ class TestGenome(unittest.TestCase, test_species.GenomeTestMixin):
         self.assertEqual(genome.get_chromosome("chrY").length, 59373566)
 
     def test_recombination_rates(self):
-        # recompute recombination rates from HapmapII_GRCh37 map then
+        # recompute recombination rates from HapMapII_GRCh37 map then
         # compare the results to the current recombination rates for each chromosome
-        genetic_map = "HapmapII_GRCh37"
+        genetic_map = "HapMapII_GRCh37"
         species = stdpopsim.get_species("HomSap")
         for chrom in self.genome.chromosomes:
             if chrom.id == "chrY":

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -39,7 +39,7 @@ class TestSpecies(unittest.TestCase):
             stdpopsim.register_species(species)
 
     def test_get_known_genetic_map(self):
-        good = ["HapmapII_GRCh37", "Decode2010_GRCh36"]
+        good = ["HapMapII_GRCh37", "DeCodeSexAveraged_GRCh36"]
         species = stdpopsim.get_species("HomSap")
         for name in good:
             gmap = species.get_genetic_map(name)
@@ -55,7 +55,7 @@ class TestSpecies(unittest.TestCase):
 
     def test_add_duplicate_genetic_map(self):
         species = stdpopsim.get_species("HomSap")
-        genetic_map = species.get_genetic_map("HapmapII_GRCh37")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
         with self.assertRaises(ValueError):
             species.add_genetic_map(genetic_map)
 
@@ -158,9 +158,9 @@ class TestGetContig(unittest.TestCase):
     def test_length_multiplier_on_empirical_map(self):
         with self.assertRaises(ValueError):
             self.species.get_contig(
-                "chr1", genetic_map="HapmapII_GRCh37", length_multiplier=2)
+                "chr1", genetic_map="HapMapII_GRCh37", length_multiplier=2)
 
     def test_genetic_map(self):
         # TODO we should use a different map here so we're not hitting the cache.
-        contig = self.species.get_contig("chr22", genetic_map="HapmapII_GRCh37")
+        contig = self.species.get_contig("chr22", genetic_map="HapMapII_GRCh37")
         self.assertIsInstance(contig.recombination_map, msprime.RecombinationMap)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,6 +61,40 @@ class TestValidDemographicModelId(unittest.TestCase):
             self.assertTrue(utils.is_valid_demographic_model_id(good_id))
 
 
+class TestValidGeneticMapId(unittest.TestCase):
+    """
+    Tests for the is_valid_demographic_model_id function.
+    """
+
+    def test_empty_string(self):
+        self.assertFalse(utils.is_valid_genetic_map_id(""))
+
+    def test_contains_spaces(self):
+        bad_ids = [
+            "CamelCase ABCD", " CamelCase_ABCD", "CamelCase_ABCD "]
+        for bad_id in bad_ids:
+            self.assertFalse(utils.is_valid_genetic_map_id(bad_id))
+
+    def test_bad_name(self):
+        bad_ids = [
+            "camelCase_ABCD", "1CamelCase_ABCD", "Camel-Case_ABCD"]
+        for bad_id in bad_ids:
+            self.assertFalse(utils.is_valid_genetic_map_id(bad_id))
+
+    def test_bad_assembly(self):
+        bad_ids = [
+            "CamelCase_AB CD", "CamelCase_", "CamelCase_AB-CD", "CamelCase_AB.CD"]
+        for bad_id in bad_ids:
+            self.assertFalse(utils.is_valid_genetic_map_id(bad_id))
+
+    def test_good_ids(self):
+        good_ids = [
+            "CamelCase_ABCD", "CamelCase_a", "CamelCase_1000",
+            "C_ABCD", "C_X"]
+        for good_id in good_ids:
+            self.assertTrue(utils.is_valid_genetic_map_id(good_id))
+
+
 class TestValidSpeciesId(unittest.TestCase):
     """
     Tests for the is_valid_demographic_model_id function.


### PR DESCRIPTION
This should finalise the changes needed in the genetic maps before release. Main changes:

- Tried to add some descriptive documentation to the maps. Users who don't know anything about the maps shouldn't have to read the paper. The long_descriptions attempt to give a summary of how the maps were made. The ``description`` is a shorter one-line description of what the map is.

- Made an attempt to make the IDs more descriptive, plus trying to avoid future name clashes (we could have the male and female maps for deCode later). I'm not sure there's much point in adding a year to the IDs since the combination of descriptive name and assembly is likely to be unique.