### PR TITLE
fix flake8 F999 failures

### DIFF
--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -102,7 +102,7 @@ def get_models_help(species_id, model_id):
         models = [model.id for model in species.demographic_models]
     else:
         models = [model_id]
-        models_text = f"\nModel description\n\n"
+        models_text = "\nModel description\n\n"
 
     # TODO improve this text formatting.
     indent = " " * 4
@@ -146,7 +146,7 @@ def get_genetic_maps_help(species_id, genetic_map_id):
         maps = [genetic_map.id for genetic_map in species.genetic_maps]
     else:
         maps = [genetic_map_id]
-        maps_text = f"\nGenetic map description\n\n"
+        maps_text = "\nGenetic map description\n\n"
 
     indent = " " * 4
     wrapper = textwrap.TextWrapper(initial_indent=indent, subsequent_indent=indent)
@@ -475,7 +475,7 @@ def write_simulation_summary(engine, model, contig, samples, seed=None):
     mean_recomb_rate = contig.recombination_map.mean_recombination_rate
     mut_rate = contig.mutation_rate
     contig_len = contig.recombination_map.get_length()
-    dry_run_text += f"Contig Description:\n"
+    dry_run_text += "Contig Description:\n"
     dry_run_text += f"{indent}Contig length: {contig_len}\n"
     dry_run_text += f"{indent}Mean recombination rate: {mean_recomb_rate}\n"
     dry_run_text += f"{indent}Mean mutation rate: {mut_rate}\n"

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -442,7 +442,7 @@ def slim_makescript(
     recomb_rates, recomb_ends = msprime_rm_to_slim_rm(contig.recombination_map)
     indent = 8*" "
     recomb_rates_str = (
-            f"c(\n" +
+            "c(\n" +
             textwrap.fill(
                     ", ".join(map(str, recomb_rates)),
                     width=80,
@@ -450,7 +450,7 @@ def slim_makescript(
                     subsequent_indent=indent) +
             ")")
     recomb_ends_str = (
-            f"c(\n" +
+            "c(\n" +
             textwrap.fill(
                     ", ".join(map(str, recomb_ends)),
                     width=80,


### PR DESCRIPTION
Recent versions of flake8 now complain thusly:

stdpopsim/slim_engine.py:445:13: F999 f-string is missing placeholders
stdpopsim/slim_engine.py:453:13: F999 f-string is missing placeholders
stdpopsim/cli.py:105:23: F999 f-string is missing placeholders
stdpopsim/cli.py:149:21: F999 f-string is missing placeholders
stdpopsim/cli.py:478:21: F999 f-string is missing placeholders