### PR TITLE
Genomic element

### DIFF
--- a/stdpopsim/ext/selection.py
+++ b/stdpopsim/ext/selection.py
@@ -13,15 +13,8 @@ class MutationType(object):
     distribution_type = attr.ib(default="f", type=str)
     distribution_args = attr.ib(factory=lambda: [0], type=list)
     convert_to_substitution = attr.ib(default=True, type=bool)
-    # MutationTypes with non-zero weight will be simulated by SLiM,
-    # using rates obtained from the relative weights of the types.
-    # I.e. the weights will be used in the ``proportion`` parameter
-    # to SLiM's :func:`initializeGenomicElementType()`.
-    weight = attr.ib(default=0, type=float)
 
     def __attrs_post_init__(self):
-        if self.weight < 0:
-            raise ValueError("weight must be >= 0.")
         if self.dominance_coeff < 0:
             raise ValueError(f"Invalid dominance coefficient {self.dominance_coeff}.")
 
@@ -61,19 +54,6 @@ class MutationType(object):
             "n": 1,  # standard deviation
             "w": 0,  # scale
         }[self.distribution_type]
-
-
-def slim_mutation_frac(mutation_types):
-    """
-    The fraction of mutations that should be added by SLiM.
-    The remainder are added by msprime.mutate() once the SLiM part
-    of the simulation is complete.
-    """
-    if mutation_types is None:
-        weighted = False
-    else:
-        weighted = any(mut_type.weight > 0 for mut_type in mutation_types)
-    return 1 if weighted else 0
 
 
 @attr.s

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -1,7 +1,13 @@
 """
-Infrastructure for defining information about species' genomes.
+Infrastructure for defining information about species' genomes and genomic
+regions to be simulated.
 """
+import logging
 import attr
+import numpy as np
+import stdpopsim
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s
@@ -107,12 +113,40 @@ class Chromosome:
     synonyms = attr.ib(factory=list, kw_only=True)
 
 
+@attr.s(kw_only=True)
+class GenomicElementType(object):
+    """
+    Class that represents a map between genomic intervals and a group of
+    mutation types and the rate in which they occur within those intervals.
+
+    :ivar mutation_type_ids: Indices for the mutation types that can occur in
+        genomic elements of this type.
+    :vartype mutation_type_ids: list
+    :ivar proportions: Proportions (out of the mutation rate) in which each
+        mutation type can happen in genomic intervals of this type.
+    :vartype: proportions: numpy.array, dtype=np.float32
+    :ivar intervals: (n, 2) numpy array with [left, right) genomic intervals
+        that will be of this GenomicElementType. The intervals are used to
+        specify SLiM GenomicElements. Intervals must be non-overlapping.
+    :vartype intervals: numpy.array, dtype=np.int32
+    """
+
+    mutation_type_ids = attr.ib(factory=lambda: [], type=list)
+    proportions = attr.ib(factory=lambda: np.array([]), type=np.ndarray)
+    intervals = attr.ib(default=None, type=np.array)
+
+    def __attrs_post_init__(self):
+        _check_mut_proportions(self.proportions, self.mutation_type_ids)
+        stdpopsim.utils.check_intervals_validity(self.intervals)
+
+
 @attr.s
 class Contig:
     """
     Class representing a contiguous region of genome that is to be
     simulated. This contains the information about mutation rates
     and recombination rates that are needed to simulate this region.
+    Genomic element types can be provided
 
     :ivar mutation_rate: The rate of mutation per base per generation.
     :vartype mutation_rate: float
@@ -129,6 +163,13 @@ class Contig:
     :ivar exclude: If True, ``mask_intervals`` specify regions to exclude. If False,
         ``mask_intervals`` specify regions in keep.
     :vartype exclude: bool
+    :ivar genomic_element_types: a list of stdpopsim.GenomicElementType
+        objects. By default, the only element is a single genomic element type
+        that spans the entire contiguous region.
+    :vartype genomic_element_types: list
+    :ivar mutation_types: a list of stdpopsim.ext.MutationType object. By
+        default, the only mutation type is neutral. See
+        stdpopsim.MutationType for more details.
 
     .. note::
         To run stdpopsim simulations with alternative, user-specified mutation
@@ -150,16 +191,154 @@ class Contig:
     genetic_map = attr.ib(default=None, kw_only=True)
     inclusion_mask = attr.ib(default=None, kw_only=True)
     exclusion_mask = attr.ib(default=None, kw_only=True)
+    genomic_element_types = attr.ib(factory=lambda: [], type=list, kw_only=True)
+    mutation_types = attr.ib(factory=lambda: [], type=list, kw_only=True)
+
+    @property
+    def length(self):
+        if self.recombination_map is None:
+            return None
+        return self.recombination_map.get_length()
+
+    @property
+    def slim_fractions(self):
+        map(lambda g: _check_mut_proportions(g.proportions), self.genomic_element_types)
+        props = np.array([sum(g.proportions) for g in self.genomic_element_types])
+        return props
+
+    @property
+    def genomic_intervals(self):
+        """
+        Returns an (n, 3) numpy array with n intervals (left, right, type)
+        """
+        all_intervals = np.concatenate(
+            [
+                np.column_stack(
+                    (g.intervals[:, :2], np.full((g.intervals.shape[0]), i))
+                )
+                for i, g in enumerate(self.genomic_element_types)
+            ],
+            axis=0,
+        )
+        all_intervals = stdpopsim.utils.build_intervals_array(all_intervals)
+        return all_intervals
+
+    @property
+    def msp_mutation_rate_map(self):
+        """
+        breaks = [0,10,20] means [0,10) and [10,20)
+        """
+        breaks = [0]
+        rates = []
+        for (start, end, t) in self.genomic_intervals:
+            if start not in breaks:
+                breaks.append(start)
+                rates.append(self.mutation_rate)
+            breaks.append(end)
+            rates.append((1 - self.slim_fractions[t]) * self.mutation_rate)
+        if not np.isclose(breaks[-1], int(self.length)):
+            breaks.append(int(self.length))
+            rates.append(self.mutation_rate)
+        assert len(breaks) == len(rates) + 1
+        return (breaks, rates)
+
+    @property
+    def slim_mutation_rate_map(self):
+        """
+        breaks = [10,20] means [0,10] and (10,20]
+        """
+        # making sure the mut types are still concordant with the ge types
+        breaks, rates = self.msp_mutation_rate_map
+        assert breaks[0] == 0
+        slim_breaks = [b - 1 for b in breaks[1:]]
+        slim_rates = [self.mutation_rate - r for r in rates]
+        return (slim_breaks, slim_rates)
+
+    def add_mutation_types(self, mutation_types, proportions, genomic_element_type_id):
+        """
+        Adds mutation types with their respective proportions to the genomic
+        element type provided.
+        """
+        _check_mut_proportions(proportions, mutation_types)
+        if genomic_element_type_id >= len(self.genomic_element_types):
+            raise ValueError(
+                f"Genomic element type of id {genomic_element_type_id} does not exist."
+            )
+
+        def _is_index(y, X):
+            for i, e in enumerate(X):
+                if e is y:
+                    return i
+            return -1
+
+        for mut_type, prop in zip(mutation_types, proportions):
+            mid = _is_index(mut_type, self.mutation_types)
+            if mid == -1:
+                self.mutation_types.append(mut_type)
+                mid = len(self.mutation_types) - 1
+            self.genomic_element_types[
+                genomic_element_type_id
+            ].mutation_type_ids.append(mid)
+            self.genomic_element_types[genomic_element_type_id].proportions = np.append(
+                self.genomic_element_types[genomic_element_type_id].proportions, [prop]
+            )
+
+    def add_genomic_element_type(self, intervals, mutation_types, proportions):
+        if self.recombination_map is None:
+            raise ValueError(
+                "You cannot add genomic element types to a "
+                "contig that has no recombination map."
+            )
+        stdpopsim.utils.check_intervals_validity(intervals)
+        ge_type = stdpopsim.GenomicElementType(intervals=intervals)
+        self.genomic_element_types.append(ge_type)
+        getid = len(self.genomic_element_types) - 1
+        self.add_mutation_types(
+            mutation_types, proportions, genomic_element_type_id=getid
+        )
+
+    def clear_genomic_mutation_types(self):
+        self.genomic_element_types = []
+        self.mutation_types = []
+
+    def fully_neutral(self, slim_mutations=False, convert_to_substitution=True):
+        self.clear_genomic_mutation_types()
+        self.add_genomic_element_type(
+            intervals=np.array([[0, int(self.length)]]),
+            mutation_types=[
+                stdpopsim.ext.MutationType(
+                    convert_to_substitution=convert_to_substitution
+                )
+            ],
+            proportions=[1 if slim_mutations else 0],
+        )
 
     def __str__(self):
         gmap = "None" if self.genetic_map is None else self.genetic_map.id
         s = (
             "Contig(length={:.2G}, recombination_rate={:.2G}, "
-            "mutation_rate={:.2G}, genetic_map={})"
+            "mutation_rate={:.2G}, genetic_map={}, genomic_element_types={}, "
+            "mutation_types={})"
         ).format(
-            self.recombination_map.get_length(),
+            self.length,
             self.recombination_map.mean_recombination_rate,
             self.mutation_rate,
             gmap,
+            self.genomic_element_types,
+            self.mutation_types,
         )
         return s
+
+
+def _check_mut_proportions(proportions, mutation_type=None, atol=1e-15):
+    if mutation_type is not None and len(proportions) != len(mutation_type):
+        raise ValueError(
+            "The list of proportions and mutation types should be of the same length."
+        )
+    if any([not (0 <= prop <= 1) for prop in proportions]):
+        raise ValueError("Proportions must lie within the [0,1] interval.")
+    if sum(proportions) > 1 + atol:
+        raise ValueError(
+            "The sum of the proportions within genomic element types cannot"
+            " exceed 1."
+        )

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -74,8 +74,6 @@ initialize() {
 
     defineConstant("burn_in", $burn_in);
     defineConstant("generation_time", $generation_time);
-    defineConstant("mutation_rate", Q * $mutation_rate);
-    defineConstant("chromosome_length", $chromosome_length);
     defineConstant("trees_file", "$trees_file");
     defineConstant("pop_names", $pop_names);
 
@@ -89,8 +87,6 @@ _slim_lower = """
     defineConstant("N", asInteger(_N/Q));
 
     initializeTreeSeq();
-    initializeMutationRate(mutation_rate);
-    initializeGenomicElement(g1, 0, chromosome_length-1);
     initializeRecombinationRate(recombination_rates, recombination_ends);
 }
 
@@ -526,12 +522,11 @@ def slim_makescript(
     demographic_model,
     contig,
     samples,
-    mutation_types,
     extended_events,
     scaling_factor,
     burn_in,
 ):
-
+    mutation_types = contig.mutation_types
     pop_names = [
         pc.metadata["id"] for pc in demographic_model.population_configurations
     ]
@@ -643,12 +638,7 @@ def slim_makescript(
         if hasattr(ee, "mutation_type_id"):
             mt_id = getattr(ee, "mutation_type_id")
             cls_name = ee.__class__.__name__
-            if mutation_types is None:
-                raise ValueError(
-                    f"Invalid {cls_name} event. No mutation types defined."
-                )
-            if not (0 < ee.mutation_type_id <= len(mutation_types)):
-                # FIXME: use zero-based indexes
+            if not (0 <= ee.mutation_type_id < len(mutation_types)):
                 raise ValueError(
                     f"Invalid {cls_name} event with mutation type id {mt_id}."
                 )
@@ -660,6 +650,7 @@ def slim_makescript(
             stdpopsim.ext.validate_time_range(start_time, end_time)
 
         if isinstance(ee, stdpopsim.ext.DrawMutation):
+            # TODO: warning if mutation type id points to a neutral mut.
             time = ee.time * demographic_model.generation_time
             save = 1 if ee.save else 0
             drawn_mutations.append(
@@ -755,10 +746,8 @@ def slim_makescript(
         string.Template(_slim_upper).substitute(
             scaling_factor=scaling_factor,
             burn_in=float(burn_in),
-            chromosome_length=int(contig.recombination_map.get_length()),
             recombination_rates=recomb_rates_str,
             recombination_ends=recomb_ends_str,
-            mutation_rate=contig.mutation_rate,
             generation_time=demographic_model.generation_time,
             trees_file=trees_file,
             pop_names=f"c({pop_names_str})",
@@ -800,29 +789,38 @@ def slim_makescript(
 
         return "".join(s)
 
-    if mutation_types is None:
-        mutation_types = [stdpopsim.ext.MutationType()]
-
-    # Mutation type; genomic elements.
-    # FIXME: Change this to use zero-based indices---one-based indices are
-    #        inconsistent with everything else, e.g. population IDs.
-    for i, m in enumerate(mutation_types, 1):
+    # Mutation types.
+    for i, m in enumerate(mutation_types):
         distrib_args = [str(arg) for arg in m.distribution_args]
         distrib_args[m.Q_scaled_index] = "Q * " + distrib_args[m.Q_scaled_index]
         distrib_args = ", ".join(distrib_args)
         printsc(
-            f'    initializeMutationType("m{i}", {m.dominance_coeff}, '
+            f"    initializeMutationType({i}, {m.dominance_coeff}, "
             + f'"{m.distribution_type}", {distrib_args});'
         )
         if not m.convert_to_substitution:
             # T is the default for WF simulations.
             printsc(f"    m{i}.convertToSubstitution = F;")
-    mut_weights = ", ".join(str(m.weight) for m in mutation_types)
-    printsc(
-        '    initializeGenomicElementType("g1", '
-        + f"seq(1, {len(mutation_types)}), c({mut_weights}));"
-    )
-    printsc()
+    # Genomic element types.
+    genomic_element_types = contig.genomic_element_types
+    for j, g in enumerate(genomic_element_types):
+        mut_props = ", ".join([str(prop) for prop in g.proportions])
+        mut_types = ", ".join([str(mid) for mid in g.mutation_type_ids])
+        element_starts = np.array2string(g.intervals[:, 0], separator=", ")[1:-1]
+        # stdpopsim intervals are 0-based left inclusive, right exclusive, but
+        # SLiM intervals are right inclusive
+        element_ends = np.array2string((g.intervals[:, 1] - 1), separator=", ")[1:-1]
+        printsc(
+            f"    initializeGenomicElementType({j}, c({mut_types}), c({mut_props}));"
+        )
+        printsc(
+            f"    initializeGenomicElement({j}, c({element_starts}), c({element_ends}));"
+        )
+    # Mutation rate map.
+    breaks, rates = contig.slim_mutation_rate_map
+    mut_rates = ", ".join([str(r) for r in rates])
+    mut_breaks = ", ".join([str(int(b)) for b in breaks])
+    printsc(f"    initializeMutationRate(c({mut_rates})*Q, c({mut_breaks}));")
 
     # Epoch times.
     printsc("    // Time of epoch boundaries, in years before present.")
@@ -1017,7 +1015,6 @@ class _SLiMEngine(stdpopsim.Engine):
         contig=None,
         samples=None,
         seed=None,
-        mutation_types=None,
         extended_events=None,
         slim_path=None,
         slim_script=False,
@@ -1068,19 +1065,15 @@ class _SLiMEngine(stdpopsim.Engine):
                     "compare results across different values of the scaling factor."
                 )
             )
+        if contig.recombination_map is None:
+            raise ValueError(
+                "Your Contig object is not compatible with the SLiM "
+                "engine. You must specify a recombination map."
+            )
+        if len(contig.genomic_element_types) == 0:
+            contig.fully_neutral()
 
         run_slim = not slim_script
-
-        # Ensure only "weighted" mutations are introduced by SLiM.
-        mutation_rate = contig.mutation_rate
-        slim_frac = stdpopsim.ext.slim_mutation_frac(mutation_types)
-        contig = stdpopsim.Contig(
-            recombination_map=contig.recombination_map,
-            mutation_rate=slim_frac * mutation_rate,
-            genetic_map=contig.genetic_map,
-            inclusion_mask=contig.inclusion_mask,
-            exclusion_mask=contig.exclusion_mask,
-        )
 
         mktemp = functools.partial(tempfile.NamedTemporaryFile, mode="w")
 
@@ -1100,7 +1093,6 @@ class _SLiMEngine(stdpopsim.Engine):
                 demographic_model,
                 contig,
                 samples,
-                mutation_types,
                 extended_events,
                 slim_scaling_factor,
                 slim_burn_in,
@@ -1120,9 +1112,7 @@ class _SLiMEngine(stdpopsim.Engine):
 
             ts = pyslim.load(ts_file.name)
 
-        ts = self._recap_and_rescale(
-            ts, seed, recap_epoch, contig, mutation_rate, slim_frac, slim_scaling_factor
-        )
+        ts = self._recap_and_rescale(ts, seed, recap_epoch, contig, slim_scaling_factor)
 
         if contig.inclusion_mask is not None:
             ts = stdpopsim.utils.mask_tree_sequence(ts, contig.inclusion_mask, False)
@@ -1189,16 +1179,7 @@ class _SLiMEngine(stdpopsim.Engine):
         )
         return ts.simplify(samples=list(nodes), filter_populations=False)
 
-    def _recap_and_rescale(
-        self,
-        ts,
-        seed,
-        recap_epoch,
-        contig,
-        mutation_rate,
-        slim_frac,
-        slim_scaling_factor,
-    ):
+    def _recap_and_rescale(self, ts, seed, recap_epoch, contig, slim_scaling_factor):
         """
         Apply post-SLiM transformations to ``ts``. This rescales node times,
         does recapitation, simplification, and adds neutral mutations.
@@ -1220,6 +1201,15 @@ class _SLiMEngine(stdpopsim.Engine):
             )
             for pop in recap_epoch.populations
         ]
+        #########################################
+        # FIX THIS BEFORE MERGING INTO MASTER!!!!
+        # NEED THE LATEST SLiM
+        #########################################
+        # TODO: remove this line once SLiM starts populating mutation times
+        tables = ts.tables
+        tables.compute_mutation_times()
+        ts = pyslim.load_tables(tables)
+        # TODO: using recombination map in recapitate. maps should be discrete.
         ts = ts.recapitate(
             recombination_rate=contig.recombination_map.mean_recombination_rate,
             population_configurations=population_configurations,
@@ -1229,25 +1219,25 @@ class _SLiMEngine(stdpopsim.Engine):
 
         ts = self._simplify_remembered(ts)
 
-        if slim_frac < 1:
-            # Add mutations to SLiM part of trees.
-            rate = (1 - slim_frac) * mutation_rate
-            ts = pyslim.SlimTreeSequence(
-                msprime.mutate(
-                    ts,
-                    rate=rate,
-                    keep=True,
-                    random_seed=s2,
-                    end_time=ts.slim_generation,
-                )
+        # Adding neutral mutations to the SLiM part
+        breaks, rates = contig.msp_mutation_rate_map
+        rate_map = msprime.RateMap(position=breaks, rate=rates)
+        ts = pyslim.SlimTreeSequence(
+            msprime.mutate(
+                ts,
+                rate=rate_map,
+                keep=True,
+                random_seed=s2,
+                end_time=ts.slim_generation,
             )
+        )
 
         # Add mutations to recapitated part of trees.
         s3 = rng.randrange(1, 2 ** 32)
         ts = pyslim.SlimTreeSequence(
             msprime.mutate(
                 ts,
-                rate=mutation_rate,
+                rate=contig.mutation_rate,
                 keep=True,
                 random_seed=s3,
                 start_time=ts.slim_generation,
@@ -1262,7 +1252,6 @@ class _SLiMEngine(stdpopsim.Engine):
         demographic_model,
         contig,
         samples,
-        mutation_types=None,
         extended_events=None,
         slim_scaling_factor=1.0,
         seed=None,
@@ -1291,14 +1280,6 @@ class _SLiMEngine(stdpopsim.Engine):
             should be consulted to determine if the behaviour is appropriate
             for your case.
         """
-        # Only "weighted" mutations are introduced by SLiM.
-        mutation_rate = contig.mutation_rate
-        slim_frac = stdpopsim.ext.slim_mutation_frac(mutation_types)
-        contig = stdpopsim.Contig(
-            recombination_map=contig.recombination_map,
-            mutation_rate=slim_frac * mutation_rate,
-            genetic_map=contig.genetic_map,
-        )
 
         with open(os.devnull, "w") as script_file:
             recap_epoch = slim_makescript(
@@ -1307,15 +1288,12 @@ class _SLiMEngine(stdpopsim.Engine):
                 demographic_model,
                 contig,
                 samples,
-                mutation_types,
                 extended_events,
                 slim_scaling_factor,
                 1,
             )
 
-        ts = self._recap_and_rescale(
-            ts, seed, recap_epoch, contig, mutation_rate, slim_frac, slim_scaling_factor
-        )
+        ts = self._recap_and_rescale(ts, seed, recap_epoch, contig, slim_scaling_factor)
         return ts
 
 

--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -9,6 +9,7 @@ import shutil
 import tarfile
 import contextlib
 import numpy as np
+import tskit
 
 
 def is_valid_demographic_model_id(model_id):
@@ -148,3 +149,35 @@ def mask_tree_sequence(ts, mask_intervals, exclude):
     else:
         ts = ts.delete_intervals(mask_intervals)
     return ts
+
+
+def check_intervals_array_shape(intervals):
+    if len(intervals.shape) != 2 or intervals.shape[1] < 2:
+        raise ValueError(
+            "Intervals must be 2D objects with at least 2 columns " "[left, right)."
+        )
+
+
+def check_intervals_validity(intervals, start=0, end=np.inf):
+    check_intervals_array_shape(intervals)
+    if np.any(intervals[:, 0] >= intervals[:, 1]):
+        raise ValueError(
+            "Left positions cannot be greater than or equal to right positions."
+        )
+    if np.any(intervals[:, :2] > end) or np.any(intervals[:, :2] < start):
+        raise ValueError(f"Intervals must be within [{start}, {end}]")
+    if not np.all(intervals[1:, 0] >= intervals[:-1, 1]):
+        raise ValueError("Intervals must be non-overlapping.")
+
+
+def build_intervals_array(intervals, start=0, end=np.inf):
+    """
+    Converts a 2D list or numpy.array to an np.int32 array, which is sorted by
+    the first axis. It also checks for the validity of intervals and non-overlappingness.
+    """
+    intervals = tskit.util.safe_np_int_cast(intervals, dtype=np.int64)
+    check_intervals_array_shape(intervals)
+    sorter = intervals[:, 0].argsort()
+    intervals = intervals[sorter]
+    check_intervals_validity(intervals, start, end)
+    return intervals

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -1,0 +1,195 @@
+"""
+Tests for classes that hold information about genomic region to be simulated.
+"""
+import unittest
+import stdpopsim
+import numpy as np
+
+
+class TestGenomicElementType(unittest.TestCase):
+    def test_bad_proportions(self):
+        # no proportion but mut type, prop > 1, sum(prop) > 1
+        proportions = ([], [2], [0.5, 0.5, 0.5])
+        mut_type_ids = ([0], [0], [0])
+        for props in proportions:
+            with self.assertRaises(ValueError):
+                stdpopsim.GenomicElementType(
+                    intervals=np.array([[0, 1]]),
+                    mutation_type_ids=mut_type_ids,
+                    proportions=props,
+                )
+
+
+class TestContig(unittest.TestCase):
+    def get_test_contig(self, no_rec_map=False):
+        species = stdpopsim.get_species("HomSap")
+        contig = species.get_contig("chr22", length_multiplier=0.001)
+        if no_rec_map:
+            contig.recombination_map = None
+        return contig
+
+    def test_length(self):
+        contig = self.get_test_contig()
+        self.assertTrue(contig.length is not None and contig.length > 0)
+        contig_nomap = self.get_test_contig(no_rec_map=True)
+        self.assertTrue(contig_nomap.length is None)
+
+    def test_slim_fractions(self):
+        contig = self.get_test_contig()
+        self.assertTrue(contig.slim_fractions.size == 0)
+        contig.fully_neutral()
+        self.assertTrue(np.isclose(contig.slim_fractions, np.array([0])))
+        contig.fully_neutral(slim_mutations=True)
+        self.assertTrue(np.isclose(contig.slim_fractions, np.array([1])))
+
+        proportions = ([0, 1.0], [0.5, 0.5], [0, 0], [0.2, 0])
+        for props in proportions:
+            slim_frac = np.array(sum(props))
+            contig.clear_genomic_mutation_types()
+            contig.add_genomic_element_type(
+                intervals=np.array([[0, 1]]),
+                mutation_types=[
+                    stdpopsim.ext.MutationType(),
+                    stdpopsim.ext.MutationType(),
+                ],
+                proportions=props,
+            )
+            self.assertTrue((slim_frac == contig.slim_fractions).all())
+
+    def test_genomic_intervals(self):
+        contig = self.get_test_contig()
+        contig.fully_neutral()
+        self.assertTrue(len(contig.genomic_intervals) == 1)
+
+        truth = np.array([[20, 30, 1], [30, 50, 0]])
+        contig.clear_genomic_mutation_types()
+        contig.add_genomic_element_type(
+            intervals=np.array([[30, 50, 0]]),
+            mutation_types=[stdpopsim.ext.MutationType()],
+            proportions=np.array([0]),
+        )
+        contig.add_genomic_element_type(
+            intervals=np.array([[20, 30, 1]]),
+            mutation_types=[stdpopsim.ext.MutationType()],
+            proportions=np.array([0]),
+        )
+        self.assertTrue((contig.genomic_intervals == truth).all())
+
+    def test_msp_mutation_rate_map(self):
+        contig = self.get_test_contig()
+        contig.fully_neutral()
+        breaks, rates = contig.msp_mutation_rate_map
+        self.assertTrue(breaks == [0, int(contig.length)])
+        self.assertTrue(rates == [contig.mutation_rate])
+
+    def test_slim_mutation_rate_map(self):
+        contig = self.get_test_contig()
+        contig.fully_neutral()
+        breaks, rates = contig.slim_mutation_rate_map
+        self.assertTrue(breaks == [int(contig.length) - 1])
+        self.assertTrue(rates == [0.0])
+
+    def test_complex_mutation_rate_maps(self):
+        contig = self.get_test_contig()
+        for prop1, prop2 in ((0.3, 0.1), (0.7, 0.2), (1.0, 0.0)):
+            contig.clear_genomic_mutation_types()
+            contig.add_genomic_element_type(
+                intervals=np.array([[10, 100]]),
+                mutation_types=[stdpopsim.ext.MutationType()],
+                proportions=[prop1],
+            )
+
+            obs_msp_breaks, obs_msp_rates = contig.msp_mutation_rate_map
+            obs_slim_breaks, obs_slim_rates = contig.slim_mutation_rate_map
+
+            exp_msp_breaks = [0, 10, 100, int(contig.length)]
+            exp_msp_rates = [
+                contig.mutation_rate,
+                contig.mutation_rate * (1 - prop1),
+                contig.mutation_rate,
+            ]
+            self.assertEqual(obs_msp_breaks, exp_msp_breaks)
+            self.assertTrue(
+                (np.isclose(np.array(obs_msp_rates), np.array(exp_msp_rates))).all()
+            )
+
+            exp_slim_breaks = [9, 99, int(contig.length) - 1]
+            exp_slim_rates = [0, contig.mutation_rate * prop1, 0]
+            self.assertEqual(obs_slim_breaks, exp_slim_breaks)
+            self.assertTrue(
+                (np.isclose(np.array(obs_slim_rates), np.array(exp_slim_rates))).all()
+            )
+
+            contig.clear_genomic_mutation_types()
+            contig.add_genomic_element_type(
+                intervals=np.array([[0, 50]]),
+                mutation_types=[stdpopsim.ext.MutationType()],
+                proportions=[prop1],
+            )
+            contig.add_genomic_element_type(
+                intervals=np.array([[50, 100]]),
+                mutation_types=[stdpopsim.ext.MutationType()],
+                proportions=[prop2],
+            )
+
+            obs_msp_breaks, obs_msp_rates = contig.msp_mutation_rate_map
+            obs_slim_breaks, obs_slim_rates = contig.slim_mutation_rate_map
+
+            exp_msp_breaks = [0, 50, 100, int(contig.length)]
+            exp_msp_rates = [
+                contig.mutation_rate * (1 - prop1),
+                contig.mutation_rate * (1 - prop2),
+                contig.mutation_rate,
+            ]
+            self.assertEqual(obs_msp_breaks, exp_msp_breaks)
+            self.assertTrue(
+                (np.isclose(np.array(obs_msp_rates), np.array(exp_msp_rates))).all()
+            )
+
+            exp_slim_breaks = [49, 99, int(contig.length) - 1]
+            exp_slim_rates = [
+                contig.mutation_rate * prop1,
+                contig.mutation_rate * prop2,
+                0,
+            ]
+            self.assertEqual(obs_slim_breaks, exp_slim_breaks)
+            self.assertTrue(
+                (np.isclose(np.array(obs_slim_rates), np.array(exp_slim_rates))).all()
+            )
+
+    def test_add_mutation_type_errors(self):
+        contig = self.get_test_contig()
+        # diff length mutation types and proportions
+        with self.assertRaises(ValueError):
+            contig.add_mutation_types([stdpopsim.ext.MutationType()], [], 0)
+        # invalid ge type id
+        with self.assertRaises(ValueError):
+            contig.add_mutation_types([stdpopsim.ext.MutationType()], [0], 0)
+        contig.fully_neutral()
+        # sum props > 1
+        with self.assertRaises(ValueError):
+            contig.add_mutation_types([stdpopsim.ext.MutationType()], [1.1], 0)
+
+    def test_add_genomic_element_type_errors(self):
+        contig = self.get_test_contig()
+        contig.recombination_map = None
+        # can't add ge type without rec map
+        with self.assertRaises(ValueError):
+            contig.add_genomic_element_type(np.array([]), [], [])
+        contig = self.get_test_contig()
+        # bad intervals
+        with self.assertRaises(ValueError):
+            contig.add_genomic_element_type(np.array([10, 20]), [], [])
+
+    def test_add_genomic_element_type(self):
+        contig = self.get_test_contig()
+        self.assertTrue(contig.mutation_types == [])
+        self.assertTrue(contig.genomic_element_types == [])
+        intervals1 = np.array([[10, 20], [20, 40], [100, 200]])
+        intervals2 = np.array([[5, 10], [45, 50], [200, 250]])
+        m1 = stdpopsim.ext.MutationType()
+        m2 = stdpopsim.ext.MutationType()
+        contig.add_genomic_element_type(intervals1, [m1, m2], [0.5, 0.3])
+        contig.add_genomic_element_type(intervals2, [m1], [0.2])
+        self.assertTrue(len(contig.genomic_element_types) == 2)
+        self.assertTrue(len(contig.mutation_types) == 2)

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -10,6 +10,7 @@ import unittest
 import tempfile
 import math
 from unittest import mock
+import numpy as np
 
 import tskit
 import pyslim
@@ -114,6 +115,20 @@ class TestAPI(unittest.TestCase):
         )
         self.assertTrue("sim.registerLateEvent" in out)
 
+    def test_no_recombination_map(self):
+        engine = stdpopsim.get_engine("slim")
+        species = stdpopsim.get_species("HomSap")
+        contig = species.get_contig("chr1", genetic_map="HapMapII_GRCh37")
+        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        contig.recombination_map = None
+        with self.assertRaises(ValueError):
+            engine.simulate(
+                demographic_model=model,
+                contig=contig,
+                samples=model.get_samples(10),
+                dry_run=True,
+            )
+
     def test_recombination_map(self):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")
@@ -147,22 +162,19 @@ class TestAPI(unittest.TestCase):
     def test_recap_and_rescale(self):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")
-        contig = species.get_contig("chr22", length_multiplier=0.001)
         model = species.get_demographic_model("OutOfAfrica_3G09")
         samples = model.get_samples(10, 10, 10)
-
-        for weight, seed in zip((0, 1), (1234, 2345)):
-            if weight:
-                mutation_types = [stdpopsim.ext.MutationType(weight=1)]
+        for proportion, seed in zip((0, 1), (1234, 2345)):
+            contig = species.get_contig("chr22", length_multiplier=0.001)
+            if proportion:
+                contig.fully_neutral(slim_mutations=True)
                 extended_events = None
             else:
-                mutation_types = None
                 extended_events = []
             ts1 = engine.simulate(
                 demographic_model=model,
                 contig=contig,
                 samples=samples,
-                mutation_types=mutation_types,
                 extended_events=extended_events,
                 slim_scaling_factor=10,
                 slim_burn_in=0,
@@ -172,7 +184,6 @@ class TestAPI(unittest.TestCase):
                 demographic_model=model,
                 contig=contig,
                 samples=samples,
-                mutation_types=mutation_types,
                 extended_events=extended_events,
                 slim_scaling_factor=10,
                 slim_burn_in=0,
@@ -183,7 +194,6 @@ class TestAPI(unittest.TestCase):
                 demographic_model=model,
                 contig=contig,
                 samples=samples,
-                mutation_types=mutation_types,
                 extended_events=extended_events,
                 slim_scaling_factor=10,
                 seed=seed,
@@ -517,13 +527,17 @@ class TestSlimAvailable(unittest.TestCase):
         self.assertEqual(IS_WINDOWS, "slim" not in all_engines)
 
 
+def get_test_contig(spp="HomSap", chrom="chr22", length_multiplier=0.001):
+    species = stdpopsim.get_species(spp)
+    contig = species.get_contig(chrom, length_multiplier=length_multiplier)
+    contig.fully_neutral(convert_to_substitution=False)
+    return contig
+
+
 class PiecewiseConstantSizeMixin(object):
     """
     Mixin that sets up a simple demographic model used by multiple unit tests.
     """
-
-    species = stdpopsim.get_species("HomSap")
-    contig = species.get_contig("chr22", length_multiplier=0.001)  # ~50 kb
 
     N0 = 1000  # size in the present
     N1 = 500  # ancestral size
@@ -532,8 +546,8 @@ class PiecewiseConstantSizeMixin(object):
     model = stdpopsim.PiecewiseConstantSize(N0, (T, N1))
     model.generation_time = 1
     samples = model.get_samples(100)
-    mutation_types = [stdpopsim.ext.MutationType(convert_to_substitution=False)]
-    mut_id = len(mutation_types)
+    contig = get_test_contig()
+    mut_id = 0
 
     def allele_frequency(self, ts):
         """
@@ -554,122 +568,172 @@ class PiecewiseConstantSizeMixin(object):
 
 
 @unittest.skipIf(IS_WINDOWS, "SLiM not available on windows")
-class TestMutationTypes(unittest.TestCase, PiecewiseConstantSizeMixin):
-    def test_single_mutation_type_in_script(self):
+class TestGenomicElementTypes(unittest.TestCase, PiecewiseConstantSizeMixin):
+    def test_single_genomic_element_type_in_script(self):
+        contig = get_test_contig()
         engine = stdpopsim.get_engine("slim")
         out, _ = capture_output(
             engine.simulate,
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
+            samples=self.samples,
+            slim_script=True,
+        )
+        self.assertEqual(out.count("initializeGenomicElementType"), 1)
+        self.assertEqual(out.count("initializeGenomicElement("), 1)
+
+    def test_multiple_genomic_element_types_in_script(self):
+        contig = get_test_contig()
+        engine = stdpopsim.get_engine("slim")
+        contig.clear_genomic_mutation_types()
+        contig.add_genomic_element_type(
+            intervals=np.array([[0, 100]]),
+            mutation_types=[stdpopsim.ext.MutationType()],
+            proportions=[0],
+        )
+        contig.add_genomic_element_type(
+            intervals=np.array([[100, 200]]),
+            mutation_types=[stdpopsim.ext.MutationType()],
+            proportions=[0],
+        )
+        contig.add_genomic_element_type(
+            intervals=np.array([[200, 300]]),
+            mutation_types=[stdpopsim.ext.MutationType()],
+            proportions=[0],
+        )
+        out, _ = capture_output(
+            engine.simulate,
+            demographic_model=self.model,
+            contig=contig,
+            samples=self.samples,
+            slim_script=True,
+        )
+        self.assertEqual(out.count("initializeGenomicElementType"), 3)
+        self.assertEqual(out.count("initializeGenomicElement("), 3)
+
+
+@unittest.skipIf(IS_WINDOWS, "SLiM not available on windows")
+class TestMutationTypes(unittest.TestCase, PiecewiseConstantSizeMixin):
+    def test_single_mutation_type_in_script(self):
+        contig = get_test_contig()
+        engine = stdpopsim.get_engine("slim")
+        out, _ = capture_output(
+            engine.simulate,
+            demographic_model=self.model,
+            contig=contig,
             samples=self.samples,
             slim_script=True,
         )
         self.assertEqual(out.count("initializeMutationType"), 1)
 
-        mutation_types = [stdpopsim.ext.MutationType(weight=1)]
         out, _ = capture_output(
             engine.simulate,
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_script=True,
         )
         self.assertEqual(out.count("initializeMutationType"), 1)
 
     def test_multiple_mutation_types_in_script(self):
+        contig = get_test_contig()
         engine = stdpopsim.get_engine("slim")
-        mutation_types = [
-            stdpopsim.ext.MutationType(weight=1),
-            stdpopsim.ext.MutationType(weight=2),
+        contig.mutation_types = [
+            stdpopsim.ext.MutationType(),
+            stdpopsim.ext.MutationType(),
         ]
         out, _ = capture_output(
             engine.simulate,
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_script=True,
         )
         self.assertEqual(out.count("initializeMutationType"), 2)
 
-        mutation_types = [stdpopsim.ext.MutationType(weight=i) for i in range(10)]
         positive = stdpopsim.ext.MutationType(convert_to_substitution=False)
-        mutation_types.append(positive)
+        contig.mutation_types = [stdpopsim.ext.MutationType() for i in range(10)] + [
+            positive
+        ]
+        contig.genomic_element_types[0].proportions = [1 / 11 for i in range(11)]
+        contig.genomic_element_types[0].mutation_type_ids = [i for i in range(11)]
         out, _ = capture_output(
             engine.simulate,
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_script=True,
         )
         self.assertEqual(out.count("initializeMutationType"), 11)
 
     def test_unweighted_mutations_are_not_simulated_by_slim(self):
-        mutation_types = [
+        contig = get_test_contig()
+        contig.mutation_types = [
             stdpopsim.ext.MutationType(convert_to_substitution=True),
             stdpopsim.ext.MutationType(convert_to_substitution=False),
         ]
+        contig.genomic_element_types[0].mutation_type_ids = [0, 1]
+        contig.genomic_element_types[0].proportions = [0, 0]
         ts = slim_simulate_no_recap(
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
         )
         self.assertEqual(ts.num_sites, 0)
 
-        mutation_types = [
+        contig.mutation_types = [
             stdpopsim.ext.MutationType(),
             stdpopsim.ext.MutationType(
-                weight=0, distribution_type="g", distribution_args=[-0.01, 0.2]
+                distribution_type="g", distribution_args=[-0.01, 0.2]
             ),
         ]
+        contig.genomic_element_types[0].proportions = [0, 0]
         ts = slim_simulate_no_recap(
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
         )
         self.assertEqual(ts.num_sites, 0)
 
     def test_weighted_mutations_are_simulated_by_slim(self):
-        mutation_types = [
-            stdpopsim.ext.MutationType(weight=1, convert_to_substitution=True)
+        contig = get_test_contig()
+        contig.mutation_types = [
+            stdpopsim.ext.MutationType(convert_to_substitution=True)
         ]
+        contig.genomic_element_types[0].proportions = [1]
         ts = slim_simulate_no_recap(
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
         )
         self.assertTrue(ts.num_sites > 0)
 
-        mutation_types = [
-            stdpopsim.ext.MutationType(weight=1, convert_to_substitution=False)
+        contig.mutation_types = [
+            stdpopsim.ext.MutationType(convert_to_substitution=False)
         ]
+        contig.genomic_element_types[0].proportions = [1]
         ts = slim_simulate_no_recap(
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
         )
         self.assertTrue(ts.num_sites > 0)
 
-        mutation_types = [stdpopsim.ext.MutationType(weight=i) for i in range(10)]
+        contig.mutation_types = [stdpopsim.ext.MutationType() for i in range(10)]
+        contig.genomic_element_types[0].proportions = [1 / 10 for i in range(10)]
+        contig.genomic_element_types[0].mutation_type_ids = list(range(10))
         ts = slim_simulate_no_recap(
             demographic_model=self.model,
-            contig=self.contig,
+            contig=contig,
             samples=self.samples,
-            mutation_types=mutation_types,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
         )
@@ -683,15 +747,6 @@ class TestMutationTypes(unittest.TestCase, PiecewiseConstantSizeMixin):
         for dominance_coeff in (-1,):
             with self.assertRaises(ValueError):
                 stdpopsim.ext.MutationType(dominance_coeff=dominance_coeff)
-
-    def test_weight(self):
-        for weight in (0, 0.1, 50):
-            stdpopsim.ext.MutationType(weight=weight)
-
-    def test_bad_weight(self):
-        for weight in (-1,):
-            with self.assertRaises(ValueError):
-                stdpopsim.ext.MutationType(weight=weight)
 
     def test_bad_distribution_type(self):
         for distribution_type in (1, {}, None, "~", "!", "F"):
@@ -724,21 +779,6 @@ class TestMutationTypes(unittest.TestCase, PiecewiseConstantSizeMixin):
                     distribution_type="g", distribution_args=distribution_args
                 )
 
-    def test_slim_mutation_frac(self):
-        for weights in ([0.1], [50], [0, 5], [0] * 100 + [0.1]):
-            mut_types = [
-                stdpopsim.ext.MutationType(weight=weight) for weight in weights
-            ]
-            self.assertEqual(1, stdpopsim.ext.slim_mutation_frac(mut_types))
-
-        for weights in ([], [0], [0] * 100):
-            mut_types = [
-                stdpopsim.ext.MutationType(weight=weight) for weight in weights
-            ]
-            self.assertEqual(0, stdpopsim.ext.slim_mutation_frac(mut_types))
-
-        self.assertEqual(0, stdpopsim.ext.slim_mutation_frac(None))
-
 
 @unittest.skipIf(IS_WINDOWS, "SLiM not available on windows")
 class TestDrawMutation(unittest.TestCase, PiecewiseConstantSizeMixin):
@@ -757,7 +797,6 @@ class TestDrawMutation(unittest.TestCase, PiecewiseConstantSizeMixin):
             demographic_model=self.model,
             contig=self.contig,
             samples=self.samples,
-            mutation_types=self.mutation_types,
             extended_events=extended_events,
             dry_run=True,
         )
@@ -776,7 +815,6 @@ class TestDrawMutation(unittest.TestCase, PiecewiseConstantSizeMixin):
             demographic_model=self.model,
             contig=self.contig,
             samples=self.samples,
-            mutation_types=self.mutation_types,
             extended_events=extended_events,
             dry_run=True,
         )
@@ -797,7 +835,6 @@ class TestDrawMutation(unittest.TestCase, PiecewiseConstantSizeMixin):
                     demographic_model=self.model,
                     contig=self.contig,
                     samples=self.samples,
-                    mutation_types=self.mutation_types,
                     extended_events=extended_events,
                     dry_run=True,
                 )
@@ -811,11 +848,13 @@ class TestDrawMutation(unittest.TestCase, PiecewiseConstantSizeMixin):
                 coordinate=100,
             ),
         ]
+        contig = self.contig
+        contig.mutation_types = []
         engine = stdpopsim.get_engine("slim")
         with self.assertRaises(ValueError):
             engine.simulate(
                 demographic_model=self.model,
-                contig=self.contig,
+                contig=contig,
                 samples=self.samples,
                 extended_events=extended_events,
                 dry_run=True,
@@ -872,7 +911,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
             demographic_model=self.model,
             contig=self.contig,
             samples=self.samples,
-            mutation_types=self.mutation_types,
             extended_events=extended_events,
             dry_run=True,
         )
@@ -899,7 +937,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
             demographic_model=self.model,
             contig=self.contig,
             samples=self.samples,
-            mutation_types=self.mutation_types,
             extended_events=extended_events,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
@@ -928,7 +965,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
             demographic_model=self.model,
             contig=self.contig,
             samples=self.samples,
-            mutation_types=self.mutation_types,
             extended_events=extended_events,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
@@ -959,7 +995,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
                 demographic_model=self.model,
                 contig=self.contig,
                 samples=self.samples,
-                mutation_types=self.mutation_types,
                 extended_events=extended_events,
                 slim_scaling_factor=10,
                 slim_burn_in=0.1,
@@ -1043,7 +1078,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
                     demographic_model=self.model,
                     contig=self.contig,
                     samples=self.samples,
-                    mutation_types=self.mutation_types,
                     extended_events=extended_events,
                     dry_run=True,
                 )
@@ -1081,7 +1115,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
                 demographic_model=self.model,
                 contig=self.contig,
                 samples=self.samples,
-                mutation_types=self.mutation_types,
                 extended_events=extended_events,
                 slim_scaling_factor=10,
                 slim_burn_in=0.1,
@@ -1105,7 +1138,6 @@ class TestAlleleFrequencyConditioning(unittest.TestCase, PiecewiseConstantSizeMi
                 demographic_model=self.model,
                 contig=self.contig,
                 samples=self.samples,
-                mutation_types=self.mutation_types,
                 extended_events=extended_events,
                 dry_run=True,
             )
@@ -1162,7 +1194,6 @@ class TestChangeMutationFitness(unittest.TestCase, PiecewiseConstantSizeMixin):
                 demographic_model=self.model,
                 contig=self.contig,
                 samples=self.samples,
-                mutation_types=self.mutation_types,
                 extended_events=extended_events,
                 slim_scaling_factor=10,
                 slim_burn_in=0.1,
@@ -1188,7 +1219,6 @@ class TestChangeMutationFitness(unittest.TestCase, PiecewiseConstantSizeMixin):
                 demographic_model=self.model,
                 contig=self.contig,
                 samples=self.samples,
-                mutation_types=self.mutation_types,
                 extended_events=extended_events,
                 dry_run=True,
             )
@@ -1240,7 +1270,6 @@ class TestChangeMutationFitness(unittest.TestCase, PiecewiseConstantSizeMixin):
                     demographic_model=self.model,
                     contig=self.contig,
                     samples=self.samples,
-                    mutation_types=self.mutation_types,
                     extended_events=extended_events,
                     dry_run=True,
                 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import tarfile
 import tempfile
+import numpy as np
 
 from stdpopsim import utils
 
@@ -372,3 +373,62 @@ class TestUntar(unittest.TestCase):
                     utils.untar(tar, dest)
                 rm_f(filename)
                 rm_f(tar)
+
+
+class TestIntervalUtilities(unittest.TestCase):
+    def test_intervals_array_shape(self):
+        # shape (n, x) where x >= 2
+        bad_arrays = (np.array([10, 20]), np.array([[[10, 20]]]))
+        for bad_array in bad_arrays:
+            with self.assertRaises(ValueError):
+                utils.check_intervals_array_shape(intervals=bad_array)
+            with self.assertRaises(ValueError):
+                utils.build_intervals_array(intervals=bad_array)
+        good_arrays = (
+            np.array([[10, 20], [30, 40]]),
+            np.array([[10, 20, 1], [30, 40, 2]]),
+        )
+        for good_array in good_arrays:
+            utils.check_intervals_array_shape(intervals=good_array)
+            built_array = utils.build_intervals_array(intervals=good_array)
+            self.assertTrue((built_array == good_array).all())
+
+    def test_invalid_intervals(self):
+        # right <= left, overlapping, uncastable float->int
+        invalid_arrays = (
+            np.array([[20, 10]]),
+            np.array([[10, 20], [15, 20]]),
+            np.array([[10, 20], [13, 41]]),
+        )
+        for invalid_array in invalid_arrays:
+            with self.assertRaises(ValueError):
+                utils.build_intervals_array(intervals=invalid_array)
+            with self.assertRaises(ValueError):
+                utils.check_intervals_validity(intervals=invalid_array)
+        # interval outside [start, end)
+        with self.assertRaises(ValueError):
+            utils.build_intervals_array(intervals=[[10, 50]], start=20)
+        with self.assertRaises(ValueError):
+            utils.check_intervals_validity(intervals=np.array([[10, 50]]), end=30)
+
+    def test_intervals_casting(self):
+        castable_intervals = (
+            [[10, 20], [20, 40]],
+            [[1, 2, 2], [2, 3, 2]],
+            np.array([[10, 20]]),
+        )
+        for intervals in castable_intervals:
+            casted = utils.build_intervals_array(intervals)
+            self.assertTrue(isinstance(casted, np.ndarray) and casted.dtype == np.int64)
+            self.assertTrue(casted.shape[0] == len(intervals))
+            self.assertTrue(casted.shape[1] >= 2)
+
+    def test_interval_sorting(self):
+        unsorted_intervals = (
+            np.array([[20, 30], [10, 20]]),
+            np.array([[10, 20], [20, 30], [2, 3]]),
+        )
+        for intervals in unsorted_intervals:
+            casted = utils.build_intervals_array(intervals)
+            self.assertFalse(np.all(np.diff(intervals[:, 0]) >= 0))
+            self.assertTrue(np.all(np.diff(casted[:, 0]) >= 0))


### PR DESCRIPTION
OK, so the plan is as follows:

One of the arguments to `simulate` is a `Contig` object. This is the class that represents the (contiguous) region to be simulated. It contains information about the mutation rate and the recombination map.

The goal of this PR is to implement a notion of genomic elements (sensu SLiM). These genomic elements are non-overlapping regions of the contig (as determined by start and end positions) in which certain mutation types can occur.

Mutation types can occur at different rates within each genomic element types, and so an important parameter is the proportion of *all* mutations that are going to be each mutation type. By default, a simulation will have one genomic element spanning the whole contig, in which only neutral mutations can occur (and are added via msprime after the SLiM run). 

You may create different mutation types (with different selection parameters and proportions) and assign them to genomic element types. In this case, SLiM is going to simulate the non-neutral mutations in the determined genomic elements, and at the end we will only add neutral mutations so that the total mutation rate (across all types, including neutral) is equal to the contig's mutation rate (see more detailed explanation here: #646).

WIP

Solves #587