### PR TITLE
Add zigzag QC

### DIFF
--- a/qc/homo_sapiens_qc.py
+++ b/qc/homo_sapiens_qc.py
@@ -838,3 +838,55 @@ class GutenkunstOOA(models.DemographicModel):
             msprime.PopulationParametersChange(time=T_AF, initial_size=N_A,
                                                population_id=0)
         ]
+
+
+class ZigZag(models.DemographicModel):
+    """
+    Model from Schiffels et al (2014) used to test inference methods on a "zigzag"
+    demography. Single population, repeated growth and decay of pop size.
+    """
+    def __init__(self):
+        # from section 7 of the supplement
+        self.generation_time = 30
+        mu = 1.25e-8
+        L = 10000000
+        theta = 7156
+        Ne = theta / 4 / mu / L
+
+        self.population_configurations = [
+            msprime.PopulationConfiguration(
+                initial_size=Ne, growth_rate=0,
+                metadata={"sampling_time": 0})
+        ]
+
+        rate_changes = {
+            0.000582262: 1318.18,
+            0.00232905: -329.546,
+            0.00931619: 82.3865,
+            0.0372648: -20.5966,
+            0.149059: 5.14916,
+            # 0.596236: 0
+        }
+
+        de = []
+        for time, rate in rate_changes.items():
+            de.append(
+                msprime.PopulationParametersChange(
+                    time=time * 4 * Ne,
+                    growth_rate=rate / 4 / Ne,
+                    population_id=0
+                )
+            )
+
+        de.append(
+            msprime.PopulationParametersChange(
+                time=0.596236 * 4 * Ne,
+                growth_rate=0,
+                population_id=0,
+                initial_size=0.1 * Ne
+                )
+            )
+
+        self.demographic_events = de
+
+        self.migration_matrix = [[0]]

--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -765,31 +765,26 @@ def _zigzag():
             reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
-    generation_time = 29
+    generation_time = 30
     N0 = 14312
 
-    g_1 = 0.023025
-    t_1 = 33.333
-    n_1 = N0
+    g_1 = 0.02302578256
+    t_1 = 33.333334976
 
-    g_2 = -0.005756
-    t_2 = 133.33
-    n_2 = N0/10
+    g_2 = -0.0057564631
+    t_2 = 133.3334544
 
-    g_3 = 0.0014391
-    t_3 = 533.33
-    n_3 = N0
+    g_3 = 0.00143911578
+    t_3 = 533.33324512
 
-    g_4 = -0.00035977
-    t_4 = 2133.33
-    n_4 = N0/10
+    g_4 = -0.0003597785
+    t_4 = 2133.3352704
 
-    g_5 = 8.99448e-5
-    t_5 = 8533.33
-    n_5 = N0
+    g_5 = 8.9944801565e-5
+    t_5 = 8533.329632
 
     n_ancient = N0/10
-    t_ancient = 34133.31
+    t_ancient = 34133.318528
 
     population_configurations = [
         msprime.PopulationConfiguration(
@@ -798,17 +793,17 @@ def _zigzag():
 
     demographic_events = [
             msprime.PopulationParametersChange(
-                initial_size=n_1, time=t_1, growth_rate=g_1),
+                time=t_1, growth_rate=g_1, population_id=0),
             msprime.PopulationParametersChange(
-                initial_size=n_2, time=t_2, growth_rate=g_2),
+                time=t_2, growth_rate=g_2, population_id=0),
             msprime.PopulationParametersChange(
-                initial_size=n_3, time=t_3, growth_rate=g_3),
+                time=t_3, growth_rate=g_3, population_id=0),
             msprime.PopulationParametersChange(
-                initial_size=n_4, time=t_4, growth_rate=g_4),
+                time=t_4, growth_rate=g_4, population_id=0),
             msprime.PopulationParametersChange(
-                initial_size=n_5, time=t_5, growth_rate=g_5),
+                time=t_5, growth_rate=g_5, population_id=0),
             msprime.PopulationParametersChange(
-                time=t_ancient, initial_size=n_ancient, growth_rate=0)
+                time=t_ancient, initial_size=n_ancient, growth_rate=0, population_id=0)
     ]
 
     return stdpopsim.DemographicModel(

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -119,5 +119,6 @@ class TestGutenkunstThreePopOutOfAfrica(
 
 
 class TestSchiffelsZigzag(
-        unittest.TestCase, test_models.CatalogDemographicModelTestMixin):
+        unittest.TestCase, test_models.QcdCatalogDemographicModelTestMixin):
     model = species.get_demographic_model("Zigzag_1S14")
+    qc_model = homo_sapiens_qc.ZigZag()


### PR DESCRIPTION
QC model for Schiffels ZigZag. However, I know there are discrepancies between the model in the catalog and the model I've implemented. For example, generation time of 29 vs 30 years (the Schiffels paper used a 30 year generation time, but the model in the catalog has a generation time of 29). But it doesn't appear that the tests have caught that difference. Do I need to do something beyond adding the `qc_model` to the `TestSchiffelsZigzag` class in `test_homo_sapiens.py` to get the comparison tests to work as expected?