### PR TITLE
Reduce readthedocs memory footprint.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,5 +16,6 @@ conda:
 python:
   # Install the local package using pip so that stdpopsim is in the path.
   install:
+    - requirements: requirements/development.txt
     - method: pip 
       path: .

--- a/requirements/rtd-conda-environment.yml
+++ b/requirements/rtd-conda-environment.yml
@@ -4,11 +4,12 @@ channels:
   - conda-forge
 
 dependencies:
-  - setuptools_scm
-  - attrs
-  - appdirs
-  - msprime
-  - sphinx-argparse
-  - sphinx-issues
-  - sphinxcontrib-programoutput
-  - humanize
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - gsl=2.6
+  - libblas=3.8.0
+  - libcblas=3.8.0
+  - libgcc-ng=9.2.0
+  - libgfortran-ng=7.3.0
+  - libopenblas=0.3.9
+  - llvm-openmp=10.0.0


### PR DESCRIPTION
Installing a conda environment on the readthdocs host often fails due
to memory exhaustion. But the readthedocs docker images don't include
gsl, which is needed to build msprime when installing with pip.
So this change uses a minimal conda environment, containing only gsl,
and installs the remaining dependencies using pip.

See #468.