### PR TITLE
Support pulses of admixture in the SLiM engine.

### DIFF
--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -17,7 +17,7 @@ How backwards-time demographic events are mapped to forwards-time SLiM code:
  * `msprime.DemographyDebugger()` does much of the hard work by extracting
    epochs from the given model's `demographic_events`, and calculating a
    migration_matrix for each epoch from the `msprime.MigrationRateChange`
-   events. The epochs boundaries defined here are indirectly translated into
+   events. The epoch boundaries defined here are indirectly translated into
    "late events" in SLiM.
 
  * `msprime.PopulationParametersChange` events are translated into SLiM as
@@ -30,6 +30,9 @@ How backwards-time demographic events are mapped to forwards-time SLiM code:
  * `msprime.MassMigration` events with proportion<1 indicate an admixture
    pulse at a single point in time. In SLiM, we call `pop.setMigrationRates()`
    in the relevant generation, and turn off migrations in the next generation.
+   When multiple MassMigration events correspond to a single SLiM generation,
+   the migration proportions multiply, following the msprime behaviour and
+   event ordering.
 
  * The migration_matrix for each epoch describes continuous migrations that
    occur over long time periods. In SLiM, we call `pop.setMigrationRates()`.
@@ -333,6 +336,8 @@ def slim_makescript(
             if isinstance(de, msprime.MassMigration):
 
                 if de.proportion < 1:
+                    # Calculate remainder of population after previous
+                    # MassMigration events in this epoch.
                     rem = 1 - np.sum([ap[3] for ap in admixture_pulses
                                      if ap[0] == i and ap[1] == de.source])
                     admixture_pulses.append((

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -163,6 +163,12 @@ function (void)setup(void) {
                         growth_phase_end = G[i] - 1;
                     }
 
+                    if (growth_phase_start >= growth_phase_end) {
+                        // Some demographic models have duplicate epoch times,
+                        // which should be ignored.
+                        next;
+                    }
+
                     N0 = N[i,j];
                     r = Q * growth_rates[i,j];
 
@@ -185,7 +191,12 @@ function (void)setup(void) {
                     if (j==k | N[i,j] == 0 | N[i,k] == 0)
                         next;
 
+                    m_last = migration_matrices[k,j,i-1];
                     m = migration_matrices[k,j,i];
+                    if (m == m_last) {
+                        // Do nothing if the migration rate hasn't changed.
+                        next;
+                    }
                     g = G[i-1];
                     sim.registerLateEvent(NULL,
                         "{dbg(self.source); " +
@@ -193,6 +204,24 @@ function (void)setup(void) {
                         g, g);
                 }
             }
+        }
+    }
+
+    // Admixture pulses.
+    if (length(admixture_pulses) > 0 ) {
+        for (i in 0:(ncol(admixture_pulses)-1)) {
+            g = G_start + gdiff(T_0, admixture_pulses[0,i]);
+            dest = admixture_pulses[1,i];
+            src = admixture_pulses[2,i];
+            rate = admixture_pulses[3,i];
+            sim.registerLateEvent(NULL,
+                "{dbg(self.source); " +
+                "p"+dest+".setMigrationRates("+src+", "+rate+");}",
+                g, g);
+            sim.registerLateEvent(NULL,
+                "{dbg(self.source); " +
+                "p"+dest+".setMigrationRates("+src+", 0);}",
+                g+1, g+1);
         }
     }
 
@@ -255,10 +284,19 @@ def slim_makescript(
             N[i, j] = int(pop.end_size)
             growth_rates[i, j] = pop.growth_rate
 
+    admixture_pulses = []
     subpopulation_splits = []
     for i, epoch in enumerate(epochs):
         for de in epoch.demographic_events:
             if isinstance(de, msprime.MassMigration):
+
+                if de.proportion < 1:
+                    admixture_pulses.append((
+                        f"_T[{i}]",
+                        de.source,  # forwards-time dest
+                        de.dest,  # forwards-time source
+                        de.proportion))
+                    continue
 
                 # Backwards: de.source is being merged into de.dest.
                 # Forwards: de.source is being created, taking individuals
@@ -268,11 +306,7 @@ def slim_makescript(
                 #       sim.addSubpopSplit(newpop, size, oldpop),
                 # which we trigger by adding a row to subpopulation_splits.
                 # This SLiM function creates newpop (=de.source), under the
-                # assumption that it doesn't already exist. But if
-                # proportion < 1, then de.source could already exist.
-                if de.proportion < 1:
-                    raise Exception("MassMigration with proportion<1.0 "
-                                    "not yet supported")
+                # assumption that it doesn't already exist.
 
                 subpopulation_splits.append((
                     f"_T[{i}]",
@@ -426,6 +460,15 @@ def slim_makescript(
             ');')
     printsc()
 
+    # Admixture pulses.
+    printsc('    // Admixture pulses, one row for each pulse.')
+    printsc('    defineConstant("admixture_pulses", ' +
+            matrix2str(
+                admixture_pulses,
+                col_comment="time, dest, source, rate") +
+            ');')
+    printsc()
+
     # Sampling episodes.
     s_counts = collections.Counter([(s.population, s.time) for s in samples])
     sampling_episodes = []
@@ -556,7 +599,7 @@ class _SLiMEngine(stdpopsim.Engine):
         s = subprocess.check_output(["slim", "-v"])
         return s.split()[2].decode("ascii").rstrip(",")
 
-    def simulate(self, contig=None, demographic_model=None, samples=None,
+    def simulate(self, demographic_model=None, contig=None, samples=None,
                  seed=None, verbosity=0,
                  slim_script_file=None, slim_rescale=10, slim_no_burnin=False,
                  **kwargs):

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -1,3 +1,40 @@
+"""
+SLiM simulation engine.
+
+This is a translation of the msprime API into SLiM's Eidos language, which
+resembles R. The generated SLiM script is designed differently to the recipes
+described in the SLiM reference manual. In our generated SLiM script, all the
+demographic model parameters are defined in multi-dimensional arrays at the
+top of the script, in the `initialize()` block. These arrays define the event
+generations, and event blocks are subsequently constructed programmatically
+using `sim.registerLateEvent()`, rather than writing out the blocks verbatim.
+This design is intended to permit modification of demographic parameters in
+the generated SLiM script, without needing to directly convert event times in
+the past into forwards-time generations.
+
+How backwards-time demographic events are mapped to forwards-time SLiM code:
+
+ * `msprime.DemographyDebugger()` does much of the hard work by extracting
+   epochs from the given model's `demographic_events`, and calculating a
+   migration_matrix for each epoch from the `msprime.MigrationRateChange`
+   events. The epochs boundaries defined here are indirectly translated into
+   "late events" in SLiM.
+
+ * `msprime.PopulationParametersChange` events are translated into SLiM as
+   `pop.setSubpopulationSize()`. If `growth_rate` is not None, the population
+   size is changed in every generation to match the specified rate.
+
+ * `msprime.MassMigration` events with proportion=1 are population splits
+   in forwards time. In SLiM, these are `sim.addSubpopSplit()`.
+
+ * `msprime.MassMigration` events with proportion<1 indicate an admixture
+   pulse at a single point in time. In SLiM, we call `pop.setMigrationRates()`
+   in the relevant generation, and turn off migrations in the next generation.
+
+ * The migration_matrix for each epoch describes continuous migrations that
+   occur over long time periods. In SLiM, we call `pop.setMigrationRates()`.
+"""
+
 import string
 import tempfile
 import subprocess


### PR DESCRIPTION
Closes #258.

This works for regular pulses of admixture, like in `HomSap/AncientEurasia_9K19`, by turning off migrations one generation after the admixture pulse is requested. However, due to a quirk of the model implementation, `HomSap/AmericanAdmixture_4B11` will silently produce the wrong admixture proportions.