### PR TITLE
Set generation_time=1 in generic models.

### DIFF
--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -325,6 +325,7 @@ class PiecewiseConstantSize(DemographicModel):
     author = None
     year = None
     doi = None
+    generation_time = 1
 
     def __init__(self, N0, *args):
         self.population_configurations = [
@@ -380,6 +381,7 @@ class IsolationWithMigration(DemographicModel):
     author = None
     year = None
     doi = None
+    generation_time = 1
 
     def __init__(self, NA, N1, N2, T, M12, M21):
         self.population_configurations = [

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -28,7 +28,6 @@ class TestAPI(unittest.TestCase):
         contig = species.get_contig("chr1")
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         samples = model.get_samples(10)
-        model.generation_time = species.generation_time
 
         for scaling_factor in (0, -1, -1e-6):
             with self.assertRaises(ValueError):
@@ -51,7 +50,6 @@ class TestAPI(unittest.TestCase):
 
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         samples = model.get_samples(10)
-        model.generation_time = species.generation_time
         out, _ = capture_output(
                 engine.simulate,
                 demographic_model=model, contig=contig, samples=samples,
@@ -80,7 +78,6 @@ class TestAPI(unittest.TestCase):
         contig = species.get_contig("chr1", genetic_map="HapMapII_GRCh37")
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         samples = model.get_samples(10)
-        model.generation_time = species.generation_time
         out, _ = capture_output(
                 engine.simulate,
                 demographic_model=model, contig=contig, samples=samples,
@@ -91,7 +88,6 @@ class TestAPI(unittest.TestCase):
         species = stdpopsim.get_species("AraTha")
         contig = species.get_contig("chr5", length_multiplier=0.001)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
-        model.generation_time = species.generation_time
         samples = model.get_samples(10)
         ts = engine.simulate(
                 demographic_model=model, contig=contig, samples=samples,


### PR DESCRIPTION
Closes #459.

This is an alternative proposal to #471. The more I think about that PR, the less I like it. All the catalog models have the `generation_time` attribute set, which makes sense in that context, particularly since many of the catalog models use parameters that were inferred using specific generation time assumptions. But the generic models really are "time in units of generations" models, and this PR better reflects that.