### PR TITLE
more issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-issue-template.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: A problem with stdpopsim
+title: 
+labels: 
+assignees: ''
+
+---
+
+*This template is a suggestion that may not fit your issue: delete/modify anything!*
+
+**Short description of the problem:**
+*Describe what you are doing, what you think should happen, and what actually happens.*
+
+**How to reproduce the problem:**
+*If possible, post code (a [minimal working example](https://en.wikipedia.org/wiki/Minimal_working_example))
+that reproduces the problem.*
+
+**Suggested fixes:**
+*If you have an idea of what's causing the problem or how to fix it, we'd like to hear it!*
+

--- a/.github/ISSUE_TEMPLATE/feature-request-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-issue-template.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: A suggestion for something to add to stdpopsim.
+title: 
+labels: enhancement
+assignees: ''
+
+---
+
+*This template is a suggestion that may not fit your issue: delete/modify anything!*
+
+**Short description of what you'd like added:**
+*Describe briefly how you think stdpopsim could be better.*
+
+**Rationale and considerations:**
+*Give some more explanation of why this is a good idea,
+and what considerations there are in implementing it.
+For instance: if you're suggesting that a new species, model, or map is added
+then say who'd use the resource.
+Or, if you're suggesting a new method in the API,
+talk through the proposed arguments to the method and outputs.*


### PR DESCRIPTION
Right now the "new issue" page makes it look like the only way to submit an issue is as a QC issue; this will fix that (and give a bit more guidance).
![Screenshot from 2020-05-01 08-58-24](https://user-images.githubusercontent.com/1046249/80819537-fe36b500-8b89-11ea-9aae-8dc95c14a894.png)
