### PR TITLE
Scale the selection coefficient when using a MutationType.

### DIFF
--- a/stdpopsim/ext/selection.py
+++ b/stdpopsim/ext/selection.py
@@ -49,6 +49,16 @@ class MutationType(object):
             raise ValueError(
                     f"{self.distribution_type} is not a supported distribution type")
 
+        # The index of the param in the distribution_args list that should be
+        # multiplied by Q when using --slim-scaling-factor Q.
+        self.Q_scaled_index = {
+            "e": 0,  # mean
+            "f": 0,  # fixed value
+            "g": 0,  # mean
+            "n": 1,  # standard deviation
+            "w": 0,  # scale
+        }[self.distribution_type]
+
 
 def slim_mutation_frac(mutation_types):
     """

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -762,7 +762,9 @@ def slim_makescript(
     # FIXME: Change this to use zero-based indices---one-based indices are
     #        inconsistent with everything else, e.g. population IDs.
     for i, m in enumerate(mutation_types, 1):
-        distrib_args = ", ".join(map(str, m.distribution_args))
+        distrib_args = [str(arg) for arg in m.distribution_args]
+        distrib_args[m.Q_scaled_index] = "Q * " + distrib_args[m.Q_scaled_index]
+        distrib_args = ", ".join(distrib_args)
         printsc(f'    initializeMutationType("m{i}", {m.dominance_coeff}, ' +
                 f'"{m.distribution_type}", {distrib_args});')
         if not m.convert_to_substitution:


### PR DESCRIPTION
Fixes #612.

Not sure how to unittest this. We could just check for `Q` in the initializeMutationType lines of the generated slim script, but this seems fairly fragile.