### PR TITLE
Another fix for the auto docs build.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,9 @@ jobs:
           python -m pip install wheel
           python -m pip install numpy==1.19.2  # for scikit-allel
           python -m pip install -r requirements/CI/requirements.txt
+          # Install the local package so that stdpopsim is in the path,
+          # which is needed for generating docs `comand-output`.
+          python -m pip install .
 
       - name: Build Docs
         run: make -C docs


### PR DESCRIPTION
Sorry about all the churn here. Due to the security model this uses, only the workflow yml file on the master branch is executed, even when a pull request happens. So we just have to merge this file in for testing.