### PR TITLE
require msprime-1.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,9 @@ name: pre-commit
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, msprime-1.0 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, msprime-1.0 ]
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, msprime-1.0 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, msprime-1.0 ]
 
 jobs:
   tests:
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increase this to reset the cache if the key hasn't changed.
-          CACHE_NUM: 0
+          CACHE_NUM: 1
         with:
           path: |
             ${{ steps.find-conda.outputs.CONDA }}/envs/${{ env.CONDA_ENV_NAME }}
@@ -74,13 +74,42 @@ jobs:
           # ensure that's used for all platforms.
           mv ~/.profile ~/.bash_profile
 
-      - name: install dependencies
+      - name: install conda dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda install --yes --file=requirements/CI/conda.txt
           if [ "$RUNNER_OS" != "Windows" ]; then
             conda install --yes slim==${{ env.SLIM_TAG }}
           fi
+
+      # manually build msprime from git
+      - name: install msprime
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          # trigger msprime's setup.py hack to change gsl path in a conda env
+          MSP_CONDA_PREFIX: ${{ steps.find-conda.outputs.CONDA }}/envs/${{ env.CONDA_ENV_NAME }}
+        run: |
+          git clone https://github.com/tskit-dev/msprime.git --recurse-submodules
+          cd msprime
+          git checkout 585d18d51294389ed0ec518b61b11f73cef44c20
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cd lib
+            rm -r subprojects/kastore
+            rm -r subprojects/tskit
+            rm -r subprojects/git-submodules/tskit/c/subprojects
+            rm -r subprojects/git-submodules/tskit/c/tests
+            rm ../lwt_interface
+            cp -r --dereference subprojects/git-submodules/kastore/c subprojects/kastore
+            cp -r --dereference subprojects/git-submodules/tskit/c subprojects/tskit
+            cp -r --dereference subprojects/git-submodules/tskit/python/lwt_interface/* subprojects/tskit/.
+            cp -r --dereference subprojects/git-submodules/tskit/python/lwt_interface ../lwt_interface
+            cd ..
+          fi
+          pip install .
+
+      - name: install pip dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
           pip install -r requirements/CI/requirements.txt
 
       - name: run test suite

--- a/requirements/CI/conda.txt
+++ b/requirements/CI/conda.txt
@@ -1,2 +1,2 @@
-msprime==0.7.4
+gsl
 numcodecs==0.7.2

--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -8,7 +8,7 @@ sphinx-argparse==0.2.5
 sphinx-issues==1.2.0
 sphinx_rtd_theme==0.5.0
 sphinxcontrib-programoutput==0.16
-msprime==0.7.4
+git+https://github.com/tskit-dev/msprime.git@585d18d51294389ed0ec518b61b11f73cef44c20#egg=msprime
 attrs==20.3.0
 appdirs==1.4.4
 humanize==3.1.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,7 +10,7 @@ sphinx-argparse
 sphinx-issues
 sphinx_rtd_theme
 sphinxcontrib-programoutput
-msprime
+git+https://github.com/tskit-dev/msprime.git@585d18d51294389ed0ec518b61b11f73cef44c20#egg=msprime
 attrs
 appdirs
 humanize


### PR DESCRIPTION
This PR is against a new `msprime-1.0` feature branch. In this branch, we can use features of the as-yet-unreleased msprime-1.0. E.g. #644.