### PR TITLE
Pin pyslim>=0.401.

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -13,4 +13,4 @@ kastore
 attrs
 appdirs
 humanize
-pyslim
+pyslim>=0.401

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     },
     # NOTE: make sure this is the 'attrs' package, not 'attr'!
     install_requires=["msprime>=0.7.1", "attrs>=19.1.0", "appdirs", "humanize",
-                      "pyslim"],
+                      "pyslim>=0.401"],
     url='https://github.com/popsim-consortium/stdpopsim',
     project_urls={
         'Bug Reports': 'https://github.com/popsim-consortium/stdpopsim/issues',


### PR DESCRIPTION
This avoids an issue with recapitation, arising due to changes between
msprime-0.7.4 and msprime-current.
https://github.com/tskit-dev/pyslim/issues/71