### PR TITLE
Warn when the user runs simulations of non-autosomes.

### DIFF
--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -404,7 +404,6 @@ def add_simulate_species_parser(parser, species):
                 f"Cannot sample from more than {model.num_sampling_populations} "
                 "populations")
         samples = model.get_samples(*args.samples)
-
         contig = species.get_contig(
             args.chromosome, genetic_map=args.genetic_map,
             length_multiplier=args.length_multiplier)

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -3,6 +3,7 @@ Infrastructure for defining basic information about species and
 organising the species catalog.
 """
 import logging
+import warnings
 
 import attr
 import msprime
@@ -133,6 +134,13 @@ class Species(object):
         :rtype: :class:`.Contig`
         :return: A :class:`.Contig` describing a simulation of the section of genome.
         """
+        # TODO: add non-autosomal support
+        if (chromosome is not None and
+                chromosome.lower() in ("x", "y", "m", "mt", "chrx", "chry", "chrm")):
+            warnings.warn(
+                    "Non-autosomal simulations are not yet supported. See "
+                    "https://github.com/popsim-consortium/stdpopsim/issues/383 and "
+                    "https://github.com/popsim-consortium/stdpopsim/issues/406")
         chrom = self.genome.get_chromosome(chromosome)
         if genetic_map is None:
             logger.debug(f"Making flat chromosome {length_multiplier} * {chrom.id}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -679,3 +679,22 @@ class TestMsprimeEngine(unittest.TestCase):
             engine.simulate(
                     model, contig, samples,
                     msprime_change_model=[(10, "notamodel"), ])
+
+
+class TestNonAutosomal(unittest.TestCase):
+    # TODO: This test should be removed when #383 is fixed.
+    # https://github.com/popsim-consortium/stdpopsim/issues/383
+    def test_chrX_gives_a_warning(self):
+        cmd = "HomSap -D -c chrX -o /dev/null -q 10".split()
+        with mock.patch("warnings.warn") as mock_warning:
+            capture_output(stdpopsim.cli.stdpopsim_main, cmd)
+        self.assertTrue(mock_warning.called_once)
+
+    # TODO: This test should be removed when #405 and #406 are fixed.
+    # https://github.com/popsim-consortium/stdpopsim/issues/405
+    # https://github.com/popsim-consortium/stdpopsim/issues/406
+    def test_chrM_gives_a_warning(self):
+        cmd = "DroMel -D -c chrM -o /dev/null -q 10".split()
+        with mock.patch("warnings.warn") as mock_warning:
+            capture_output(stdpopsim.cli.stdpopsim_main, cmd)
+        self.assertTrue(mock_warning.called_once)


### PR DESCRIPTION
Currently affects:
CanFam chrX
DroMel chrX chrY chrM
PonPyg chrX
HomSap chrX chrY

Closes #384.