### PR TITLE
pin python 3.8

### DIFF
--- a/requirements/rtd-conda-environment.yml
+++ b/requirements/rtd-conda-environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - libgfortran-ng=7.3.0
   - libopenblas=0.3.9
   - llvm-openmp=10.0.0
+  - python=3.8
   - sphinx-argparse=0.2.5
   - sphinx-issues=1.2.0
   - sphinxcontrib-programoutput=0.16


### PR DESCRIPTION
pinned python to version 3.8 in rtd-conda-environment.yml