### PR TITLE
Check the genetic map length matches the chromsome length.

### DIFF
--- a/tests/test_genetic_maps.py
+++ b/tests/test_genetic_maps.py
@@ -202,22 +202,35 @@ class TestGetChromosomeMap(tests.CacheReadingTest):
     Tests if we get chromosome maps using the HapMapII_GRCh37 human map.
     """
 
-    species = stdpopsim.get_species("HomSap")
-    genetic_map = species.get_genetic_map("HapMapII_GRCh37")
-
     def test_warning_from_no_mapped_chromosome(self):
-        chrom = self.species.genome.get_chromosome("chrY")
+        species = stdpopsim.get_species("HomSap")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
+        chrom = species.genome.get_chromosome("chrY")
         with self.assertWarns(Warning):
-            cm = self.genetic_map.get_chromosome_map(chrom.id)
-            self.assertIsInstance(cm, msprime.RecombinationMap)
-            self.assertEqual(chrom.length, cm.get_sequence_length())
+            cm = genetic_map.get_chromosome_map(chrom.id)
+        self.assertIsInstance(cm, msprime.RecombinationMap)
+        self.assertEqual(chrom.length, cm.get_sequence_length())
 
     def test_known_chromosome(self):
-        chrom = self.species.genome.get_chromosome("chr22")
-        cm = self.genetic_map.get_chromosome_map(chrom.id)
+        species = stdpopsim.get_species("CanFam")
+        genetic_map = species.get_genetic_map("Campbell2016_CanFam3_1")
+        chrom = species.genome.get_chromosome("1")
+        cm = genetic_map.get_chromosome_map(chrom.id)
         self.assertIsInstance(cm, msprime.RecombinationMap)
+        self.assertEqual(chrom.length, cm.get_sequence_length())
+
+    def test_warning_for_long_recomb_map(self):
+        species = stdpopsim.get_species("HomSap")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
+        chrom = species.genome.get_chromosome("chr1")
+        with self.assertWarns(Warning):
+            cm = genetic_map.get_chromosome_map(chrom.id)
+        self.assertIsInstance(cm, msprime.RecombinationMap)
+        self.assertLess(chrom.length, cm.get_sequence_length())
 
     def test_unknown_chromosome(self):
+        species = stdpopsim.get_species("HomSap")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
         for bad_chrom in ["", "ABD", None]:
             with self.assertRaises(ValueError):
-                self.genetic_map.get_chromosome_map(bad_chrom)
+                genetic_map.get_chromosome_map(bad_chrom)


### PR DESCRIPTION
* If the genetic map is shorter, we extend it to the end of the chromosome
  with a zero-rate region. This is the nominal case.
* If the genetic map is longer than the chromsome, we emit a warning and
  use the genetic map length. This can occur when there is a mismatch
  between the reference coordinates used for the genetic map and the
  chromosome. By using the genetic map length, we maintain some
  semblance of backwards compatibility.

See #701 and #719.