### PR TITLE
Annotation WIP

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - cmd: conda config --add channels conda-forge
   - cmd: conda create --yes -n testenv python=%PYTHON_VERSION%
   - cmd: activate testenv
+  - cmd: conda config --add channels bioconda
   - cmd: conda install --yes --file=requirements\conda-minimal.txt
   - cmd: conda info -a
   - cmd: python --version

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,6 +35,9 @@ accessed through the main entry point, :func:`.get_species`.
 .. autoclass:: stdpopsim.Citation()
     :members:
 
+.. autoclass:: stdpopsim.Annotation()
+    :members:
+
 ******************
 Demographic Models
 ******************

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@
 name: stdpopsim-environment
 channels:
         - conda-forge
+        - bioconda
 dependencies:
         - numpy
         - pandas

--- a/maintenance/annotation_maint.py
+++ b/maintenance/annotation_maint.py
@@ -1,0 +1,38 @@
+import allel
+import zarr
+import numpy as np
+import stdpopsim as stp
+import logging
+import warnings
+import urllib.request
+import os
+
+logger = logging.getLogger(__name__)
+# make root directory for zarr annotations
+annot_path = "annotations"
+os.mkdir(annot_path)
+# loop through species and download
+for spc in stp.all_species():
+    if spc.annotations:
+        address = spc.annotations[0].url
+        genome_version = os.path.basename(address).split(".")[1]
+        logger.info(f"Downloading GFF file {spc.id}")
+        tmp_path = f"{spc.id}.tmp.gff.gz"
+        try:
+            x, y = urllib.request.urlretrieve(address, tmp_path)
+        except FileNotFoundError:
+            warnings.warn("can't connnect to url")
+        logger.info(f"creating zarr arrays {spc.id}")
+        # create zarr store and zarr root
+        spc_path = os.path.join(annot_path, spc.id+"."+genome_version+".zip")
+        store = zarr.ZipStore(spc_path)
+        root = zarr.group(store=store, overwrite=True)
+        x = allel.gff3_to_dataframe(tmp_path)
+        for col_name in x.columns:
+            if x[col_name].dtype == 'O':
+                tmp = root.array(col_name, np.array(x[col_name], dtype=str))
+            else:
+                tmp = root.array(col_name, np.array(x[col_name]))
+        # cleanup
+        os.unlink(tmp_path)
+        store.close()

--- a/requirements/conda-minimal.txt
+++ b/requirements/conda-minimal.txt
@@ -5,3 +5,5 @@ tskit
 humanize
 attrs
 appdirs
+pandas
+zarr

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -14,3 +14,8 @@ attrs
 appdirs
 humanize
 pyslim>=0.401
+pandas
+numpy
+cython
+scikit-allel[full]
+zarr>=2.4

--- a/requirements/rtd-conda-environment.yml
+++ b/requirements/rtd-conda-environment.yml
@@ -2,6 +2,7 @@ name: stdpopsim-rtd
 
 channels:
   - conda-forge
+  - bioconda
 
 dependencies:
   - _libgcc_mutex=0.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     },
     # NOTE: make sure this is the 'attrs' package, not 'attr'!
     install_requires=["msprime>=0.7.1", "attrs>=19.1.0", "appdirs", "humanize",
-                      "pyslim>=0.401"],
+                      "pyslim>=0.401", "pandas", "scikit-allel", "zarr",
+                      "numpy"],
     url='https://github.com/popsim-consortium/stdpopsim',
     project_urls={
         'Bug Reports': 'https://github.com/popsim-consortium/stdpopsim/issues',

--- a/stdpopsim/__init__.py
+++ b/stdpopsim/__init__.py
@@ -12,6 +12,7 @@ from . genetic_maps import *  # NOQA
 from . models import *  # NOQA
 from . species import *  # NOQA
 from . genomes import *  # NOQA
+from . annotations import *  # NOQA
 from . cache import *  # NOQA
 from . citations import *  # NOQA
 from . engines import *  # NOQA

--- a/stdpopsim/annotations.py
+++ b/stdpopsim/annotations.py
@@ -1,0 +1,164 @@
+"""
+Infrastructure for defining information about genome annotation.
+"""
+import logging
+import attr
+import pandas
+import pathlib
+import warnings
+import os
+import urllib.request
+from . import cache
+import zarr
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+
+def zarr_to_dataframe(path):
+    """
+    converts zarr annotation file to
+    pandas dataframe for manipulations
+    """
+    z = zarr.open(path)
+    df = pandas.DataFrame(
+        {'seqid': z['seqid'],
+         'source': z['source'],
+         'type': z['type'],
+         'start': z['start'],
+         'end': z['end'],
+         'score': z['score'],
+         'strand': z['strand'],
+         'phase': z['phase']}
+    )
+    return df
+
+
+@attr.s
+class Annotation(object):
+    """
+    Class represnting a Annotation file
+    assume GFF3/GTF or similar
+
+    :ivar url: The URL where the packed and compressed GTF can be found
+    :vartype url: str
+    :ivar species_id: species id
+    :vartype id: str
+    :ivar species: a `stdpopsim.species` instance
+    :ivar annotation_description: description of annotation file
+    :vartype annotation_description: str
+    """
+    url = attr.ib(default=None)
+    zarr_url = attr.ib(default=None)
+    species = attr.ib(default=None)
+    id = attr.ib(default=None)
+    file_name = attr.ib(default=None)
+    description = attr.ib(default=None)
+    citations = attr.ib(factory=list)
+    long_description = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        self.file_name = os.path.basename(self.zarr_url)
+
+    @property
+    def annot_cache_dir(self):
+        return pathlib.Path(cache.get_cache_dir()) / "annotations"
+
+    @property
+    def species_cache_dir(self):
+        return self.annot_cache_dir / self.species.id
+
+    def __str__(self):
+        s = "GTF Annotation:\n"
+        s += "\tspecies   = {}\n".format(self.species.name)
+        s += "\tid        = {}\n".format(self.id)
+        s += "\turl       = {}\n".format(self.url)
+        s += "\tzarr url       = {}\n".format(self.zarr_url)
+        s += "\tcached    = {}\n".format(self.is_cached())
+        s += "\tcache_dir = {}\n".format(self.species_cache_dir)
+        return s
+
+    def is_cached(self):
+        """
+        Returns True if this annotation is cached locally.
+        """
+        return os.path.exists(self.species_cache_dir)
+
+    def download(self):
+        """
+        Downloads the zarr from the source URL and stores it in the
+        cache directory. If the annotation directory already exists it is first
+        removed.
+        """
+        self.file_name = os.path.basename(self.zarr_url)
+        if self.is_cached():
+            logger.info(f"Clearing cache {self.species_cache_dir}")
+            with tempfile.TemporaryDirectory() as tempdir:
+                dest = pathlib.Path(tempdir) / "will_be_deleted"
+                os.rename(self.annot_cache_dir, dest)
+        logger.debug(f"Checking species cache directory {self.species_cache_dir}")
+        os.makedirs(self.species_cache_dir, exist_ok=True)
+        download_file = f'{self.species_cache_dir}/{self.file_name}'
+        logger.info(f"Downloading Zarr file '{self.id}' from {self.zarr_url}")
+        logger.info(f"download_file: {download_file}")
+        logger.info(f"species_cache_dir: {self.species_cache_dir}")
+        if os.path.exists(download_file):
+            warnings.warn("multiple downloads?")
+        try:
+            urllib.request.urlretrieve(self.zarr_url, filename=download_file)
+        except urllib.error.URLError:
+            print(f"could not connect to {self.zarr_url}")
+            raise
+        logger.debug("Download Zarr complete")
+        logger.info(f"Storing Zarr in {self.species_cache_dir}")
+
+    def get_chromosome_annotations(self, id):
+        """
+        Returns the pandas dataframe for
+        the chromosome with the specified id.
+        """
+        if not self.is_cached():
+            self.download()
+        annot_file = os.path.join(self.species_cache_dir, self.file_name)
+        if id is None:
+            raise ValueError("bad chrom id")
+        chr_prefix = "chr"  # building this in for future generalization
+        if id.startswith(chr_prefix):
+            id = id[len(chr_prefix):]
+        if os.path.exists(annot_file):
+            bed = zarr_to_dataframe(annot_file)
+            assert type(bed) == pandas.DataFrame
+            ret = bed[bed.seqid == id]
+            if len(ret) == 0:
+                raise ValueError
+        else:
+            ret = None
+            raise ValueError(
+                "Warning: annotation file not found for chromosome: '{}'"
+                " on annotation: '{}', no annotations will be used".format(
+                    id, self.id))
+        return ret
+
+    def get_annotation_type_from_chromomosome(self, a_type, chrom_id, full_table=False):
+        """
+        Returns all elements of
+        type a_type from chromosome
+        specified
+        """
+        annots = self.get_chromosome_annotations(chrom_id)
+        subset = annots[annots.type == a_type]
+        if subset.empty:
+            raise ValueError(f"annotation type '{a_type}' not found on chrom"
+                             f" {chrom_id}")
+        if full_table:
+            return subset
+        else:
+            return subset[['start', 'end']]
+
+    def get_genes_from_chromosome(self, chrom_id, full_table=False):
+        """
+        Returns all elements of
+        type gene from annotation
+        """
+        return self.get_annotation_type_from_chromomosome('gene', chrom_id,
+                                                          full_table)

--- a/stdpopsim/catalog/HomSap/__init__.py
+++ b/stdpopsim/catalog/HomSap/__init__.py
@@ -202,6 +202,36 @@ for pop in ["ACB", "ASW", "BEB", "CDX", "CEU", "CHB", "CHS", "CLM", "ESN",
     )
     _species.add_genetic_map(_gm)
 
+###########################################################
+#
+# Annotations
+#
+#
+#
+###########################################################
+
+_an = stdpopsim.Annotation(
+    species=_species,
+    id="Ensembl_GRCh38_gff3",
+    description="Ensembl GFF3 annotations on GRCh38",
+    long_description="""
+        These are the complete GFF3 annotations from
+        Ensembl. Please see
+        """,
+    url=(
+        "ftp://ftp.ensembl.org/pub/release-101/"
+        "gff3/homo_sapiens/Homo_sapiens.GRCh38.101.gff3.gz"),
+    zarr_url=(
+        "https://stdpopsim.s3-us-west-2.amazonaws.com/"
+        "annotations/HomSap.GRCh38.zip"),
+    citations=[
+        stdpopsim.Citation(
+            year=2018,
+            author="Hunt et al",
+            doi="https://doi.org/10.1093/database/bay119",
+            reasons={stdpopsim.CiteReason.ANNOTATION})]
+    )
+_species.add_annotations(_an)
 
 ###########################################################
 #

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -18,6 +18,7 @@ class CiteReason:
     MUT_RATE = "mutation rate"
     REC_RATE = "recombination rate"
     ASSEMBLY = "genome assembly"
+    ANNOTATION = "genome annotation"
     STDPOPSIM = "stdpopsim"
 
 

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -68,6 +68,12 @@ def all_demographic_models():
             yield model
 
 
+def all_annotations():
+    for species in all_species():
+        for an in species.annotations:
+            yield an
+
+
 @attr.s()
 class Species:
     """
@@ -135,6 +141,7 @@ class Species:
     # intended to be used when the Species is initialsed.
     # Use add_genetic_map() instead.
     genetic_maps = attr.ib(factory=list, kw_only=True)
+    annotations = attr.ib(factory=list, kw_only=True)
 
     @ensembl_id.default
     def _default_ensembl_id(self):
@@ -236,3 +243,27 @@ class Species:
             if gm.id == id:
                 return gm
         raise ValueError(f"Genetic map '{self.id}/{id}' not in catalog")
+
+    def add_annotations(self, annotations):
+        if annotations.id in [an.id for an in self.annotations]:
+            raise ValueError(
+                    f"Annotations '{self.id}/{annotations.id}' "
+                    "already in catalog.")
+        annotations.species = self
+        self.annotations.append(annotations)
+
+    def get_annotations(self, id):
+        """
+        Returns a set of annotations with the specified ``id``.
+
+        :param str id: The string identifier for the set of annotations
+            A complete list of IDs for each species can be found in the
+            "Annotations" subsection for the species in the :ref:`sec_catalog`.
+        :rtype: :class:`Annotation`
+        :return: A :class:`Annotation` that holds genome annotation
+            information from Ensembl
+        """
+        for an in self.annotations:
+            if an.id == id:
+                return an
+        raise ValueError(f"Annotations '{self.id}/{id}' not in catalog")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,207 @@
+"""
+Tests for the annotations management.
+"""
+import unittest
+from unittest import mock
+import gzip
+import tempfile
+import os.path
+import shutil
+import urllib.request
+import pathlib
+
+import pandas
+import stdpopsim
+from stdpopsim import annotations
+import tests
+
+
+# Here we download all the annotations in one go and store
+# then in the local cache directory, _test_cache. Tests are then run
+# with the download URLs redirected to local files, which makes them
+# much faster and takes network errors out of the equation. The
+# tarball cache is also useful for developers as it means that these
+# files are only downloaded once.
+
+saved_urls = {}
+
+
+def setUpModule():
+    destination = pathlib.Path("_test_cache/zipfiles/")
+    for an in stdpopsim.all_annotations():
+        key = an.file_name
+        local_file = destination / key
+        if not local_file.exists():
+            cache_dir = local_file.parent
+            cache_dir.mkdir(exist_ok=True, parents=True)
+            print("Downloading", an.zarr_url)
+            urllib.request.urlretrieve(an.zarr_url, local_file)
+        saved_urls[key] = an.zarr_url
+        an.zarr_url = local_file.resolve().as_uri()
+
+
+def tearDownModule():
+    for an in stdpopsim.all_annotations():
+        an.zarr_url = saved_urls[an.file_name]
+
+
+class AnnotationTestClass(annotations.Annotation):
+    """
+    A Annotation that we can instantiate to get an annotation for testing.
+    """
+
+    def __init__(self):
+        genome = stdpopsim.Genome(chromosomes=[])
+        _species = stdpopsim.Species(
+            id="TesSpe", name="Test species", common_name="Testy McTestface",
+            genome=genome)
+        super().__init__(
+            species=_species,
+            id="test_annotation",
+            url="http://example.com/annotation.gff.gz",
+            zarr_url="http://example.com/annotation.zip",
+            file_name="annotation.gff.gz")
+
+
+# number of chromosomes etc.
+def get_annotation_file(custom_file_f=None, filter=None):
+    """
+    Returns a GFF file as a bytes object.
+
+    :param func custom_file_f: A function that accepts a single parameter
+        (a folder name), which may be used to create additional files under
+        the given folder. All files in the folder will be included in the
+        returned tarball.
+    :param func filter: A function which is passed as the ``filter`` argument
+        to ``TarFile.add()``. This function can be used to change the info
+        field for each file in the returned tarball. See tarfile documentation
+        for more details.
+    """
+    b = "21\t.\tbiological_region\t6111184\t6111187\t0.999\t+\t.\tlogic_name=eponine\n"
+    b += b
+    b += b
+
+    with tempfile.TemporaryDirectory() as map_dir:
+        with open(os.path.join(map_dir, "test.gff"), "w") as f:
+            print("##gff-version 3", file=f)
+            print("##sequence-region   21 1 46709983", file=f)
+            print(b, file=f)
+
+        if custom_file_f is not None:
+            # Do arbitrary things under map_dir.
+            custom_file_f(map_dir)
+
+        # For the zipfile to be in the right format, we must be in the right directory.
+        with open(os.path.join(map_dir, "test.gff"), 'rb') as f_in:
+            # Now zip this
+            with gzip.open("test.gff.gz", mode="wb") as gz_file:
+                shutil.copyfileobj(f_in, gz_file)
+        # Read back the tarball
+        an = gzip.open("test.gff.gz", mode='rb')
+    return an
+
+
+class TestAnnotation(tests.CacheWritingTest):
+    """
+    Tests for the basic functionality of the Annotation class.
+    """
+
+    def test_cache_dirs(self):
+        gm = AnnotationTestClass()
+        cache_dir = stdpopsim.get_cache_dir() / "annotations"
+        self.assertEqual(gm.annot_cache_dir, cache_dir)
+        self.assertEqual(gm.species_cache_dir, gm.annot_cache_dir / gm.species.id)
+
+    def test_str(self):
+        gm = AnnotationTestClass()
+        self.assertGreater(len(str(gm)), 0)
+
+    def test_is_cached(self):
+        gm = AnnotationTestClass()
+        os.makedirs(gm.species_cache_dir, exist_ok=True)
+        self.assertTrue(gm.is_cached())
+        shutil.rmtree(gm.annot_cache_dir)
+        self.assertFalse(gm.is_cached())
+
+
+class TestAnnotationDownload(tests.CacheWritingTest):
+    """
+    Tests downloading code for the annotations.
+    """
+
+    def test_correct_url(self):
+        gm = AnnotationTestClass()
+        with mock.patch("urllib.request.urlretrieve", autospec=True) as mocked_get:
+            gm.download()
+        mocked_get.assert_called_once_with(gm.zarr_url, filename=unittest.mock.ANY)
+
+    def test_incorrect_url(self):
+        gm = AnnotationTestClass()
+        gm.zarr_url = 'http://asdfwersdf.com/foozip'
+        with self.assertRaises(urllib.error.URLError):
+            gm.download()
+
+    def test_download_over_cache(self):
+        for gm in stdpopsim.all_annotations():
+            gm.download()
+            self.assertTrue(gm.is_cached())
+            gm.download()
+            self.assertTrue(gm.is_cached())
+
+    def test_multiple_threads_downloading(self):
+        gm = next(stdpopsim.all_annotations())
+        gm.download()
+        saved = gm.is_cached
+        try:
+            # Trick the download code into thinking there's several happening
+            # concurrently
+            gm.is_cached = lambda: False
+            with self.assertWarns(Warning):
+                gm.download()
+        finally:
+            gm.is_cached = saved
+
+
+class TestGetChromosomeAnnotations(tests.CacheReadingTest):
+    """
+    Tests if we get chromosome level annotations
+    using the Ensembl_GRCh38 human GFF.
+    """
+    species = stdpopsim.get_species("HomSap")
+    an = species.get_annotations("Ensembl_GRCh38_gff3")
+
+    def test_known_chromosome(self):
+        print(self.cache_dir)
+        cm = self.an.get_chromosome_annotations("21")
+        self.assertIsInstance(cm, pandas.DataFrame)
+
+    def test_known_chromosome_prefix(self):
+        print(self.cache_dir)
+        cm = self.an.get_chromosome_annotations("chr21")
+        self.assertIsInstance(cm, pandas.DataFrame)
+
+    def test_unknown_chromosome(self):
+        for bad_chrom in ["", "ABD", None]:
+            with self.assertRaises(ValueError):
+                self.an.get_chromosome_annotations(bad_chrom)
+
+    def test_unknown_annot_file(self):
+        real_fn = self.an.file_name
+        self.an.file_name = "foo"
+        bad_chrom = "chrF"
+        with self.assertRaises(ValueError):
+            self.an.get_chromosome_annotations(bad_chrom)
+        self.an.file_name = real_fn
+
+    def test_get_genes(self):
+        g = self.an.get_genes_from_chromosome("chr21")
+        self.assertIsInstance(g, pandas.DataFrame)
+
+    def test_get_genes_full(self):
+        g = self.an.get_genes_from_chromosome("chr21", full_table=True)
+        self.assertIsInstance(g, pandas.DataFrame)
+
+    def test_bad_annot_type(self):
+        bad_annot = "foo"
+        with self.assertRaises(ValueError):
+            self.an.get_annotation_type_from_chromomosome(bad_annot, '21')

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -72,6 +72,19 @@ class TestSpecies(unittest.TestCase):
         with self.assertRaises(ValueError):
             species.add_demographic_model(model)
 
+    def test_get_unknown_annotation(self):
+        bad = ["GDXXX", "", None]
+        species = stdpopsim.get_species("HomSap")
+        for name in bad:
+            with self.assertRaises(ValueError):
+                species.get_annotations(name)
+
+    def test_add_duplicate_annotation(self):
+        species = stdpopsim.get_species("HomSap")
+        an = species.get_annotations("Ensembl_GRCh38_gff3")
+        with self.assertRaises(ValueError):
+            species.add_annotations(an)
+
 
 class SpeciesTestMixin(object):
     """


### PR DESCRIPTION
Hey all-

I've sketched out what i think are the main bits of the infrastructure for dealing with annotation. I've aimed to mirror what we do with genetic maps, although I figure if we do this right we don't have to host the data at all, and instead we can rely on Ensembl (or similar) as I'm doing now. 

The basic idea is that annotations will be downloaded to the cache as a GFF file. Annotations will have citations, ids, etc, just as do genetic_maps. Handling of the actual annotation files is currently done using [pybedtools](https://daler.github.io/pybedtools/), although I haven't build anything in other than a function that gets the annotations from a chromosome (we will need to make this useful with SLiM-- tagging @mufernando to help me).

Currently I only have annotations defined for HomSap. I will build this out further for the rest of the catalog once people have a look over this code. 

thanks.