### PR TITLE
Revert "Bump numcodecs from 0.7.2 to 0.7.3 in /requirements/CI"

### DIFF
--- a/requirements/CI/conda.txt
+++ b/requirements/CI/conda.txt
@@ -1,2 +1,2 @@
 msprime==0.7.4
-numcodecs==0.7.3
+numcodecs==0.7.2


### PR DESCRIPTION
Reverts popsim-consortium/stdpopsim#742

This seems to have broken a bunch of tests. *sigh*