### PR TITLE
Remove **kwargs from engine.simulate().

### DIFF
--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -57,7 +57,7 @@ class Engine(object):
 
     def simulate(
             self, demographic_model=None, contig=None, samples=None, seed=None,
-            dry_run=False, **kwargs):
+            dry_run=False):
         """
         Simulates the model for the specified contig and samples.
 
@@ -110,7 +110,7 @@ class _MsprimeEngine(Engine):
 
     def simulate(
             self, demographic_model=None, contig=None, samples=None, seed=None,
-            msprime_model=None, msprime_change_model=None, dry_run=False, **kwargs):
+            msprime_model=None, msprime_change_model=None, dry_run=False):
         """
         Simulate the demographic model using msprime.
         See :meth:`.Engine.simulate()` for definitions of parameters defined

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -640,7 +640,7 @@ class _SLiMEngine(stdpopsim.Engine):
     def simulate(
             self, demographic_model=None, contig=None, samples=None, seed=None,
             slim_path=None, slim_script=False, slim_scaling_factor=1.0,
-            slim_burn_in=10.0, dry_run=False, **kwargs):
+            slim_burn_in=10.0, dry_run=False):
         """
         Simulate the demographic model using SLiM.
         See :meth:`.Engine.simulate()` for definitions of the

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -49,3 +49,20 @@ class TestEngineAPI(unittest.TestCase):
         e = stdpopsim.Engine()
         self.assertRaises(NotImplementedError, e.simulate)
         self.assertRaises(NotImplementedError, e.get_version)
+
+
+class TestBehaviour(unittest.TestCase):
+    def test_simulate_nonexistent_param(self):
+        species = stdpopsim.get_species("HomSap")
+        model = species.get_demographic_model("AshkSub_7G19")
+        good_kwargs = dict(
+            demographic_model=model,
+            contig=species.get_contig("chr1"),
+            samples=model.get_samples(10, 10, 10),
+            dry_run=True,
+        )
+        bad_kwargs = good_kwargs.copy().update(nonexistent_param=None)
+        for engine in stdpopsim.all_engines():
+            engine.simulate(**good_kwargs)
+            with self.assertRaises(TypeError):
+                engine.simulate(**bad_kwargs)


### PR DESCRIPTION
This avoids silently accepting parameters that are misspelt.
See #565.