### PR TITLE
link to code in developer docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -50,6 +50,8 @@ help+wanted%22>`_
 
 To get started helping with ``stdpopsim`` development, please read the
 following sections to learn how to contribute.
+And, importantly, please have a look at our
+`code of conduct <https://github.com/popsim-consortium/stdpopsim/blob/master/CODE_OF_CONDUCT.md>`_.
 
 .. _sec_development_installation:
 


### PR DESCRIPTION
I realized we didn't actually have a link to the code of conduct in the developer docs. Here it is!  I thought about moving the code over to rst, but really it should go somewhere else (it's not specific to stdpopsim for one thing). This is good enough for now, anyhow.