### PR TITLE
Just use the mean recombination rate for recapitation.

### DIFF
--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -682,23 +682,13 @@ class _SLiMEngine(stdpopsim.Engine):
             rng = random.Random(seed)
             s1, s2 = rng.randrange(1, 2**32), rng.randrange(1, 2**32)
 
-            recombination_map = contig.recombination_map
-            positions = recombination_map.get_positions()
-            if positions[-1] != ts.sequence_length:
-                # The recombination map passed in can have non-integer length
-                # (e.g. for contig length multiplier < 1), but SLiM trees will
-                # have integer sequence_length.
-                positions[-1] = ts.sequence_length
-                rates = recombination_map.get_rates()
-                recombination_map = msprime.RecombinationMap(positions, rates)
-
             population_configurations = [
                     msprime.PopulationConfiguration(
                         initial_size=pop.start_size,
                         growth_rate=pop.growth_rate)
                     for pop in recap_epoch.populations]
             ts = ts.recapitate(
-                    recombination_map=recombination_map,
+                    recombination_rate=contig.recombination_map.mean_recombination_rate,
                     population_configurations=population_configurations,
                     migration_matrix=recap_epoch.migration_matrix,
                     random_seed=s1)

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -65,14 +65,14 @@ class TestAPI(unittest.TestCase):
     def test_simulate(self):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("AraTha")
-        # Integral length (10kb) to hit specific code path in slim_engine.py
-        contig = species.get_contig("chr5", length_multiplier=10000/26975502)
+        contig = species.get_contig("chr5", length_multiplier=0.001)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         model.generation_time = species.generation_time
         samples = model.get_samples(10)
         ts = engine.simulate(
                 demographic_model=model, contig=contig, samples=samples)
         self.assertEqual(ts.num_samples, 10)
+        self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
 
 
 @unittest.skipIf(IS_WINDOWS, "SLiM not available on windows")
@@ -100,6 +100,7 @@ class TestCLI(unittest.TestCase):
             self.docmd(f"--slim-path slim HomSap -o {f.name}")
             ts = tskit.load(f.name)
         self.assertEqual(ts.num_samples, 10)
+        self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
 
         if saved_slim_env is None:
             del os.environ["SLIM"]
@@ -129,6 +130,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(observed_counts[0], 0)
         self.assertEqual(observed_counts[1], 0)
         self.assertEqual(observed_counts[2], 8)
+        self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
 
     def test_bad_slim_environ_var(self):
         saved_slim_env = os.environ.get("SLIM")


### PR DESCRIPTION
There's something funny going on here when using the truncated
recombination map. Some of the trees still have more than 1 root.
Msprime 1.0 will bring discrete recombination maps, which is a
better way to do recapitation with recombination maps.

Closes #439.