### PR TITLE
Add species parameter to generic models.

### DIFF
--- a/docs/examples.py
+++ b/docs/examples.py
@@ -11,7 +11,7 @@ import stdpopsim
 def generic_models_example():
     species = stdpopsim.get_species("HomSap")
     contig = species.get_contig("chr22", length_multiplier=0.1)
-    model = stdpopsim.PiecewiseConstantSize(species.population_size)
+    model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
     samples = model.get_samples(10)
     engine = stdpopsim.get_default_engine()
     ts = engine.simulate(model, contig, samples)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -501,11 +501,11 @@ Set up the generic model
 Next, we set the model to be the generic piecewise constant size model, using the
 predefined human effective population size (see :ref:`sec_catalog`).
 Since we are providing only one effective population size, the model is a
-single population of constant over all time.
+single population of constant size over all time.
 
 .. code-block:: python
 
-    model = stdpopsim.PiecewiseConstantSize(species.population_size)
+    model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
 
 Each species has a "default" population size, ``species.population_size``,
 which for humans is 10,000.
@@ -1033,7 +1033,7 @@ and that rates of migration since the split between the populations are both zer
 
 .. code-block:: python
 
-    model = stdpopsim.IsolationWithMigration(NA=5000, N1=4000, N2=1000, T=1000, M12=0, M21=0)
+    model = stdpopsim.IsolationWithMigration(species, NA=5000, N1=4000, N2=1000, T=1000, M12=0, M21=0)
 
 We'll simulate 10 chromosomes from each of the populations using the ``msprime`` engine.
 

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -403,10 +403,8 @@ def add_simulate_species_parser(parser, species):
 
     def run_simulation(args):
         if args.demographic_model is None:
-            model = stdpopsim.PiecewiseConstantSize(species.population_size)
-            model.generation_time = species.generation_time
+            model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
             model.citations.extend(species.population_size_citations)
-            model.citations.extend(species.generation_time_citations)
         else:
             model = get_model_wrapper(species, args.demographic_model)
         if len(args.samples) > model.num_sampling_populations:

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -305,6 +305,8 @@ class PiecewiseConstantSize(DemographicModel):
     tree sequence. This is a piecewise constant size model, which allows for
     instantaneous population size change over multiple epochs in a single population.
 
+    :ivar species: The species to be used with this model
+    :vartype species: stdpopsim.Species
     :ivar N0: The initial effective population size
     :vartype N0: float
     :ivar args: Each subsequent argument is a tuple (t, N) which gives the
@@ -314,8 +316,10 @@ class PiecewiseConstantSize(DemographicModel):
 
     .. code-block:: python
 
-        model1 = stdpopsim.PiecewiseConstantSize(N0, (t1, N1)) # One change
-        model2 = stdpopsim.PiecewiseConstantSize(N0, (t1, N1), (t2, N2)) # Two changes
+        # One change
+        model1 = stdpopsim.PiecewiseConstantSize(species, N0, (t1, N1))
+        # Two changes
+        model2 = stdpopsim.PiecewiseConstantSize(species, N0, (t1, N1), (t2, N2))
     """
 
     id = "PiecewiseConstant"
@@ -326,7 +330,9 @@ class PiecewiseConstantSize(DemographicModel):
     year = None
     doi = None
 
-    def __init__(self, N0, *args):
+    def __init__(self, species, N0, *args):
+        self.generation_time = species.generation_time
+        self.citations.extend(species.generation_time_citations)
         self.population_configurations = [
             msprime.PopulationConfiguration(
                 initial_size=N0, metadata=self.populations[0].asdict())
@@ -347,6 +353,8 @@ class IsolationWithMigration(DemographicModel):
     the split populations. Sampling is disallowed in population index 0,
     as this is the ancestral population.
 
+    :ivar species: The species to be used with this model
+    :vartype species: stdpopsim.Species
     :ivar NA: The initial ancestral effective population size
     :vartype NA: float
     :ivar N1: The effective population size of population 1
@@ -365,7 +373,7 @@ class IsolationWithMigration(DemographicModel):
 
     .. code-block:: python
 
-        model1 = stdpopsim.IsolationWithMigration(NA, N1, N2, T, M12, M21)
+        model1 = stdpopsim.IsolationWithMigration(species, NA, N1, N2, T, M12, M21)
 
     """
     id = "IsolationWithMigration"
@@ -381,7 +389,9 @@ class IsolationWithMigration(DemographicModel):
     year = None
     doi = None
 
-    def __init__(self, NA, N1, N2, T, M12, M21):
+    def __init__(self, species, NA, N1, N2, T, M12, M21):
+        self.generation_time = species.generation_time
+        self.citations.extend(species.generation_time_citations)
         self.population_configurations = [
             msprime.PopulationConfiguration(
                 initial_size=N1, metadata=self.populations[0].asdict()),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -468,7 +468,7 @@ class TestWriteBibtex(unittest.TestCase):
         species = stdpopsim.get_species("HomSap")
         genetic_map = species.get_genetic_map("HapMapII_GRCh37")
         contig = species.get_contig("chr22", genetic_map=genetic_map.id)
-        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
         engine = stdpopsim.get_default_engine()
         cites_and_cites = [
                 genetic_map.citations,
@@ -510,7 +510,7 @@ class TestWriteCitations(unittest.TestCase):
         species = stdpopsim.get_species("HomSap")
         genetic_map = species.get_genetic_map("HapMapII_GRCh37")
         contig = species.get_contig("chr22", genetic_map=genetic_map.id)
-        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
         engine = stdpopsim.get_default_engine()
         stdout, stderr = capture_output(
                 cli.write_citations, engine, model, contig, species)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -351,25 +351,28 @@ class TestModelsEqual(unittest.TestCase):
 
 
 class TestConstantSizeModel(unittest.TestCase, DemographicModelTestMixin):
-    model = models.PiecewiseConstantSize(100)
+    model = models.PiecewiseConstantSize(stdpopsim.get_species("CanFam"), 100)
 
 
 class TestTwoEpochModel(unittest.TestCase, DemographicModelTestMixin):
-    model = models.PiecewiseConstantSize(100, (10, 10))
+    model = models.PiecewiseConstantSize(
+            stdpopsim.get_species("CanFam"), 100, (10, 10))
 
 
 class TestPiecewiseConstantSize(unittest.TestCase):
     """
     Specific tests for the piecewise constant model.
     """
+    species = stdpopsim.get_species("CanFam")
+
     def test_single_epoch(self):
-        model = models.PiecewiseConstantSize(100)
+        model = models.PiecewiseConstantSize(self.species, 100)
         self.assertEqual(model.population_configurations[0].initial_size, 100)
         self.assertEqual(len(model.population_configurations), 1)
         self.assertEqual(len(model.demographic_events), 0)
 
     def test_two_epoch(self):
-        model = models.PiecewiseConstantSize(50, (10, 100))
+        model = models.PiecewiseConstantSize(self.species, 50, (10, 100))
         self.assertEqual(model.population_configurations[0].initial_size, 50)
         self.assertEqual(len(model.demographic_events), 1)
         event = model.demographic_events[0]
@@ -378,7 +381,7 @@ class TestPiecewiseConstantSize(unittest.TestCase):
         self.assertEqual(event.growth_rate, 0)
 
     def test_three_epoch(self):
-        model = models.PiecewiseConstantSize(0.1, (0.1, 10), (0.2, 100))
+        model = models.PiecewiseConstantSize(self.species, 0.1, (0.1, 10), (0.2, 100))
         self.assertEqual(model.population_configurations[0].initial_size, 0.1)
         self.assertEqual(len(model.demographic_events), 2)
         event = model.demographic_events[0]
@@ -395,21 +398,24 @@ class TestIsolationWithMigration(unittest.TestCase):
     """
     Tests for the generic IM model.
     """
+    species = stdpopsim.get_species("AraTha")
+
     def test_pop_configs(self):
-        model = models.IsolationWithMigration(100, 200, 300, 50, 0, 0)
+        model = models.IsolationWithMigration(self.species, 100, 200, 300, 50, 0, 0)
         self.assertEqual(len(model.population_configurations), 3)
         self.assertEqual(model.population_configurations[0].initial_size, 200)
         self.assertEqual(model.population_configurations[1].initial_size, 300)
         self.assertEqual(model.population_configurations[2].initial_size, 100)
 
     def test_split(self):
-        model = models.IsolationWithMigration(100, 200, 300, 50, 0, 0)
+        model = models.IsolationWithMigration(self.species, 100, 200, 300, 50, 0, 0)
         self.assertEqual(len(model.demographic_events), 2)
         self.assertEqual(model.demographic_events[0].time, 50)
         self.assertEqual(model.demographic_events[1].time, 50)
 
     def test_migration_rates(self):
-        model = models.IsolationWithMigration(100, 200, 300, 50, 0.002, 0.003)
+        model = models.IsolationWithMigration(
+                self.species, 100, 200, 300, 50, 0.002, 0.003)
         self.assertEqual(np.shape(model.migration_matrix), (3, 3))
         self.assertEqual(model.migration_matrix[0][1], 0.002)
         self.assertEqual(model.migration_matrix[1][0], 0.003)

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -26,7 +26,7 @@ class TestAPI(unittest.TestCase):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr1")
-        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
         samples = model.get_samples(10)
         model.generation_time = species.generation_time
 
@@ -49,7 +49,7 @@ class TestAPI(unittest.TestCase):
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr1")
 
-        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
         samples = model.get_samples(10)
         model.generation_time = species.generation_time
         out, _ = capture_output(
@@ -78,7 +78,7 @@ class TestAPI(unittest.TestCase):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr1", genetic_map="HapMapII_GRCh37")
-        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
         samples = model.get_samples(10)
         model.generation_time = species.generation_time
         out, _ = capture_output(
@@ -91,7 +91,7 @@ class TestAPI(unittest.TestCase):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("AraTha")
         contig = species.get_contig("chr5", length_multiplier=0.001)
-        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        model = stdpopsim.PiecewiseConstantSize(species, species.population_size)
         model.generation_time = species.generation_time
         samples = model.get_samples(10)
         ts = engine.simulate(

--- a/validation.py
+++ b/validation.py
@@ -52,7 +52,7 @@ def _onepop_PC(engine_id, out_dir, seed, N0=1000, *size_changes, **sim_kwargs):
     species = stdpopsim.get_species("CanFam")
     contig = species.get_contig("chr35", length_multiplier=0.01)  # ~265 kb
     contig = irradiate(contig)
-    model = stdpopsim.PiecewiseConstantSize(N0, *size_changes)
+    model = stdpopsim.PiecewiseConstantSize(species, N0, *size_changes)
     model.generation_time = species.generation_time
     samples = model.get_samples(100)
     engine = stdpopsim.get_engine(engine_id)
@@ -211,7 +211,7 @@ def _twopop_IM(
     contig = species.get_contig("chr5", length_multiplier=0.01)  # ~270 kb
     contig = irradiate(contig)
     model = stdpopsim.IsolationWithMigration(
-            NA=NA, N1=N1, N2=N2, T=T, M12=M12, M21=M21)
+            species, NA=NA, N1=N1, N2=N2, T=T, M12=M12, M21=M21)
     if pulse is not None:
         model.demographic_events.append(pulse)
         model.demographic_events.sort(key=lambda x: x.time)


### PR DESCRIPTION
Closes #459.

This is a potential breaking change. I *think* I got all the occurrences of `PiecewiseConstantSize` and `IsolationWithMigration` in the stdpopsim tree. I didn't check if there are references to these lurking elsewhere though, e.g. in the manuscript or the https://github.com/popsim-consortium/analysis repo.