### PR TITLE
Add stdpopsim citation to CLI output.

### DIFF
--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -18,6 +18,7 @@ class CiteReason(object):
     MUT_RATE = "mutation rate"
     REC_RATE = "recombination rate"
     ASSEMBLY = "genome assembly"
+    STDPOPSIM = "stdpopsim"
 
 
 @attr.s
@@ -75,3 +76,11 @@ class Citation(object):
         req.add_header("Accept", "text/bibliography; style=bibtex")
         with urllib.request.urlopen(req) as con:
             return con.read().decode()
+
+
+_stdpopsim_citation = Citation(
+    # biorxiv; update upon publication
+    doi="https://doi.org/10.1101/2019.12.20.885129",
+    year="2019",
+    author="Adrion et al.",
+    reasons={CiteReason.STDPOPSIM})

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -256,7 +256,8 @@ def get_citations(engine, model, contig, species):
     """
     Return a list of all the citations.
     """
-    citations = engine.citations[:]
+    citations = [stdpopsim.citations._stdpopsim_citation]
+    citations.extend(engine.citations)
     citations.extend(species.genome.assembly_citations)
     citations.extend(species.genome.mutation_rate_citations)
     citations.extend(species.genome.recombination_rate_citations)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -520,6 +520,7 @@ class TestWriteBibtex(unittest.TestCase):
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         engine = stdpopsim.get_default_engine()
         cites_and_cites = [
+                [stdpopsim.citations._stdpopsim_citation],
                 genetic_map.citations,
                 model.citations,
                 engine.citations,


### PR DESCRIPTION
Closes #451.

Example output:
```
$ stdpopsim HomSap -o /dev/null -l 0.001 10
Simulation information:
    Engine: msprime (0.7.4)
    Model id: PiecewiseConstant
    Model desciption: Piecewise constant size population model over multiple epochs.
    Population: number_samples (sampling_time_generations):
        pop0: 10 (0)
Contig Description:
    Contig length: 249250.621
    Mean recombination rate: 1.1485597641285933e-08
    Mean mutation rate: 1.29e-08
    Genetic map: None

If you use this simulation in published work, please cite:
[stdpopsim]
Adrion et al., 2019: https://doi.org/10.1101/2019.12.20.885129
[simulation engine]
Kelleher et al., 2016: https://doi.org/10.1371/journal.pcbi.1004842
[genome assembly]
The Genome Sequencing Consortium, 2001: http://dx.doi.org/10.1038/35057062
[mutation rate]
Tian, Browning, and Browning, 2019: https://doi.org/10.1016/j.ajhg.2019.09.012
[recombination rate]
The International HapMap Consortium, 2007: https://doi.org/10.1038/nature06258
[population size]
Takahata, 1993: https://doi.org/10.1093/oxfordjournals.molbev.a039995
[generation time]
Tremblay and Vezina, 2000: https://doi.org/10.1086/302770
```