### PR TITLE
Fix error in test redirection of stdout.

### DIFF
--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -214,6 +214,13 @@ def get_provenance_dict():
     return document
 
 
+def write_to_stdout(fileobj):
+    """
+    Write the contents of the specified file to stdout.
+    """
+    shutil.copyfileobj(fileobj, sys.stdout.buffer)
+
+
 def write_output(ts, args):
     """
     Adds provenance information to the specified tree sequence (ensuring that the
@@ -231,7 +238,7 @@ def write_output(ts, args):
             tmpfile = pathlib.Path(tmpdir) / "tmp.trees"
             ts.dump(tmpfile)
             with open(tmpfile, "rb") as f:
-                shutil.copyfileobj(f, sys.stdout.buffer)
+                write_to_stdout(f)
     else:
         logger.info(f"Writing to {args.output}")
         ts.dump(args.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,9 +277,9 @@ class TestWriteOutput(unittest.TestCase):
         ts = msprime.simulate(10, random_seed=2)
         parser = cli.stdpopsim_cli_parser()
         args = parser.parse_args(["AraTha", "2"])
-        with mock.patch("shutil.copyfileobj") as mocked_copy:
+        with mock.patch("stdpopsim.cli.write_to_stdout") as mocked_func:
             cli.write_output(ts, args)
-            mocked_copy.assert_called_once()
+            mocked_func.assert_called_once()
 
     def test_to_file(self):
         ts = msprime.simulate(10, random_seed=2)


### PR DESCRIPTION
Closes #428

A little bit of indirection so that we can mock out the correct call. Doesn't seem to be any good way to make sure that we can write arbitrary bytes to stdout when it can be a fileobj or a StringIO.