### PR TITLE
Specify generic contig

### DIFF
--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -3,6 +3,7 @@ Tests for the genetic species interface.
 """
 import unittest
 import math
+import numpy as np
 
 import msprime
 
@@ -14,6 +15,7 @@ class TestSpecies(unittest.TestCase):
     """
     Tests for basic methods for the species.
     """
+
     def test_str(self):
         for species in stdpopsim.all_species():
             s = str(species)
@@ -90,6 +92,7 @@ class SpeciesTestMixin(object):
     """
     Mixin class for testing individual species properties.
     """
+
     species = None  # To be defined in subclasses.
 
     def test_str(self):
@@ -114,6 +117,7 @@ class GenomeTestMixin(object):
     """
     Mixin class for testing individual genome properties.
     """
+
     genome = None  # To be defined in subclasses.
 
     def test_str(self):
@@ -154,6 +158,7 @@ class TestAllGenomes(unittest.TestCase):
     """
     Tests for basic properties aon all genomes.
     """
+
     def test_str(self):
         for species in stdpopsim.all_species():
             s = str(species.genome)
@@ -165,6 +170,7 @@ class TestGetContig(unittest.TestCase):
     """
     Tests for the get contig method.
     """
+
     species = stdpopsim.get_species("HomSap")
 
     def test_length_multiplier(self):
@@ -173,14 +179,51 @@ class TestGetContig(unittest.TestCase):
             contig2 = self.species.get_contig("chr22", length_multiplier=x)
             self.assertEqual(
                 contig1.recombination_map.get_positions()[-1] * x,
-                contig2.recombination_map.get_positions()[-1])
+                contig2.recombination_map.get_positions()[-1],
+            )
 
     def test_length_multiplier_on_empirical_map(self):
         with self.assertRaises(ValueError):
             self.species.get_contig(
-                "chr1", genetic_map="HapMapII_GRCh37", length_multiplier=2)
+                "chr1", genetic_map="HapMapII_GRCh37", length_multiplier=2
+            )
 
     def test_genetic_map(self):
         # TODO we should use a different map here so we're not hitting the cache.
         contig = self.species.get_contig("chr22", genetic_map="HapMapII_GRCh37")
         self.assertIsInstance(contig.recombination_map, msprime.RecombinationMap)
+
+    def test_generic_contig(self):
+        with self.assertRaises(ValueError):
+            self.species.get_contig("generic", genetic_map="ABC")
+        with self.assertRaises(ValueError):
+            self.species.get_contig("generic", length_multiplier=0.1)
+        with self.assertRaises(ValueError):
+            self.species.get_contig("generic")
+        with self.assertRaises(ValueError):
+            self.species.get_contig("Generic", sequence_length=100)
+        with self.assertRaises(ValueError):
+            self.species.get_contig("chr1", sequence_length=1e6)
+
+        L = 1e6
+        contig = self.species.get_contig("generic", sequence_length=L)
+        self.assertTrue(contig.recombination_map.get_length() == L)
+
+        chrom_ids = np.arange(1, 23).astype("str")
+        Ls = [c.length for c in self.species.genome.chromosomes if c.id in chrom_ids]
+        rs = [
+            c.recombination_rate
+            for c in self.species.genome.chromosomes
+            if c.id in chrom_ids
+        ]
+        us = [
+            c.mutation_rate
+            for c in self.species.genome.chromosomes
+            if c.id in chrom_ids
+        ]
+
+        self.assertTrue(contig.mutation_rate == np.average(us, weights=Ls))
+        self.assertTrue(
+            contig.recombination_map.mean_recombination_rate
+            == np.average(rs, weights=Ls)
+        )


### PR DESCRIPTION
This is to put up a quick illustration of what I mean in #668, which allows you to specify a "generic" contig (open to suggestions for naming - "generic" is maybe too close to "genetic"). The contig is called just as you would any chromosome, but with "generic" as its name, and you must specify `sequence_length`. The mutation and recombination rates are genome wide averages across autosomal chromosomes for that species.