### PR TITLE
Add Gutunkunst OOA QC

### DIFF
--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -294,6 +294,8 @@ def _ooa_3():
             # Population B merges into YRI at T_B
             msprime.MassMigration(
                 time=T_B, source=1, destination=0, proportion=1.0),
+            msprime.MigrationRateChange(
+                time=T_B, rate=0),
             # Size changes to N_A at T_AF
             msprime.PopulationParametersChange(
                 time=T_AF, initial_size=N_A, population_id=0)

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -109,11 +109,13 @@ class TestJacobsPapuansOutOfAfrica(
     qc_model = homo_sapiens_qc.DenisovanAncestryInPapuans()
 
 
-# Models that have not been QC'd:
-
 class TestGutenkunstThreePopOutOfAfrica(
-        unittest.TestCase, test_models.CatalogDemographicModelTestMixin):
+        unittest.TestCase, test_models.QcdCatalogDemographicModelTestMixin):
     model = species.get_demographic_model("OutOfAfrica_3G09")
+    qc_model = homo_sapiens_qc.GutenkunstOOA()
+
+
+# Models that have not been QC'd:
 
 
 class TestSchiffelsZigzag(


### PR DESCRIPTION
Implemented qc version of the 2009 OOA model (to close #492). I'm having issues getting the tests to catch if I made a mistake in implementation, and I think the development docs are out of date (specifically, item 5 under Demographic model review process, perhaps)? Do I need to add anything beyond `qc_model = homo_sapiens_qc.GutenkunstOOA()` to the `TestGutenkunstThreePopOutOfAfrica` class in `test_homo_sapiens.py`?