### PR TITLE
Use the logging module for all terminal output.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -290,7 +290,7 @@ but should also make you *very* nervous.
 What actually *is* being simulated here?
 We can at least find out what the actual population sizes are in the SLiM simulation
 by asking the simulation to be more verbose.
-Prepending the ``-vv`` flag will request that SLiM print out information
+Prepending the ``-v`` flag will request that SLiM print out information
 every time a demographic event occurs
 (helpfully, this also gives us an idea of how quickly the simulation is going):
 This also outputs a fair bit of other debugging output,
@@ -298,7 +298,7 @@ which can be turned off with ``--quiet``:
 
 .. code-block:: console
 
-   $ stdpopsim -vv -e slim --slim-scaling-factor 1000 DroMel \
+   $ stdpopsim -v -e slim --slim-scaling-factor 1000 DroMel \
    $     -c chr2L -l 0.05 -o foo.ts -d African3Epoch_1S16 100 --quiet
 
 Trimming down the output somewhat, we get:

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -3,7 +3,6 @@ Citation management for stdpopsim. Provides utilities for printing
 citation information associated with different entities derived from the
 literature that are used within a simulation.
 """
-import sys
 import collections
 import urllib.request
 
@@ -42,13 +41,15 @@ class Citation(object):
     def __str__(self):
         return f"{self.author}, {self.year}: {self.doi}"
 
-    def print(self, file=sys.stdout):
-        print("[", end="", file=file)
+    def displaystr(self):
+        s = ["["]
         for i, reason in enumerate(self.reasons):
-            end = "" if i == len(self.reasons)-1 else ", "
-            print(reason, end=end, file=file)
-        print("]", file=file)
-        print("  "+str(self), file=file)
+            if i != 0:
+                s.append(", ")
+            s.append(reason)
+        s.append("]\n")
+        s.append(str(self))
+        return "".join(s)
 
     def because(self, reasons):
         """Returns a new Citation with the given reasons."""

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -641,7 +641,7 @@ class _SLiMEngine(stdpopsim.Engine):
                 return None
 
             slim_cmd.append(script_file.name)
-            stdout = subprocess.DEVNULL if verbosity == 0 else None
+            stdout = subprocess.DEVNULL if verbosity < 2 else None
             subprocess.check_call(slim_cmd, stdout=stdout)
 
             if dry_run:


### PR DESCRIPTION
See #473.

This PR makes all terminal output go through the logging module. The `logging` module provides DEBUG, INFO, WARN, ERROR and CRITICAL logging levels. This PR sets the default to show all messages at level INFO and above. DEBUG level is set with the `-v`  CLI parameter, and WARN level is set with `-q`. I've assumed that we'll use exceptions to report errors, so the ERROR and CRITICAL levels are unused.

Terminal output is very similar to before. INFO level messages have no prefix, but DEBUG messages have a simple `DEBUG: ` prefix and WARN messages have a simple `WARNING: ` prefix. The `warnings.warn()` messages are redirected to the default logger.

Example output below.

```
$ stdpopsim HomSap 10 -l 0.01 -o /dev/null -q
```

```
$ stdpopsim HomSap 10 -l 0.01 -c chrX -o /dev/null -q
WARNING: Non-autosomal simulations are not yet supported. See https://github.com/popsim-consortium/stdpopsim/issues/383 and https://github.com/popsim-consortium/stdpopsim/issues/406

```

```
t490:stdpopsim $ stdpopsim HomSap 10 -l 0.01 -c chrX -o /dev/null
WARNING: Non-autosomal simulations are not yet supported. See https://github.com/popsim-consortium/stdpopsim/issues/383 and https://github.com/popsim-consortium/stdpopsim/issues/406

Simulation information:
    Engine: msprime (0.7.4)
    Model id: PiecewiseConstant
    Model desciption: Piecewise constant size population model over multiple epochs.
    Population: number_samples (sampling_time_generations):
        pop0: 10 (0)
Contig Description:
    Contig length: 1552705.6
    Mean recombination rate: 1.164662223273842e-08
    Mean mutation rate: 1.29e-08
    Genetic map: None

If you use this simulation in published work, please cite:
[simulation engine]
Kelleher et al., 2016: https://doi.org/10.1371/journal.pcbi.1004842
[genome assembly]
The Genome Sequencing Consortium, 2001: http://dx.doi.org/10.1038/35057062
[mutation rate]
Tian, Browning, and Browning, 2019: https://doi.org/10.1016/j.ajhg.2019.09.012
[recombination rate]
The International HapMap Consortium, 2007: https://doi.org/10.1038/nature06258
[population size]
Takahata, 1993: https://doi.org/10.1093/oxfordjournals.molbev.a039995
[generation time]
Tremblay and Vezina, 2000: https://doi.org/10.1086/302770
```

```
$ stdpopsim -v HomSap 10 -l 0.01 -c chrX -o /dev/null
WARNING: Non-autosomal simulations are not yet supported. See https://github.com/popsim-consortium/stdpopsim/issues/383 and https://github.com/popsim-consortium/stdpopsim/issues/406

DEBUG: Making flat chromosome 0.01 * chrX
Simulation information:
    Engine: msprime (0.7.4)
    Model id: PiecewiseConstant
    Model desciption: Piecewise constant size population model over multiple epochs.
    Population: number_samples (sampling_time_generations):
        pop0: 10 (0)
Contig Description:
    Contig length: 1552705.6
    Mean recombination rate: 1.164662223273842e-08
    Mean mutation rate: 1.29e-08
    Genetic map: None

DEBUG: rusage: user=a moment; sys=0.03s; max_rss=56.6 MiB
DEBUG: Updating provenance
DEBUG: Writing to /dev/null
If you use this simulation in published work, please cite:
[simulation engine]
Kelleher et al., 2016: https://doi.org/10.1371/journal.pcbi.1004842
[genome assembly]
The Genome Sequencing Consortium, 2001: http://dx.doi.org/10.1038/35057062
[mutation rate]
Tian, Browning, and Browning, 2019: https://doi.org/10.1016/j.ajhg.2019.09.012
[recombination rate]
The International HapMap Consortium, 2007: https://doi.org/10.1038/nature06258
[population size]
Takahata, 1993: https://doi.org/10.1093/oxfordjournals.molbev.a039995
[generation time]
Tremblay and Vezina, 2000: https://doi.org/10.1086/302770
```

```
$ stdpopsim -v HomSap 10 -l 0.01 -c chrX -o /dev/null -q
WARNING: Non-autosomal simulations are not yet supported. See https://github.com/popsim-consortium/stdpopsim/issues/383 and https://github.com/popsim-consortium/stdpopsim/issues/406

DEBUG: Making flat chromosome 0.01 * chrX
DEBUG: rusage: user=a moment; sys=0.03s; max_rss=57.0 MiB
DEBUG: Updating provenance
DEBUG: Writing to /dev/null
```