### PR TITLE
Add recombination map support in SLiM engine.

### DIFF
--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -49,8 +49,6 @@ class TestAPI(unittest.TestCase):
                 slim_script=True)
         self.assertTrue("sim.registerLateEvent" in out)
 
-    # TODO: remove decorator once recombination maps are implemented.
-    @unittest.expectedFailure
     def test_recombination_map(self):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")


### PR DESCRIPTION
Closes #262.

Recombination map positions and rates are stored as arrays in the
SLiM script. As SLiM includes each script in the provenance table,
whole chromosome recombination maps result in very long arrays in
the provenance table. Note also that SLiM versions prior to 3.3
print the entire recombination map when initializeRecombinationRate()
is called.

I'll rebase onto master once #409 is merged.