### PR TITLE
link to code of conduct in docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,6 +5,8 @@ Development
 ===========
 
 ``stdpopsim`` **is a community effort, and YOU are welcome to join in!**
+We aim to be welcoming, inclusive and supportive:
+please see `our code of conduct <https://github.com/popsim-consortium/stdpopsim/blob/master/CODE_OF_CONDUCT.md>`_ for our community standards.
 
 We envision at least three main types of ``stdpopsim`` developers:
 


### PR DESCRIPTION
We didn't have a link to the code of conduct in the developer docs, so I added one.