### PR TITLE
Added a mention of generic models into the catalog.

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -31,8 +31,14 @@ and saves the output to a file called ``test.trees``:
 
     $ stdpopsim HomSap -c chr22 -o test.trees -g HapMapII_GRCh37 --model OutOfAfrica_3G09 2 2 2
 
-(To learn more about using ``stdpopsim`` via the command-line, read our :ref:`sec_tutorial`
-about it.)
+(To learn more about using ``stdpopsim`` via the command-line, read our 
+:ref:`tutorial <sec_cli_tute>` about it.)
+
+In addition to the species-specific models listed in this catalog, ``stdpopsim`` offers
+a number of generic demographic models that can be run with any species.
+These are described and listed in the :ref:`Generic models API <sec_api_generic_models>`.
+Simulations using these generic models must be run via the Python interface; see our
+:ref:`Python tutorial <sec_python_tute>` to learn how to do this.
 
 Are there other well-known organisms, genetic maps or models that
 you'd like to see in ``stdpopsim``? Head to our :ref:`sec_development`
@@ -50,3 +56,4 @@ Then, if you feel ready, make an issue on our
 .. speciescatalog:: AraTha
 
 .. speciescatalog:: EscCol
+

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -16,7 +16,7 @@ advanced tasks you may wish to do.
 Running ``stdpopsim``
 *********************
 
-.. sec_cli_tute:
+.. _sec_cli_tute:
 
 The command-line interface (CLI)
 ********************************
@@ -111,7 +111,7 @@ Lastly, the CLI also outputs the relevant citations for both the simulator used
 and the resources used for simulation scenario.
 
 
-.. sec_python_tute:
+.. _sec_python_tute:
 
 The Python interface
 *****************************


### PR DESCRIPTION
Closes #191.

> How about we add a "Generic models" section to the end of the catalog page, and put a manual table in there linking to the generic models?

I played around with this, but ended up deciding against it because it was just repeating a lot of the info in the API. There's also no natural way to structure this table so that it looks like the rest of the catalog, given can be used with any of the species.

The main point was that the catalog should make mention of *all* of the simulation options available -- so I've added a small bit to the intro that explains where the generic models are listed.