### PR TITLE
Add missing citations for AraTha and EscCol.

### DIFF
--- a/stdpopsim/catalog/AraTha.py
+++ b/stdpopsim/catalog/AraTha.py
@@ -34,19 +34,28 @@ for line in _chromosome_data.splitlines():
     _chromosomes.append(stdpopsim.Chromosome(
         id=name, length=int(length),
         mutation_rate=7e-9,
-        recombination_rate=8.1e-9))
-
-_SwarbreckEtAl = stdpopsim.Citation(
-    doi="https://doi.org/10.1093/nar/gkm965",
-    year="2007",
-    author="Swarbreck et al.",
-    reasons={stdpopsim.CiteReason.ASSEMBLY}
-)
+        recombination_rate=200 / 124000 / 2 / 1e6))
 
 _genome = stdpopsim.Genome(
         chromosomes=_chromosomes,
+        mutation_rate_citations=[
+            stdpopsim.Citation(
+                author="Ossowski et al.",
+                year="2010",
+                doi="https://doi.org/10.1126/science.1180677",
+                reasons={stdpopsim.CiteReason.MUT_RATE})],
+        recombination_rate_citations=[
+            stdpopsim.Citation(
+                author="Huber et al.",
+                year="2014",
+                doi="https://doi.org/10.1093/molbev/msu247",
+                reasons={stdpopsim.CiteReason.REC_RATE})],
         assembly_citations=[
-            _SwarbreckEtAl])
+            stdpopsim.Citation(
+                doi="https://doi.org/10.1093/nar/gkm965",
+                year="2007",
+                author="Swarbreck et al.",
+                reasons={stdpopsim.CiteReason.ASSEMBLY})])
 
 _species = stdpopsim.Species(
     id="AraTha",

--- a/stdpopsim/catalog/EscCol.py
+++ b/stdpopsim/catalog/EscCol.py
@@ -19,10 +19,28 @@ _sezonov_et_al = stdpopsim.Citation(
     year="2007",
     doi="https://doi.org/10.1128/JB.01368-07")
 
+_perfeito_et_al = stdpopsim.Citation(
+    author="Perfeito et al.",
+    year="2007",
+    doi="https://doi.org/10.1126/science.1142284")
+
+_kibota_and_lynch = stdpopsim.Citation(
+    author="Kibota and Lynch",
+    year="1996",
+    doi="https://doi.org/10.1038/381694a0")
+
+_blattner_et_al = stdpopsim.Citation(
+    author="Blattner et al.",
+    year="1997",
+    doi="10.1126/science.277.5331.1453")
+
 _chromosomes = []
 _chromosomes.append(stdpopsim.Chromosome(
         id=None,
         length=4641652,
+        # Lapierre et al. (2016) refer to:
+        #  Genomic adaptive mutation rate: 1e-5, Perfeito et al. (2007), and
+        #  Genomic deleterious mutation rate: 2e−4, Kibota and Lynch (1996).
         mutation_rate=1e-5+2e-4,
         recombination_rate=0.0))
 # mean_conversion_rate=8.9e-11 # not implemented yet!
@@ -31,7 +49,14 @@ _chromosomes.append(stdpopsim.Chromosome(
 #: :class:`stdpopsim.Genome` definition for E. Coli.
 # Chromosome length data is based on strain K-12.
 
-_genome = stdpopsim.Genome(chromosomes=_chromosomes)
+_genome = stdpopsim.Genome(
+        chromosomes=_chromosomes,
+        mutation_rate_citations=[
+            _perfeito_et_al.because(stdpopsim.CiteReason.MUT_RATE),
+            _kibota_and_lynch.because(stdpopsim.CiteReason.MUT_RATE),
+            ],
+        assembly_citations=[
+            _blattner_et_al.because(stdpopsim.CiteReason.ASSEMBLY)])
 
 _species = stdpopsim.Species(
     id="EscCol",


### PR DESCRIPTION
Closes #355.

Theses species were added by @fbaumdicker and @arundurvasula --- would you be kind enough to quickly check that I haven't messed anything up here? Note that for AraTha, the recombination rate was listed as 8.1e-9, but I get `200 / 124000 / 2 / 1e6 = 8.064516129032258e-10`.