### PR TITLE
msprime kwargs

### DIFF
--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -1013,9 +1013,10 @@ class _SLiMEngine(stdpopsim.Engine):
 
     def simulate(
         self,
-        demographic_model=None,
-        contig=None,
-        samples=None,
+        demographic_model,
+        contig,
+        samples,
+        *,
         seed=None,
         mutation_types=None,
         extended_events=None,

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -4,6 +4,7 @@ Tests for simulation engine infrastructure.
 import unittest
 
 import stdpopsim
+import msprime
 
 
 class TestEngineAPI(unittest.TestCase):
@@ -49,7 +50,8 @@ class TestEngineAPI(unittest.TestCase):
 
     def test_abstract_base_class(self):
         e = stdpopsim.Engine()
-        self.assertRaises(NotImplementedError, e.simulate)
+        with self.assertRaises(NotImplementedError):
+            e.simulate(None, None, None)
         self.assertRaises(NotImplementedError, e.get_version)
 
 
@@ -68,3 +70,34 @@ class TestBehaviour(unittest.TestCase):
             engine.simulate(**good_kwargs)
             with self.assertRaises(TypeError):
                 engine.simulate(**bad_kwargs)
+
+    def test_required_params(self):
+        species = stdpopsim.get_species("HomSap")
+        model = species.get_demographic_model("AshkSub_7G19")
+        contig = (species.get_contig("chr1"),)
+        for engine in stdpopsim.all_engines():
+            with self.assertRaises(TypeError):
+                engine.simulate(model, contig)
+
+    def test_msprime_kwargs(self):
+        species = stdpopsim.get_species("HomSap")
+        model = species.get_demographic_model("AshkSub_7G19")
+        contig = species.get_contig("chr22", length_multiplier=0.01)
+        samples = model.get_samples(10)
+        engine = stdpopsim.get_engine("msprime")
+        sim_arg = engine.simulate(
+            model, contig, samples, record_full_arg=True, random_seed=1
+        )
+        assert any(msprime.NODE_IS_RE_EVENT == sim_arg.tables.nodes.flags)
+
+    def test_msprime_seed(self):
+        species = stdpopsim.get_species("HomSap")
+        model = species.get_demographic_model("AshkSub_7G19")
+        contig = species.get_contig("chr22", length_multiplier=0.01)
+        samples = model.get_samples(10)
+        engine = stdpopsim.get_engine("msprime")
+        with self.assertRaises(ValueError):
+            engine.simulate(model, contig, samples, seed=1, random_seed=1)
+        sim_seed = engine.simulate(model, contig, samples, seed=1)
+        sim_random_seed = engine.simulate(model, contig, samples, random_seed=1)
+        self.assertEquals(sim_seed.tables.edges, sim_random_seed.tables.edges)


### PR DESCRIPTION
As mentioned in #735, I noticed that there's no option to pass further arguments to `msprime.simulate`. I've added `kwargs` to the relevant `simulate` function and added a test that the information is passed through to msprime successfully.

I aslo thought it would be sensible to require the `demographic_model`, `contig`, and `samples` parameters in `simulate` and make all the other arguments keyword-only. When I first started using `stdpopsim` I found the error messages a bit opaque when any of the first three weren't specified and defaulted to `None`. Happy to take this part out of the PR though others don't agree!