### PR TITLE
added msprime req to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+msprime_ver = "msprime>=0.7.1"
+
 setup(
     name='stdpopsim',
     description='A library of population genetic simulation models',
@@ -32,7 +34,7 @@ setup(
         ]
     },
     # NOTE: make sure this is the 'attrs' package, not 'attr'!
-    install_requires=["msprime", "attrs", "appdirs", "humanize"],
+    install_requires=[msprime_ver, "attrs", "appdirs", "humanize"],
     url='https://github.com/popsim-consortium/stdpopsim',
     project_urls={
         'Bug Reports': 'https://github.com/popsim-consortium/stdpopsim/issues',


### PR DESCRIPTION
When I installed the latest stdpopsim through conda, I ended getting an obscure error that had to do with my msprime version not being quite up to 0.7.1 (metadata param being added to population configuration). @jeromekelleher maybe you can review whether or not this is actually the right way to do this, but it might help ensure users don't have to do some debugging.