### PR TITLE
Multiply migration rates by the scaling factor.

### DIFF
--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -115,7 +115,7 @@ function (void)end(void) {
             if (j==k | N[i,j] == 0 | N[i,k] == 0)
                 next;
 
-            m = migration_matrices[k,j,i];
+            m = Q * migration_matrices[k,j,i];
             p = sim.subpopulations[j];
             dbg("p"+j+".setMigrationRates("+k+", "+m+");");
             p.setMigrationRates(k, m);
@@ -237,8 +237,8 @@ function (void)setup(void) {
                     if (j==k | N[i,j] == 0 | N[i,k] == 0)
                         next;
 
-                    m_last = migration_matrices[k,j,i-1];
-                    m = migration_matrices[k,j,i];
+                    m_last = Q * migration_matrices[k,j,i-1];
+                    m = Q * migration_matrices[k,j,i];
                     if (m == m_last) {
                         // Do nothing if the migration rate hasn't changed.
                         next;

--- a/validation.py
+++ b/validation.py
@@ -150,7 +150,7 @@ def twopop_asymmetric_migration_msprime1(out_dir, seed):
     """
     Two populations with different sizes and migrations from pop2 to pop1.
     """
-    return _twopop_IM("msprime", out_dir, seed, M12=0, M21=0.1)
+    return _twopop_IM("msprime", out_dir, seed, M12=0, M21=0.001)
 
 
 def twopop_asymmetric_migration_slim1(out_dir, seed):
@@ -158,7 +158,7 @@ def twopop_asymmetric_migration_slim1(out_dir, seed):
     Two populations with different sizes and migrations from pop2 to pop1.
     Recapitation. Default scaling factor of 10 is applied.
     """
-    return _twopop_IM("slim", out_dir, seed, M12=0, M21=0.1)
+    return _twopop_IM("slim", out_dir, seed, M12=0, M21=0.001)
 
 
 def twopop_asymmetric_migration_slim2(out_dir, seed):
@@ -167,7 +167,7 @@ def twopop_asymmetric_migration_slim2(out_dir, seed):
     No recapitation. No scaling.
     """
     return _twopop_IM(
-            "slim", out_dir, seed, M12=0, M21=0.1,
+            "slim", out_dir, seed, M12=0, M21=0.001,
             slim_no_recapitation=True, slim_scaling_factor=1)
 
 


### PR DESCRIPTION
Note that only the rate for continuous migrations is multiplied,
whereas the pulse migrations are left unscaled.

Closes #435.