### PR TITLE
Fix push-to-docs-repo in docs CI action when merging.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         run: make -C docs
 
       - name: Checkout docs site
-        if: github.event.push
+        if: (!github.event.pull_request)
         uses: actions/checkout@v2
         with:
           repository: popsim-consortium/stdpopsim-docs
@@ -45,7 +45,7 @@ jobs:
           path: stdpopsim-docs
 
       - name: Copy our docs to the tag specific location
-        if: github.event.push
+        if: (!github.event.pull_request)
         run: |
           cd stdpopsim-docs
           export DEST=`echo ${GITHUB_REF} | sed -e "s/refs\/heads\///g" |  sed -e "s/refs\/tags\///g"`
@@ -53,7 +53,7 @@ jobs:
           cp -r ../docs/_build/html $DEST
 
       - name: Commit and push the docs
-        if: github.event.push
+        if: (!github.event.pull_request)
         run: |
           cd stdpopsim-docs
           git config user.name PopSim-bot


### PR DESCRIPTION
I didn't do this correctly in #759, and found out in the Demes repository which has essentially the same docs action (https://github.com/popsim-consortium/demes-python/issues/204).