### PR TITLE
Masking simulated data

### DIFF
--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -64,8 +64,13 @@ class Engine:
     """
 
     def simulate(
-            self, demographic_model=None, contig=None, samples=None, seed=None,
-            dry_run=False):
+        self,
+        demographic_model=None,
+        contig=None,
+        samples=None,
+        seed=None,
+        dry_run=False,
+    ):
         """
         Simulates the model for the specified contig and samples.
 
@@ -99,25 +104,36 @@ class _MsprimeEngine(Engine):
     id = "msprime"  #:
     description = "Msprime coalescent simulator"  #:
     citations = [
-            stdpopsim.Citation(
-                doi="https://doi.org/10.1371/journal.pcbi.1004842",
-                year="2016",
-                author="Kelleher et al.",
-                reasons={stdpopsim.CiteReason.ENGINE}),
-            ]
+        stdpopsim.Citation(
+            doi="https://doi.org/10.1371/journal.pcbi.1004842",
+            year="2016",
+            author="Kelleher et al.",
+            reasons={stdpopsim.CiteReason.ENGINE},
+        )
+    ]
     # We default to the first model in the list.
     supported_models = ["hudson", "dtwf", "smc", "smc_prime"]
-    model_citations = {"dtwf": [
-             stdpopsim.Citation(
-                 doi="https://doi.org/10.1371/journal.pgen.1008619",
-                 year="2020",
-                 author="Nelson et al.",
-                 reasons={stdpopsim.CiteReason.ENGINE}),
-             ]}
+    model_citations = {
+        "dtwf": [
+            stdpopsim.Citation(
+                doi="https://doi.org/10.1371/journal.pgen.1008619",
+                year="2020",
+                author="Nelson et al.",
+                reasons={stdpopsim.CiteReason.ENGINE},
+            )
+        ]
+    }
 
     def simulate(
-            self, demographic_model=None, contig=None, samples=None, seed=None,
-            msprime_model=None, msprime_change_model=None, dry_run=False):
+        self,
+        demographic_model=None,
+        contig=None,
+        samples=None,
+        seed=None,
+        msprime_model=None,
+        msprime_change_model=None,
+        dry_run=False,
+    ):
         """
         Simulate the demographic model using msprime.
         See :meth:`.Engine.simulate()` for definitions of parameters defined
@@ -154,15 +170,22 @@ class _MsprimeEngine(Engine):
             demographic_events.sort(key=lambda x: x.time)
 
         ts = msprime.simulate(
-                samples=samples,
-                recombination_map=contig.recombination_map,
-                mutation_rate=contig.mutation_rate,
-                population_configurations=demographic_model.population_configurations,
-                migration_matrix=demographic_model.migration_matrix,
-                demographic_events=demographic_events,
-                random_seed=seed,
-                model=msprime_model,
-                end_time=0 if dry_run else None)
+            samples=samples,
+            recombination_map=contig.recombination_map,
+            mutation_rate=contig.mutation_rate,
+            population_configurations=demographic_model.population_configurations,
+            migration_matrix=demographic_model.migration_matrix,
+            demographic_events=demographic_events,
+            random_seed=seed,
+            model=msprime_model,
+            end_time=0 if dry_run else None,
+        )
+
+        if contig.inclusion_mask is not None:
+            ts = stdpopsim.utils.mask_tree_sequence(ts, contig.inclusion_mask, False)
+        if contig.exclusion_mask is not None:
+            ts = stdpopsim.utils.mask_tree_sequence(ts, contig.exclusion_mask, True)
+
         if dry_run:
             ts = None
         return ts

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -23,6 +23,7 @@ class Genome:
     :ivar length: The total length of the genome.
     :vartype length: int
     """
+
     chromosomes = attr.ib(factory=list)
     mutation_rate_citations = attr.ib(factory=list, kw_only=True)
     recombination_rate_citations = attr.ib(factory=list, kw_only=True)
@@ -98,6 +99,7 @@ class Chromosome:
         chromosome by ID, e.g. from the command line interface.
     :vartype synonyms: list of str
     """
+
     id = attr.ib(type=str, kw_only=True)
     length = attr.ib(kw_only=True)
     recombination_rate = attr.ib(type=float, kw_only=True)
@@ -119,9 +121,16 @@ class Contig:
         <https://msprime.readthedocs.io/en/stable/api.html#msprime.RecombinationMap>`_
         for more details.
     :vartype recombination_map: msprime.simulations.RecombinationMap
+    :ivar mask_intervals: Intervals to keep in simulated tree sequence, as a list
+        of (left_position, right_position), such that intervals are non-overlapping
+        and in ascending order. Should have shape Nx2, where N is the number of
+        intervals.
+    :vartype mask_intervals: array-like (?)
+    :ivar exclude: If True, ``mask_intervals`` specify regions to exclude. If False,
+        ``mask_intervals`` specify regions in keep.
+    :vartype exclude: bool
 
     .. note::
-
         To run stdpopsim simulations with alternative, user-specified mutation
         or recombination rates, a new contig can be created based on an existing
         one. For instance, the following will create a ``new_contig`` that,
@@ -135,17 +144,22 @@ class Contig:
                 genetic_map=old_contig.genetic_map,
             )
     """
+
     recombination_map = attr.ib(default=None, kw_only=True)
     mutation_rate = attr.ib(default=None, type=float, kw_only=True)
     genetic_map = attr.ib(default=None, kw_only=True)
+    inclusion_mask = attr.ib(default=None, kw_only=True)
+    exclusion_mask = attr.ib(default=None, kw_only=True)
 
     def __str__(self):
         gmap = "None" if self.genetic_map is None else self.genetic_map.id
         s = (
             "Contig(length={:.2G}, recombination_rate={:.2G}, "
-            "mutation_rate={:.2G}, genetic_map={})").format(
-                self.recombination_map.get_length(),
-                self.recombination_map.mean_recombination_rate,
-                self.mutation_rate,
-                gmap)
+            "mutation_rate={:.2G}, genetic_map={})"
+        ).format(
+            self.recombination_map.get_length(),
+            self.recombination_map.mean_recombination_rate,
+            self.mutation_rate,
+            gmap,
+        )
         return s

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -216,7 +216,7 @@ class TestEndToEnd(unittest.TestCase):
         self.assertEqual(prov_seed, seed)
 
     def test_homsap_seed(self):
-        cmd = "HomSap -c chr22 -l0.1 20"
+        cmd = "HomSap -c chr22 -l0.1 -s 1234 20"
         self.verify(cmd, num_samples=20, seed=1234)
 
     def test_homsap_constant(self):
@@ -252,15 +252,15 @@ class TestEndToEnd(unittest.TestCase):
         self.verify(cmd, num_samples=3)
 
     def test_aratha_constant(self):
-        cmd = "AraTha -l 0.001 8"
+        cmd = "AraTha -L 100 8"
         self.verify(cmd, num_samples=8)
 
     def test_durvusula_2017_msmc(self):
-        cmd = "AraTha -l 0.001 -d SouthMiddleAtlas_1D17 7"
+        cmd = "AraTha -L 100 -d SouthMiddleAtlas_1D17 7"
         self.verify(cmd, num_samples=7)
 
     def test_lapierre_constant(self):
-        cmd = "EscCol -l 1e-7 2"
+        cmd = "EscCol -L 100 2"
         self.verify(cmd, num_samples=2)
 
 
@@ -740,7 +740,7 @@ class TestDryRun(unittest.TestCase):
             path = pathlib.Path(tmpdir)
             with open(path / "stderr", "w+") as stderr:
                 filename = path / "output.trees"
-                cmd = f"{sys.executable} -m stdpopsim HomSap -D -l 0.01 -o {filename} 2"
+                cmd = f"{sys.executable} -m stdpopsim HomSap -D -L 1000 -o {filename} 2"
                 subprocess.run(cmd, stderr=stderr, shell=True, check=True)
                 self.assertGreater(stderr.tell(), 0)
             self.assertFalse(os.path.isfile(filename))
@@ -751,7 +751,7 @@ class TestDryRun(unittest.TestCase):
             with open(path / "stderr", "w+") as stderr:
                 filename = path / "output.trees"
                 cmd = (
-                    f"{sys.executable} -m stdpopsim -q HomSap -D -l 0.01 "
+                    f"{sys.executable} -m stdpopsim -q HomSap -D -L 1000 "
                     "-o {filename} 2")
                 subprocess.run(cmd, stderr=stderr, shell=True, check=True)
                 self.assertEqual(stderr.tell(), 0)
@@ -762,7 +762,7 @@ class TestMsprimeEngine(unittest.TestCase):
     def docmd(self, _cmd):
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = pathlib.Path(tmpdir) / "output.trees"
-            cmd = f"-q -e msprime {_cmd} AraTha -l 0.001 --seed 1 -o {filename} 10"
+            cmd = f"-q -e msprime {_cmd} AraTha -L 100 --seed 1 -o {filename} 10"
             return capture_output(stdpopsim.cli.stdpopsim_main, cmd.split())
 
     def test_simulate(self):
@@ -848,10 +848,10 @@ class TestNoQCWarning(unittest.TestCase):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd.split())
 
     def test_noQC_warning(self):
-        self.verify_noQC_warning("EscCol -d FakeModel -D 10")
+        self.verify_noQC_warning("EscCol -d FakeModel -D 10 -L 10")
 
     def test_noQC_warning_quiet(self):
-        self.verify_noQC_warning("-q EscCol -d FakeModel -D 10")
+        self.verify_noQC_warning("-q EscCol -d FakeModel -D 10 -L 10")
 
     def verify_noQC_citations_not_written(self, cmd):
         # Non-QCed models shouldn't be used in publications, so citations
@@ -868,7 +868,7 @@ class TestNoQCWarning(unittest.TestCase):
             self.assertFalse(citation.doi in log_output)
 
     def test_noQC_citations_not_written(self):
-        self.verify_noQC_citations_not_written("EscCol -d FakeModel -D 10")
+        self.verify_noQC_citations_not_written("EscCol -d FakeModel -D 10 -L 10")
 
     def test_noQC_citations_not_written_verbose(self):
-        self.verify_noQC_citations_not_written("-vv EscCol -d FakeModel -D 10")
+        self.verify_noQC_citations_not_written("-vv EscCol -d FakeModel -D 10 -L 10")

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,150 @@
+"""
+Tests for the genetic maps management.
+"""
+import unittest
+
+import stdpopsim.utils
+import msprime
+import numpy as np
+import os
+import sys
+
+IS_WINDOWS = sys.platform.startswith("win")
+
+
+class TestMasking(unittest.TestCase):
+    def test_load_intervals(self):
+        intervals_in = {
+            "chr1": [(10, 10000)],
+            "chr22": [(100, 1000), (2000, 5000), (6000, 9000)],
+        }
+        with open("temp_file.bed", "w+") as fout:
+            for c, i in intervals_in.items():
+                for (l, r) in i:
+                    fout.write(f"{c}\t{l}\t{r}\n")
+        intervals_chr1 = stdpopsim.utils.read_bed("temp_file.bed", "chr1")
+        intervals_chr22 = stdpopsim.utils.read_bed("temp_file.bed", "chr22")
+        os.remove("temp_file.bed")
+        for interval in intervals_chr1:
+            self.assertTrue(tuple(interval) in intervals_in["chr1"])
+        for interval in intervals_chr22:
+            self.assertTrue(tuple(interval) in intervals_in["chr22"])
+        self.assertTrue(len(intervals_chr1) == len(intervals_in["chr1"]))
+        self.assertTrue(len(intervals_chr22) == len(intervals_in["chr22"]))
+
+    def test_length_interval_invalid(self):
+        species = stdpopsim.get_species("HomSap")
+        with self.assertRaises(ValueError):
+            contig = species.get_contig(
+                "chr22", length_multiplier=0.1, inclusion_mask="test.bed"
+            )
+            print(contig.recombination_map.get_sequence_length())
+
+    def test_read_bed(self):
+        def intervals_to_keep_test_func(mask_fpath, chrom):
+            intervals = []
+            with open(mask_fpath, "r") as fin:
+                for line in fin:
+                    if line.split()[0] == chrom:
+                        intervals.append((int(line.split()[1]), int(line.split()[2])))
+            intervals = sorted(intervals)
+            return intervals
+
+        intervals_in = {"chr1": [(0, 10), (100, 1000), (2000, 5000), (6000, 10000)]}
+        with open("temp_file.bed", "w+") as fout:
+            for c, i in intervals_in.items():
+                for (l, r) in i:
+                    fout.write(f"{c}\t{l}\t{r}\n")
+        intervals_test = intervals_to_keep_test_func("temp_file.bed", "chr1")
+        intervals_utils = stdpopsim.utils.read_bed("temp_file.bed", "chr1")
+        os.remove("temp_file.bed")
+        for i1, i2 in zip(intervals_utils, intervals_test):
+            self.assertTrue(i1[0] == i2[0])
+            self.assertTrue(i1[1] == i2[1])
+
+    def test_mask_from_intervals(self):
+        species = stdpopsim.get_species("HomSap")
+        contig = species.get_contig("chr22", exclusion_mask=[(0, 16.5e6)])
+        self.assertTrue(contig.inclusion_mask is None)
+        self.assertTrue(contig.exclusion_mask[0][0] == 0)
+        self.assertTrue(contig.exclusion_mask[0][1] == 16.5e6)
+        contig = species.get_contig("chr22", inclusion_mask=[(16.5e6, 45e6)])
+        self.assertTrue(contig.inclusion_mask[0][0] == 16.5e6)
+        self.assertTrue(contig.inclusion_mask[0][1] == 45e6)
+        self.assertTrue(contig.exclusion_mask is None)
+
+    def test_multiple_masks(self):
+        species = stdpopsim.get_species("HomSap")
+        with self.assertRaises(ValueError):
+            species.get_contig(
+                "chr22", exclusion_mask=[(0, 16.5e6)], inclusion_mask=[(16.5e6, 50e6)]
+            )
+
+    def test_read_masks_from_bed(self):
+        intervals_in = {"chr1": [(0, 10), (100, 1000), (2000, 5000), (6000, 10000)]}
+        with open("temp_file.bed", "w+") as fout:
+            for c, i in intervals_in.items():
+                for (l, r) in i:
+                    fout.write(f"{c}\t{l}\t{r}\n")
+        species = stdpopsim.get_species("HomSap")
+        contig = species.get_contig("chr1", inclusion_mask="temp_file.bed")
+        self.assertTrue(contig.exclusion_mask is None)
+        self.assertTrue(len(contig.inclusion_mask) == 4)
+        contig = species.get_contig("chr1", exclusion_mask="temp_file.bed")
+        self.assertTrue(contig.inclusion_mask is None)
+        self.assertTrue(contig.exclusion_mask[1][0] == 100)
+        os.remove("temp_file.bed")
+
+    def test_mask_tree_sequence(self):
+        intervals = np.array([[0, 10], [100, 200], [500, 1000]])
+        ts = msprime.simulate(Ne=1000, samples=[(0, 0), (0, 0)], length=1000)
+        ts = msprime.mutate(ts, rate=1e-4)
+
+        exclude = False
+        ts_mask = stdpopsim.utils.mask_tree_sequence(ts, intervals, exclude)
+        # check we get the right number of trees (simulated with no recomb)
+        self.assertTrue(ts_mask.num_trees == len(intervals) * 2 - 1)
+
+        exclude = True
+        intervals = np.array([[0, 100], [200, 1000]])
+        ts_mask = stdpopsim.utils.mask_tree_sequence(ts, intervals, exclude)
+        # check we get the right number of trees (simulated with no recomb)
+        self.assertTrue(ts_mask.num_trees == len(intervals) * 2 - 1)
+        # check that positions of mutations in ts_mask are within mask
+        positions = np.array([m.position for m in ts_mask.mutations()])
+        self.assertTrue(np.all(np.logical_and(100 <= positions, positions < 200)))
+
+
+@unittest.skipIf(IS_WINDOWS, "SLiM not available on windows")
+class TestSimulate(unittest.TestCase):
+    def test_simulate_with_mask(self):
+        engines = ["msprime", "slim"]
+        species = stdpopsim.get_species("HomSap")
+        L = 1000
+        contig = species.get_contig(length=L)
+        contig.mutation_rate = 1e-3
+        contig.recombination_map = msprime.RecombinationMap.uniform_map(L, 0)
+        samples = [msprime.Sample(0, 0), msprime.Sample(0, 0)]
+        model = stdpopsim.PiecewiseConstantSize(100)
+        for engine_name in engines:
+            engine = stdpopsim.get_engine(engine_name)
+
+            # test engine with exclusion mask
+            contig.inclusion_mask = None
+            contig.exclusion_mask = np.array([[0, L // 2]])
+            ts = engine.simulate(
+                demographic_model=model, contig=contig, samples=samples
+            )
+            # check that positions of mutations are within mask
+            positions = np.array([m.position for m in ts.mutations()])
+            self.assertTrue(np.all(positions >= L // 2))
+
+            # test engine with inclusion mask
+            contig.exclusion_mask = None
+            contig.inclusion_mask = np.array([[0, L // 2]])
+            ts = engine.simulate(
+                demographic_model=model, contig=contig, samples=samples
+            )
+            # check that positions of mutations are within mask
+            positions = np.array([m.position for m in ts.mutations()])
+            self.assertTrue(np.all(positions < L // 2))

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -269,11 +269,11 @@ class TestWarningsAndErrors(unittest.TestCase):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
 
     def test_odd_sample_warning(self):
-        cmd = "-q -e slim --slim-script HomSap -d OutOfAfrica_2T12 4 5".split()
+        cmd = "-q -e slim --slim-script HomSap -d OutOfAfrica_2T12 -L 100 4 5".split()
         with self.assertWarns(stdpopsim.SLiMOddSampleWarning):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
 
-        cmd = "-q -e slim --slim-script HomSap -d OutOfAfrica_2T12 3 5".split()
+        cmd = "-q -e slim --slim-script HomSap -d OutOfAfrica_2T12 -L 100 3 5".split()
         with self.assertWarns(stdpopsim.SLiMOddSampleWarning):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
 
@@ -406,8 +406,8 @@ class TestWarningsAndErrors(unittest.TestCase):
 
     def test_warning_when_scaling(self):
         for cmd in [
-                "-e slim --slim-scaling-factor 2 HomSap 100 -D",
-                "-e slim --slim-scaling-factor 1000 EscCol 100 -D",
+                "-e slim --slim-scaling-factor 2 HomSap 100 -D -L 1",
+                "-e slim --slim-scaling-factor 1000 EscCol 100 -D -L 1",
                 ]:
             with self.assertWarns(stdpopsim.SLiMScalingFactorWarning):
                 capture_output(stdpopsim.cli.stdpopsim_main, cmd.split())


### PR DESCRIPTION
Inspired by #663, and remembering that we had discussed adding masking features a while back (#104), I thought I'd sketch out a possible way of including a mask for simulating data. It's by no means complete, since I wanted to get feedback about it before putting much more time into it.

Essentially, at the time of defining a `contig`, we can specify the path to a mask file in bed format, where the mask specifies intervals to keep (following the format in the 1000G downloadable strict mask). Then the mask intervals are an attribute of the contig, and after simulating, we use `ts.keep_intervals(contig.mask_intervals)` to keep only the intervals in the tree sequence given by the mask, if given.

E.g.
```
import stdpopsim
species = stdpopsim.get_species("HomSap")
contig = species.get_contig("chr22", length_multiplier=0.1, mask="path/to/masks/GRCh38/pilot_strict_combined.allChr.mask.bed")
model = stdpopsim.PiecewiseConstantSize(species.population_size)
samples = model.get_samples(2)
engine = stdpopsim.get_engine('msprime')
ts = engine.simulate(model, contig, samples)
```