### PR TITLE
Transition to msprime 1.0 demography model

### DIFF
--- a/stdpopsim/catalog/BosTau/__init__.py
+++ b/stdpopsim/catalog/BosTau/__init__.py
@@ -115,7 +115,7 @@ def _HolsteinFriesan_1M13():
     inspection of the plots.
     """
     populations = [
-        stdpopsim.Population(id="Holstein-Friesian", description="Holstein-Friesian"),
+        stdpopsim.Population(id="Holstein_Friesian", description="Holstein Friesian"),
     ]
     citations = [_MacLeodEtAl.because(stdpopsim.CiteReason.DEM_MODEL)]
 

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -577,7 +577,7 @@ def write_simulation_summary(engine, model, contig, samples, seed=None):
     dry_run_text += f"{indent}Population: number_samples (sampling_time_generations):\n"
     sample_counts = [0] * model.num_sampling_populations
     for s in samples:
-        sample_counts[s.population] += 1
+        sample_counts[s.population] += s.num_samples
     for p in range(0, model.num_sampling_populations):
         pop_name = model.populations[p].id
         sample_time = model.populations[p].sampling_time
@@ -585,9 +585,9 @@ def write_simulation_summary(engine, model, contig, samples, seed=None):
         dry_run_text += f"{sample_counts[p]} ({sample_time})\n"
     # Get information about relevant contig
     gmap = "None" if contig.genetic_map is None else contig.genetic_map.id
-    mean_recomb_rate = contig.recombination_map.mean_recombination_rate
+    mean_recomb_rate = contig.recombination_map.mean_rate
     mut_rate = contig.mutation_rate
-    contig_len = contig.recombination_map.get_length()
+    contig_len = contig.recombination_map.sequence_length
     dry_run_text += "Contig Description:\n"
     dry_run_text += f"{indent}Contig length: {contig_len}\n"
     dry_run_text += f"{indent}Mean recombination rate: {mean_recomb_rate}\n"

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -117,10 +117,8 @@ class Contig:
     :ivar mutation_rate: The rate of mutation per base per generation.
     :vartype mutation_rate: float
     :ivar recombination_map: The recombination map for the region. See the
-        `msprime documentation
-        <https://msprime.readthedocs.io/en/stable/api.html#msprime.RecombinationMap>`_
-        for more details.
-    :vartype recombination_map: msprime.simulations.RecombinationMap
+        :class:`msprime.RateMap` for details.
+    :vartype recombination_map: msprime.RateMap
     :ivar mask_intervals: Intervals to keep in simulated tree sequence, as a list
         of (left_position, right_position), such that intervals are non-overlapping
         and in ascending order. Should have shape Nx2, where N is the number of
@@ -157,8 +155,8 @@ class Contig:
             "Contig(length={:.2G}, recombination_rate={:.2G}, "
             "mutation_rate={:.2G}, genetic_map={})"
         ).format(
-            self.recombination_map.get_length(),
-            self.recombination_map.mean_recombination_rate,
+            self.recombination_map.sequence_length,
+            self.recombination_map.mean_rate,
             self.mutation_rate,
             gmap,
         )

--- a/stdpopsim/qc/AraTha.py
+++ b/stdpopsim/qc/AraTha.py
@@ -6,15 +6,10 @@ import stdpopsim
 
 _species = stdpopsim.get_species("AraTha")
 
-# Some generic populations to use for qc
-population_sample_0 = stdpopsim.Population(
-    "sampling_0", "Population that samples at time 0", 0
-)
-
 
 def Durvasula2017MSMC():
     id = "QC-SouthMiddleAtlas_1D17"
-    populations = [population_sample_0]
+    populations = [stdpopsim.Population("SouthMiddleAtlas", "")]
 
     # Both of the following are directly
     # converted from MSMC output scaled by A.Thaliana
@@ -126,6 +121,7 @@ def Durvasula2017MSMC():
         populations=populations,
         population_configurations=population_configurations,
         demographic_events=demographic_events,
+        population_id_map=[{"SouthMiddleAtlas": 0}] * 33,
     )
 
 
@@ -135,7 +131,7 @@ _species.get_demographic_model("SouthMiddleAtlas_1D17").register_qc(Durvasula201
 def HuberTwoEpoch():
     id = "QC-African2Epoch_1H18"
     populations = [
-        stdpopsim.Population(id="ATL", description="A. thalina"),
+        stdpopsim.Population(id="SouthMiddleAtlas", description="A. thalina"),
     ]
 
     # Time of second epoch
@@ -160,6 +156,7 @@ def HuberTwoEpoch():
                 time=T_2, initial_size=N_ANC, population_id=0
             ),
         ],
+        population_id_map=[{"SouthMiddleAtlas": 0}] * 2,
     )
 
 
@@ -169,7 +166,7 @@ _species.get_demographic_model("African2Epoch_1H18").register_qc(HuberTwoEpoch()
 def HuberThreeEpoch():
     id = "QC-African3Epoch_1H18"
     populations = [
-        stdpopsim.Population(id="ATL", description="A. thalina"),
+        stdpopsim.Population(id="SouthMiddleAtlas", description="A. thalina"),
     ]
 
     # Time of second epoch
@@ -199,6 +196,7 @@ def HuberThreeEpoch():
                 time=T_2 + T_3, initial_size=N_ANC, population_id=0
             ),
         ],
+        population_id_map=[{"SouthMiddleAtlas": 0}] * 3,
     )
 
 

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -5,18 +5,13 @@ import stdpopsim
 
 _species = stdpopsim.get_species("DroMel")
 
-# Some generic populations to use for qc
-population_sample_0 = stdpopsim.Population(
-    "sampling_0", "Population that samples at time 0", 0
-)
-population_sample_none = stdpopsim.Population(
-    "sampling_none", "Population that does not sample", None
-)
-
 
 def LiStephanTwoPopulation():
     id = "QC-OutOfAfrica_2L06"
-    populations = [population_sample_0] * 2
+    populations = [
+        stdpopsim.Population("AFR", ""),
+        stdpopsim.Population("EUR", ""),
+    ]
 
     # Parameters for the African population are taken from the section Demographic
     # History of the African Population
@@ -59,6 +54,12 @@ def LiStephanTwoPopulation():
                 time=T_A0, initial_size=N_A1, population_id=0
             ),
         ],
+        population_id_map=[
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
+        ],
     )
 
 
@@ -67,7 +68,7 @@ _species.get_demographic_model("OutOfAfrica_2L06").register_qc(LiStephanTwoPopul
 
 def SheehanSongThreeEpic():
     id = "QC-African3Epoch_1S16"
-    populations = [population_sample_0]
+    populations = [stdpopsim.Population("AFR", "")]
 
     # Model from paper https://doi.org/10.1371/journal.pcbi.1004845
 
@@ -107,6 +108,7 @@ def SheehanSongThreeEpic():
                 time=T_2, initial_size=N_3, population_id=0
             ),
         ],
+        population_id_map=[{"AFR": 0}] * 3,
     )
 
 

--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -9,10 +9,10 @@ _species = stdpopsim.get_species("HomSap")
 
 # Some generic populations to use for qc
 population_sample_0 = stdpopsim.Population(
-    "sampling_0", "Population that samples at time 0", 0
+    "qc_sampling_0", "Population that samples at time 0", 0
 )
 population_sample_none = stdpopsim.Population(
-    "sampling_none", "Population that does not sample", None
+    "qc_sampling_none", "Population that does not sample", None
 )
 
 
@@ -72,6 +72,13 @@ def TennessenOnePopAfrica():
             msprime.PopulationParametersChange(
                 time=T_AF, initial_size=N_A, population_id=0
             ),
+        ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        population_id_map=[
+            {"AFR": 0},
+            {"AFR": 0},
+            {"AFR": 0},
         ],
     )
 
@@ -176,6 +183,15 @@ def TennessenTwoPopOutOfAfrica():
             msprime.PopulationParametersChange(
                 time=T_AF, initial_size=N_A, population_id=0
             ),
+        ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        population_id_map=[
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
+            {"AFR": 0, "EUR": 1},
         ],
     )
 
@@ -291,6 +307,15 @@ def BrowningAmerica():
             msprime.PopulationParametersChange(
                 time=T_AF0_AF1, initial_size=N_AF0, population_id=0
             ),
+        ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        population_id_map=[
+            {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
+            {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
+            {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
+            {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
+            {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
         ],
     )
 
@@ -436,6 +461,18 @@ def RagsdaleArchaic():
             # NEAN pop. coalesces into AF (E7)
             msprime.MassMigration(time=T_NEAN_split, source=3, dest=0, proportion=1.0),
         ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        population_id_map=[
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+            {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+        ],
     )
 
 
@@ -517,6 +554,18 @@ def KammAncientSamples():
     # at the time of sampling the Altai individual
     r_Nean = -math.log(N_Nean_Losch / N_Nean) / (t_Mbu_Losch - t_Altai)
 
+    pop_id_map = {
+        "Mbuti": 0,
+        "LBK": 1,
+        "Sardinian": 2,
+        "Loschbour": 3,
+        "MA1": 4,
+        "Han": 5,
+        "UstIshim": 6,
+        "Neanderthal": 7,
+        "BasalEurasian": 8,
+    }
+
     return stdpopsim.DemographicModel(
         id=id,
         description=id,
@@ -563,12 +612,12 @@ def KammAncientSamples():
             msprime.PopulationConfiguration(  # Neanderthal
                 initial_size=N_Nean,
                 growth_rate=0,
-                metadata={"name": "Altai", "sampling_time": t_Altai},
+                metadata={"name": "Neanderthal", "sampling_time": t_Altai},
             ),
             msprime.PopulationConfiguration(  # Basal Eurasian
                 initial_size=N_Basal,
                 growth_rate=0,
-                metadata={"name": "Basal", "sampling_time": None},
+                metadata={"name": "BasalEurasian", "sampling_time": None},
             ),
         ],
         # Using columns in figure in Kamm paper as proxies for pop number
@@ -631,6 +680,10 @@ def KammAncientSamples():
                 time=t_Nean_Losch, initial_size=N_Nean_Losch, population_id=3
             ),
         ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        # Note: we'll be updating this map as the model is modernised.
+        population_id_map=[pop_id_map] * 13,
     )
 
 
@@ -747,7 +800,7 @@ def DenisovanAncestryInPapuans():
         msprime.PopulationConfiguration(  # 5 NeanA
             initial_size=N_NeanA,
             growth_rate=0,
-            metadata={"name": "NeanA", "sampling_time": t_NeanA},
+            metadata={"name": "NeaA", "sampling_time": t_NeanA},
         ),
         msprime.PopulationConfiguration(  # 6 Den1
             initial_size=N_Den1,
@@ -762,7 +815,7 @@ def DenisovanAncestryInPapuans():
         msprime.PopulationConfiguration(  # 8 Nean1
             initial_size=N_Nean1,
             growth_rate=0,
-            metadata={"name": "Nean1", "sampling_time": None},
+            metadata={"name": "Nea1", "sampling_time": None},
         ),
         msprime.PopulationConfiguration(  # 9 Ghost
             initial_size=N_Ghost,
@@ -911,6 +964,19 @@ def DenisovanAncestryInPapuans():
         ),
     ]
     demographic_events.sort(key=lambda x: x.time)
+
+    pop_id_map = {
+        "YRI": 0,
+        "CEU": 1,
+        "CHB": 2,
+        "Papuan": 3,
+        "DenA": 4,
+        "NeaA": 5,
+        "Den1": 6,
+        "Den2": 7,
+        "Nea1": 8,
+        "Ghost": 9,
+    }
     return stdpopsim.DemographicModel(
         id=id,
         description=id,
@@ -920,6 +986,10 @@ def DenisovanAncestryInPapuans():
         population_configurations=population_configurations,
         migration_matrix=migration_matrix,
         demographic_events=demographic_events,
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        # Note: we'll be updating this map as the model is modernised.
+        population_id_map=[pop_id_map] * 19,
     )
 
 
@@ -997,6 +1067,14 @@ def GutenkunstOOA():
             msprime.PopulationParametersChange(
                 time=T_AF, initial_size=N_A, population_id=0
             ),
+        ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        population_id_map=[
+            {"YRI": 0, "CEU": 1, "CHB": 2},
+            {"YRI": 0, "CEU": 1, "CHB": 2},
+            {"YRI": 0, "CEU": 1, "CHB": 2},
+            {"YRI": 0, "CEU": 1, "CHB": 2},
         ],
     )
 
@@ -1084,6 +1162,12 @@ def GladsteinAshkSubstructure():
                 time=T_growth, initial_size=N_ANC, population_id=0
             ),
         ],
+        # Mapping of per-epoch population names in the production model to
+        # population IDs in this model.
+        population_id_map=[
+            {"YRI": 0, "CHB": 1, "CEU": 2, "ME": 3, "J": 4, "WAJ": 5, "EAJ": 6},
+        ]
+        * 10,
     )
 
 
@@ -1146,6 +1230,7 @@ def ZigZag():
         populations=populations,
         population_configurations=population_configurations,
         demographic_events=de,
+        population_id_map=[{"generic": 0}] * 7,
     )
 
 

--- a/stdpopsim/qc/PonAbe.py
+++ b/stdpopsim/qc/PonAbe.py
@@ -6,15 +6,13 @@ import stdpopsim
 
 _species = stdpopsim.get_species("PonAbe")
 
-# Some generic populations to use for qc
-population_sample_0 = stdpopsim.Population(
-    "sampling_0", "Population that samples at time 0", 0
-)
-
 
 def LockePongo():
     id = "QC-TwoSpecies_2L11"
-    populations = [population_sample_0] * 2
+    populations = [
+        stdpopsim.Population("Bornean", ""),
+        stdpopsim.Population("Sumatran", ""),
+    ]
 
     # This is a split-migration style model, with exponential growth or
     # decay allowed in each population after the split. They assumed a
@@ -54,6 +52,10 @@ def LockePongo():
             msprime.PopulationParametersChange(
                 time=T, initial_size=Ne, growth_rate=0, population_id=0
             ),
+        ],
+        population_id_map=[
+            {"Bornean": 0, "Sumatran": 1},
+            {"Bornean": 0, "Sumatran": 1},
         ],
     )
 

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -226,7 +226,7 @@ class Species:
                     u_tot += chrom_data.length * chrom_data.mutation_rate
             u = u_tot / L_tot
             r = r_tot / L_tot
-            recomb_map = msprime.RecombinationMap.uniform_map(length, r)
+            recomb_map = msprime.RateMap.uniform(length, r)
             ret = stdpopsim.Contig(recombination_map=recomb_map, mutation_rate=u)
         else:
             if length is not None:
@@ -237,8 +237,8 @@ class Species:
             if genetic_map is None:
                 logger.debug(f"Making flat chromosome {length_multiplier} * {chrom.id}")
                 gm = None
-                recomb_map = msprime.RecombinationMap.uniform_map(
-                    chrom.length * length_multiplier, chrom.recombination_rate
+                recomb_map = msprime.RateMap.uniform(
+                    round(chrom.length * length_multiplier), chrom.recombination_rate
                 )
             else:
                 if length_multiplier != 1:

--- a/tests/test_HomSap.py
+++ b/tests/test_HomSap.py
@@ -32,12 +32,13 @@ class TestGenome(unittest.TestCase, test_species.GenomeTestMixin):
         genetic_map = "HapMapII_GRCh37"
         species = stdpopsim.get_species("HomSap")
         for chrom in self.genome.chromosomes:
-            if chrom.id == "chrY":
+            if chrom.id == "Y":
                 with self.assertWarns(Warning):
                     contig = species.get_contig(chrom.id, genetic_map=genetic_map)
+                print("HERE")
             else:
                 contig = species.get_contig(chrom.id, genetic_map=genetic_map)
             self.assertAlmostEqual(
                 chrom.recombination_rate,
-                contig.recombination_map.mean_recombination_rate,
+                contig.recombination_map.mean_rate,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -216,9 +216,6 @@ class TestEndToEnd(unittest.TestCase):
             self.assertEqual(len(stdout), 0)
             ts = tskit.load(str(filename))
         self.assertEqual(ts.num_samples, num_samples)
-        provenance = json.loads(ts.provenance(0).record)
-        prov_seed = provenance["parameters"]["random_seed"]
-        self.assertEqual(prov_seed, seed)
 
     def test_homsap_seed(self):
         cmd = "HomSap -c chr22 -l0.1 -s 1234 20"
@@ -285,9 +282,6 @@ class TestEndToEndSubprocess(TestEndToEnd):
         self.assertEqual(stored_cmd[-1], str(seed))
         self.assertEqual(stored_cmd[-2], "-s")
         self.assertEqual(stored_cmd[1:-4], cmd.split())
-        provenance = json.loads(ts.provenance(0).record)
-        prov_seed = provenance["parameters"]["random_seed"]
-        self.assertEqual(prov_seed, seed)
 
 
 class TestWriteOutput(unittest.TestCase):

--- a/tests/test_genetic_maps.py
+++ b/tests/test_genetic_maps.py
@@ -119,7 +119,7 @@ class TestGeneticMapTarball(unittest.TestCase):
                     with utils.cd(extract_dir):
                         tar_file.extractall()
                         for fn in os.listdir(extract_dir):
-                            maps[fn] = msprime.RecombinationMap.read_hapmap(fn)
+                            maps[fn] = msprime.RateMap.read_hapmap(fn)
         return maps
 
     def test_no_args(self):
@@ -208,16 +208,16 @@ class TestGetChromosomeMap(tests.CacheReadingTest):
         chrom = species.genome.get_chromosome("chrY")
         with self.assertWarns(Warning):
             cm = genetic_map.get_chromosome_map(chrom.id)
-        self.assertIsInstance(cm, msprime.RecombinationMap)
-        self.assertEqual(chrom.length, cm.get_sequence_length())
+        self.assertIsInstance(cm, msprime.RateMap)
+        self.assertEqual(chrom.length, cm.sequence_length)
 
     def test_known_chromosome(self):
         species = stdpopsim.get_species("CanFam")
         genetic_map = species.get_genetic_map("Campbell2016_CanFam3_1")
         chrom = species.genome.get_chromosome("1")
         cm = genetic_map.get_chromosome_map(chrom.id)
-        self.assertIsInstance(cm, msprime.RecombinationMap)
-        self.assertEqual(chrom.length, cm.get_sequence_length())
+        self.assertIsInstance(cm, msprime.RateMap)
+        self.assertEqual(chrom.length, cm.sequence_length)
 
     def test_warning_for_long_recomb_map(self):
         species = stdpopsim.get_species("HomSap")
@@ -225,8 +225,8 @@ class TestGetChromosomeMap(tests.CacheReadingTest):
         chrom = species.genome.get_chromosome("chr1")
         with self.assertWarns(Warning):
             cm = genetic_map.get_chromosome_map(chrom.id)
-        self.assertIsInstance(cm, msprime.RecombinationMap)
-        self.assertLess(chrom.length, cm.get_sequence_length())
+        self.assertIsInstance(cm, msprime.RateMap)
+        self.assertLess(chrom.length, cm.sequence_length)
 
     def test_unknown_chromosome(self):
         species = stdpopsim.get_species("HomSap")

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -123,8 +123,8 @@ class TestSimulate(unittest.TestCase):
         L = 1000
         contig = species.get_contig(length=L)
         contig.mutation_rate = 1e-3
-        contig.recombination_map = msprime.RecombinationMap.uniform_map(L, 0)
-        samples = [msprime.Sample(0, 0), msprime.Sample(0, 0)]
+        contig.recombination_map = msprime.RateMap.uniform(L, 0)
+        samples = [msprime.SampleSet(2, population=0, ploidy=1)]
         model = stdpopsim.PiecewiseConstantSize(100)
         for engine_name in engines:
             engine = stdpopsim.get_engine(engine_name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,12 +2,12 @@
 Tests for simulation model infrastructure.
 """
 import unittest
-import itertools
-import io
 import sys
+import textwrap
 
 import numpy as np
 import msprime
+import pytest
 
 import stdpopsim
 from stdpopsim import models
@@ -25,10 +25,8 @@ class DemographicModelTestMixin(object):
     model = None
 
     def test_debug_runs(self):
-        output = io.StringIO()
-        self.model.debug(output)
-        s = output.getvalue()
-        self.assertGreater(len(s), 0)
+        dbg = self.model.model.debug()
+        assert dbg.num_epochs > 0
 
     def test_simulation_runs(self):
         # With a recombination_map of None, we simulate a coalescent without
@@ -63,9 +61,10 @@ class QcdCatalogDemographicModelTestMixin(CatalogDemographicModelTestMixin):
     """
 
     def test_qc_model_equal(self):
-        self.assertTrue(self.model.equals(self.model.qc_model))
-        # Verify that we didn't just compare a model with itself.
-        self.assertNotEqual(self.model, self.model.qc_model)
+        d1 = self.model.model
+        d2 = self.model.qc_model
+        d1.assert_equivalent(d2, rel_tol=1e-5)
+        assert d1 != d2
 
 
 # Add model specific test classes, derived from one of the above.
@@ -89,249 +88,6 @@ for cls in qc_test_classes:
     setattr(sys.modules[__name__], cls.__name__, cls)
 
 
-class TestPopulationConfigsEqual(unittest.TestCase):
-    """
-    Tests the equality comparison of different msprime population configurations.
-    """
-
-    def test_empty(self):
-        self.assertTrue(models.population_configurations_equal([], []))
-
-    def test_sample_size_error(self):
-        pc1 = msprime.PopulationConfiguration(sample_size=2, initial_size=1)
-        pc2 = msprime.PopulationConfiguration(initial_size=1)
-        with self.assertRaises(ValueError):
-            models.population_configurations_equal([pc1], [pc1])
-        with self.assertRaises(ValueError):
-            models.population_configurations_equal([pc1], [pc2])
-        with self.assertRaises(ValueError):
-            models.population_configurations_equal([pc2], [pc1])
-
-    def test_no_initial_size_error(self):
-        pc1 = msprime.PopulationConfiguration()
-        pc2 = msprime.PopulationConfiguration(initial_size=1)
-        with self.assertRaises(ValueError):
-            self.assertTrue(models.population_configurations_equal([pc1], [pc1]))
-        with self.assertRaises(ValueError):
-            self.assertTrue(models.population_configurations_equal([pc1], [pc2]))
-        with self.assertRaises(ValueError):
-            self.assertTrue(models.population_configurations_equal([pc2], [pc1]))
-
-    def test_different_lengths(self):
-        pc = msprime.PopulationConfiguration(initial_size=1)
-        self.assertFalse(models.population_configurations_equal([], [pc]))
-        self.assertFalse(models.population_configurations_equal([pc], []))
-        self.assertFalse(models.population_configurations_equal([pc, pc], [pc]))
-        self.assertFalse(models.population_configurations_equal([pc], [pc, pc]))
-        self.assertTrue(models.population_configurations_equal([pc], [pc]))
-        with self.assertRaises(models.UnequalModelsError):
-            models.verify_population_configurations_equal([pc], [pc, pc])
-
-    def test_initial_sizes(self):
-        test_sizes = [
-            ([1], [1.001]),
-            ([1.001], [1]),
-            ([1, 2, 3], [2, 3, 4]),
-            (np.arange(1, 100), np.arange(1, 100) - 0.001),
-        ]
-
-        for sizes1, sizes2 in test_sizes:
-            pc_list1 = [
-                msprime.PopulationConfiguration(initial_size=size) for size in sizes1
-            ]
-            pc_list2 = [
-                msprime.PopulationConfiguration(initial_size=size) for size in sizes2
-            ]
-            self.assertFalse(models.population_configurations_equal(pc_list1, pc_list2))
-            self.assertFalse(models.population_configurations_equal(pc_list2, pc_list1))
-            self.assertTrue(models.population_configurations_equal(pc_list1, pc_list1))
-            self.assertTrue(models.population_configurations_equal(pc_list2, pc_list2))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_population_configurations_equal(pc_list2, pc_list1)
-
-    def test_growth_rates(self):
-        test_rates = [
-            ([1], [1.001]),
-            ([-1.001], [-1]),
-            ([1, 2, 3], [2, 3, 4]),
-            (np.arange(1, 100), np.arange(1, 100) - 0.001),
-        ]
-        for rates1, rates2 in test_rates:
-            pc_list1 = [
-                msprime.PopulationConfiguration(initial_size=1, growth_rate=rate)
-                for rate in rates1
-            ]
-            pc_list2 = [
-                msprime.PopulationConfiguration(initial_size=1, growth_rate=rate)
-                for rate in rates2
-            ]
-            self.assertFalse(models.population_configurations_equal(pc_list1, pc_list2))
-            self.assertFalse(models.population_configurations_equal(pc_list2, pc_list1))
-            self.assertTrue(models.population_configurations_equal(pc_list1, pc_list1))
-            self.assertTrue(models.population_configurations_equal(pc_list2, pc_list2))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_population_configurations_equal(pc_list2, pc_list1)
-
-    def test_sampling_times_equal(self):
-        no_sample_pop = stdpopsim.Population("none", "none", sampling_time=None)
-        zero_sample_pop = stdpopsim.Population("zero", "zero")
-        nonzero_sample_pop = stdpopsim.Population("nzero", "nzero", sampling_time=10)
-        plist1 = [no_sample_pop] * 2 + [nonzero_sample_pop] + [zero_sample_pop] * 2
-        plist2 = [no_sample_pop] * 4 + [nonzero_sample_pop]
-        plist3 = [no_sample_pop] * 3 + [nonzero_sample_pop]
-        self.assertFalse(
-            stdpopsim.sampling_times_equal([no_sample_pop], [zero_sample_pop])
-        )
-        self.assertFalse(
-            stdpopsim.sampling_times_equal([nonzero_sample_pop], [zero_sample_pop])
-        )
-        self.assertFalse(stdpopsim.sampling_times_equal(plist1, plist2))
-        self.assertFalse(stdpopsim.sampling_times_equal(plist1, plist3))
-        self.assertTrue(stdpopsim.sampling_times_equal(plist3, plist3))
-
-
-class TestDemographicEventsEqual(unittest.TestCase):
-    """
-    Tests the equality comparison of different msprime demographic events.
-    """
-
-    def test_empty(self):
-        self.assertTrue(models.demographic_events_equal([], [], 1))
-
-    def test_different_lengths(self):
-        events = [msprime.PopulationParametersChange(time=1, initial_size=1)] * 10
-        self.assertFalse(models.demographic_events_equal(events[:1], [], 1))
-        self.assertFalse(models.demographic_events_equal([], events[:1], 1))
-        self.assertFalse(models.demographic_events_equal(events, [], 1))
-        self.assertFalse(models.demographic_events_equal([], events, 1))
-        with self.assertRaises(models.UnequalModelsError):
-            models.verify_demographic_events_equal([], events, 1)
-
-    def test_different_times(self):
-        n = 10
-        e1 = [
-            msprime.PopulationParametersChange(time=j, initial_size=1) for j in range(n)
-        ]
-        e2 = [
-            msprime.PopulationParametersChange(time=j + 1, initial_size=1)
-            for j in range(n)
-        ]
-        for j in range(1, n):
-            self.assertFalse(models.demographic_events_equal(e1[:j], e2[:j], 1))
-            self.assertFalse(models.demographic_events_equal(e2[:j], e1[:j], 1))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal(e1[:j], e2[:j], 1)
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal(e2[:j], e1[:j], 1)
-
-    def test_different_types(self):
-        events = [
-            msprime.PopulationParametersChange(time=1, initial_size=1),
-            msprime.MigrationRateChange(time=1, rate=1),
-            msprime.MassMigration(time=1, source=1),
-            msprime.SimpleBottleneck(time=1, population=0),
-        ]
-        for a, b in itertools.combinations(events, 2):
-            self.assertFalse(models.demographic_events_equal([a], [b], 1))
-            self.assertFalse(models.demographic_events_equal([b], [a], 1))
-            self.assertTrue(models.demographic_events_equal([a], [a], 1))
-            self.assertTrue(models.demographic_events_equal([b], [b], 1))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([b], [a], 1)
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([a], [b], 1)
-
-    def test_population_parameters_change(self):
-        def f(time=1, initial_size=1, growth_rate=None, population=None):
-            return msprime.PopulationParametersChange(
-                time=time,
-                initial_size=initial_size,
-                growth_rate=growth_rate,
-                population=population,
-            )
-
-        test_events = [
-            (f(time=1), f(time=2)),
-            (f(initial_size=1), f(initial_size=2)),
-            (f(growth_rate=1), f(growth_rate=2)),
-            (f(population=1), f(population=2)),
-        ]
-        for a, b in test_events:
-            self.assertFalse(models.demographic_events_equal([a], [b], 1))
-            self.assertFalse(models.demographic_events_equal([b], [a], 1))
-            self.assertTrue(models.demographic_events_equal([a], [a], 1))
-            self.assertTrue(models.demographic_events_equal([b], [b], 1))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([b], [a], 1)
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([a], [b], 1)
-
-    def test_migration_rate_change(self):
-        def f(time=1, rate=1, matrix_index=None):
-            return msprime.MigrationRateChange(
-                time=time, rate=rate, matrix_index=matrix_index
-            )
-
-        test_events = [
-            (f(time=1), f(time=2)),
-            (f(rate=1), f(rate=2)),
-            (f(matrix_index=[0, 1]), f(matrix_index=[0, 2])),
-            (f(matrix_index=np.array([0, 1])), f(matrix_index=[0, 2])),
-        ]
-        for a, b in test_events:
-            self.assertFalse(models.demographic_events_equal([a], [b], 1))
-            self.assertFalse(models.demographic_events_equal([b], [a], 1))
-            self.assertTrue(models.demographic_events_equal([a], [a], 1))
-            self.assertTrue(models.demographic_events_equal([b], [b], 1))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([b], [a], 1)
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([a], [b], 1)
-
-    def test_mass_migration(self):
-        def f(time=1, source=1, dest=1, proportion=1):
-            return msprime.MassMigration(
-                time=time, source=source, dest=dest, proportion=proportion
-            )
-
-        test_events = [
-            (f(time=1), f(time=2)),
-            (f(source=1), f(source=2)),
-            (f(dest=1), f(dest=2)),
-            (f(proportion=1), f(proportion=0.2)),
-        ]
-        for a, b in test_events:
-            self.assertFalse(models.demographic_events_equal([a], [b], 1))
-            self.assertFalse(models.demographic_events_equal([b], [a], 1))
-            self.assertTrue(models.demographic_events_equal([a], [a], 1))
-            self.assertTrue(models.demographic_events_equal([b], [b], 1))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([b], [a], 1)
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([a], [b], 1)
-
-    def test_simple_bottleneck(self):
-        def f(time=1, population=1, proportion=1):
-            return msprime.SimpleBottleneck(
-                time=time, population=population, proportion=proportion
-            )
-
-        test_events = [
-            (f(time=1), f(time=2)),
-            (f(population=1), f(population=2)),
-            (f(proportion=1), f(proportion=0.2)),
-        ]
-        for a, b in test_events:
-            self.assertFalse(models.demographic_events_equal([a], [b], 1))
-            self.assertFalse(models.demographic_events_equal([b], [a], 1))
-            self.assertTrue(models.demographic_events_equal([a], [a], 1))
-            self.assertTrue(models.demographic_events_equal([b], [b], 1))
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([b], [a], 1)
-            with self.assertRaises(models.UnequalModelsError):
-                models.verify_demographic_events_equal([a], [b], 1)
-
-
 class TestRegisterQCModel(unittest.TestCase):
     def make_model(self, name):
         return models.DemographicModel(
@@ -339,7 +95,7 @@ class TestRegisterQCModel(unittest.TestCase):
             description=name,
             long_description=name,
             generation_time=1,
-            populations=[],
+            model=msprime.Demography.isolated_model([1]),
         )
 
     def test_register_qc(self):
@@ -359,30 +115,60 @@ class TestRegisterQCModel(unittest.TestCase):
                 model.register_qc(not_a_model)
 
 
-class TestAllModels(unittest.TestCase):
+class TestAllModels:
     """
     Tests for registered simulation models.
     """
 
     def test_non_empty(self):
-        self.assertGreater(len(list(stdpopsim.all_demographic_models())), 0)
+        assert len(list(stdpopsim.all_demographic_models())) > 0
 
-    def test_all_instances(self):
-        for model in stdpopsim.all_demographic_models():
-            self.assertIsInstance(model, models.DemographicModel)
+    @pytest.mark.parametrize("model", stdpopsim.all_demographic_models())
+    def test_all_instances(self, model):
+        assert isinstance(model, models.DemographicModel)
+        assert len(model.id) > 0
+        assert len(model.description) > 0
+        assert len(model.long_description) > 0
+        assert len(model.citations) > 0
+        assert model.generation_time > 0
+        model.model.validate()
 
-            self.assertGreater(len(model.id), 0)
-            self.assertGreater(len(model.description), 0)
-            self.assertGreater(len(model.long_description), 0)
-            self.assertGreater(len(model.citations), 0)
-            self.assertGreater(model.generation_time, 0)
 
-            npops = len(model.populations)
-            self.assertGreater(npops, 0)
-            self.assertEqual(len(model.population_configurations), npops)
-            self.assertEqual(len(model.migration_matrix), npops)
-            self.assertEqual(len(model.migration_matrix[0]), npops)
-            self.assertIsInstance(model.demographic_events, list)
+class TestModelOutput:
+    def test_str(self):
+        model = stdpopsim.DemographicModel(
+            id="xyz",
+            description="abc",
+            long_description="ABC",
+            generation_time=1234,
+            model=msprime.Demography.isolated_model([1]),
+        )
+        s = str(model)
+        assert "xyz" in s
+        assert "abc" in s
+        assert "ABC" in s
+        assert "1234" in s
+
+    def test_wrap_long_lines(self):
+        model = stdpopsim.DemographicModel(
+            id="xyz",
+            description="abc",
+            long_description="ABC " * 50,
+            generation_time=1234,
+            model=msprime.Demography.isolated_model([1]),
+        )
+        s = str(model)
+        expected = """\
+        Demographic model:
+        ║  id               = xyz
+        ║  description      = abc
+        ║  long_description = ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC
+        ║                     ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC
+        ║                     ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC
+        ║  generation_time  = 1234
+        ║  citations        = []
+        """  # noqa 501
+        assert textwrap.dedent(expected) in s
 
 
 class TestModelsEqual(unittest.TestCase):
@@ -391,42 +177,11 @@ class TestModelsEqual(unittest.TestCase):
     """
 
     def test_known_models(self):
-        # All models should be equal to themselves.
-        other_model = models.DemographicModel.empty()
+        other_model = msprime.Demography.isolated_model([1])
         for model in stdpopsim.all_demographic_models():
-            self.assertTrue(model.equals(model))
-            self.assertFalse(model.equals(other_model))
-
-    def test_different_objects(self):
-        m1 = models.DemographicModel.empty()
-        self.assertFalse(m1.equals(self))
-        self.assertFalse(m1.equals({}))
-        self.assertFalse(m1.equals(None))
-
-    def test_default_models(self):
-        m1 = models.DemographicModel.empty()
-        m2 = models.DemographicModel.empty()
-        self.assertTrue(m1.equals(m2))
-
-    def test_migration_matrices(self):
-        m1 = models.DemographicModel.empty()
-        m2 = models.DemographicModel.empty()
-        m1.migration_matrix = [[]]
-        self.assertFalse(m1.equals(m2))
-        m2.migration_matrix = [[]]
-        self.assertTrue(m1.equals(m2))
-        mm1 = np.arange(100, dtype=float).reshape(10, 10)
-        m1.migration_matrix = mm1
-        self.assertFalse(m1.equals(m2))
-        m2.migration_matrix = mm1
-        self.assertTrue(m1.equals(m2))
-        # Perturb the matrix by a tiny bit and see if we're still equal
-        mm2 = mm1.copy() + 1e-9
-        m2.migration_matrix = mm2
-        self.assertFalse(np.all(m1.migration_matrix == m2.migration_matrix))
-        self.assertTrue(m1.equals(m2))
-        # If we have higher tolerances we catch the differences
-        self.assertFalse(m1.equals(m2, atol=1e-10, rtol=1e-9))
+            model.model.assert_equivalent(model.model)
+            model.model.assert_equal(model.model)
+            assert not model.model.is_equivalent(other_model)
 
 
 class TestConstantSizeModel(unittest.TestCase, DemographicModelTestMixin):
@@ -444,31 +199,33 @@ class TestPiecewiseConstantSize(unittest.TestCase):
 
     def test_single_epoch(self):
         model = models.PiecewiseConstantSize(100)
-        self.assertEqual(model.population_configurations[0].initial_size, 100)
-        self.assertEqual(len(model.population_configurations), 1)
-        self.assertEqual(len(model.demographic_events), 0)
+        self.assertEqual(model.model.populations[0].initial_size, 100)
+        self.assertEqual(model.model.num_populations, 1)
+        self.assertEqual(model.model.num_events, 0)
 
     def test_two_epoch(self):
         model = models.PiecewiseConstantSize(50, (10, 100))
-        self.assertEqual(model.population_configurations[0].initial_size, 50)
-        self.assertEqual(len(model.demographic_events), 1)
-        event = model.demographic_events[0]
+        self.assertEqual(model.model.populations[0].initial_size, 50)
+        self.assertEqual(model.model.num_populations, 1)
+        self.assertEqual(model.model.num_events, 1)
+        event = model.model.events[0]
         self.assertEqual(event.time, 10)
         self.assertEqual(event.initial_size, 100)
-        self.assertEqual(event.growth_rate, 0)
+        self.assertIsNone(event.growth_rate)
 
     def test_three_epoch(self):
         model = models.PiecewiseConstantSize(0.1, (0.1, 10), (0.2, 100))
-        self.assertEqual(model.population_configurations[0].initial_size, 0.1)
-        self.assertEqual(len(model.demographic_events), 2)
-        event = model.demographic_events[0]
+        self.assertEqual(model.model.populations[0].initial_size, 0.1)
+        self.assertEqual(model.model.num_populations, 1)
+        self.assertEqual(model.model.num_events, 2)
+        event = model.model.events[0]
         self.assertEqual(event.time, 0.1)
         self.assertEqual(event.initial_size, 10)
-        self.assertEqual(event.growth_rate, 0)
-        event = model.demographic_events[1]
+        self.assertIsNone(event.growth_rate)
+        event = model.model.events[1]
         self.assertEqual(event.time, 0.2)
         self.assertEqual(event.initial_size, 100)
-        self.assertEqual(event.growth_rate, 0)
+        self.assertIsNone(event.growth_rate)
 
 
 class TestIsolationWithMigration(unittest.TestCase):
@@ -477,20 +234,19 @@ class TestIsolationWithMigration(unittest.TestCase):
     """
 
     def test_pop_configs(self):
-        model = models.IsolationWithMigration(100, 200, 300, 50, 0, 0)
-        self.assertEqual(len(model.population_configurations), 3)
-        self.assertEqual(model.population_configurations[0].initial_size, 200)
-        self.assertEqual(model.population_configurations[1].initial_size, 300)
-        self.assertEqual(model.population_configurations[2].initial_size, 100)
+        model = models.IsolationWithMigration(100, 200, 300, 50, 0, 0).model
+        self.assertEqual(model.num_populations, 3)
+        self.assertEqual(model.populations[0].initial_size, 200)
+        self.assertEqual(model.populations[1].initial_size, 300)
+        self.assertEqual(model.populations[2].initial_size, 100)
 
     def test_split(self):
-        model = models.IsolationWithMigration(100, 200, 300, 50, 0, 0)
-        self.assertEqual(len(model.demographic_events), 2)
-        self.assertEqual(model.demographic_events[0].time, 50)
-        self.assertEqual(model.demographic_events[1].time, 50)
+        model = models.IsolationWithMigration(100, 200, 300, 50, 0, 0).model
+        self.assertEqual(len(model.events), 1)
+        self.assertEqual(model.events[0].time, 50)
 
     def test_migration_rates(self):
-        model = models.IsolationWithMigration(100, 200, 300, 50, 0.002, 0.003)
+        model = models.IsolationWithMigration(100, 200, 300, 50, 0.002, 0.003).model
         self.assertEqual(np.shape(model.migration_matrix), (3, 3))
         self.assertEqual(model.migration_matrix[0][1], 0.002)
         self.assertEqual(model.migration_matrix[1][0], 0.003)
@@ -499,30 +255,46 @@ class TestIsolationWithMigration(unittest.TestCase):
 
 
 class TestPopulationSampling(unittest.TestCase):
-    # Create populations to test on
-    _pop1 = stdpopsim.Population("pop0", "Test pop. 0")
-    _pop2 = stdpopsim.Population("pop1", "Test pop. 1", sampling_time=10)
-    _pop3 = stdpopsim.Population("pop2", "Test pop. 2", sampling_time=None)
+    def make_model(self):
+        # Create populations to test on
+        _pop1 = stdpopsim.Population("pop0", "Test pop. 0")
+        _pop2 = stdpopsim.Population("pop1", "Test pop. 1", sampling_time=10)
+        _pop3 = stdpopsim.Population("pop2", "Test pop. 2", sampling_time=None)
 
-    # Create an empty model to hold populations
-    base_mod = models.DemographicModel.empty(populations=[_pop1, _pop2, _pop3])
+        # Create an model to hold populations
+        base_mod = models.DemographicModel(
+            id="x",
+            description="y",
+            long_description="z",
+            populations=[_pop1, _pop2, _pop3],
+            population_configurations=[
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+        )
+        return base_mod
 
     def test_num_sampling_populations(self):
-        self.assertEqual(self.base_mod.num_sampling_populations, 2)
+        base_mod = self.make_model()
+        self.assertEqual(base_mod.num_sampling_populations, 2)
 
     def test_get_samples(self):
-        test_samples = self.base_mod.get_samples(2, 1)
-        self.assertEqual(len(test_samples), 3)
+        base_mod = self.make_model()
+        test_samples = base_mod.get_samples(2, 1)
+        self.assertEqual(len(test_samples), 2)
+        self.assertEqual(sum([ss.num_samples for ss in test_samples]), 3)
+
         # Check for error when prohibited sampling asked for
         with self.assertRaises(ValueError):
-            self.base_mod.get_samples(2, 2, 1)
+            base_mod.get_samples(2, 2, 1)
         # Get the population corresponding to each sample
         sample_populations = [i.population for i in test_samples]
         # Check sample populations
-        self.assertEqual(sample_populations, [0, 0, 1])
+        self.assertEqual(sample_populations, [0, 1])
         # Test sampling times
         sample_times = [i.time for i in test_samples]
-        self.assertEqual(sample_times, [0, 0, 10])
+        self.assertEqual(sample_times, [0, 10])
 
     # Test that all sampling populations are specified before non-sampling populations
     # in the model.populations list
@@ -532,80 +304,6 @@ class TestPopulationSampling(unittest.TestCase):
             num_sampling = sum(allow_sample_status)
             # All sampling populations must be at the start of the list
             self.assertEqual(sum(allow_sample_status[num_sampling:]), 0)
-
-    # Test that populations are listed in the same order in model.populations and
-    # model.population_configurations
-    def test_population_config_order_equal(self):
-        for model in stdpopsim.all_demographic_models():
-            pop_ids = [pop.id for pop in model.populations]
-            config_ids = [
-                config.metadata["id"] for config in model.population_configurations
-            ]
-            for p, c in zip(pop_ids, config_ids):
-                self.assertEqual(p, c)
-
-    # Test that we are indeed getting a valid DDB back
-    # admittedly a pretty bad test...
-    def test_demography_debugger(self):
-        for model in stdpopsim.all_demographic_models():
-            ddb = model.get_demography_debugger()
-            self.assertIsInstance(ddb, msprime.DemographyDebugger)
-
-    # test for equality of ddbs
-    def test_demography_debugger_equal(self):
-        for model in stdpopsim.all_demographic_models():
-            ddb1 = model.get_demography_debugger()
-            ddb2 = msprime.DemographyDebugger(
-                population_configurations=model.population_configurations,
-                migration_matrix=model.migration_matrix,
-                demographic_events=model.demographic_events,
-            )
-            f1 = io.StringIO()
-            f2 = io.StringIO()
-            ddb1.print_history(f1)
-            ddb2.print_history(f2)
-            self.assertEqual(f1.getvalue(), f2.getvalue())
-
-
-class TestDemographicModelConstruction(unittest.TestCase):
-    # Test construction of a Population object when provided a PopulationConfiguration
-    # object but no populations
-    def test_population_construction_popconfig(self):
-        pc = [msprime.PopulationConfiguration(initial_size=1, growth_rate=0.03)]
-        dm = stdpopsim.DemographicModel(
-            id="",
-            description="",
-            long_description="",
-            generation_time=1,
-            population_configurations=pc,
-        )
-        self.assertEqual(dm.populations[0].id, "pop0")
-
-    # Test construction of a Population object when provided a PopulationConfiguration
-    # object with metadata but no populations
-    def test_population_construction_popconfig_metadata(self):
-        pop0 = stdpopsim.Population(id="A", description="Pop A")
-        pc_meta = [
-            msprime.PopulationConfiguration(
-                initial_size=1, growth_rate=0.03, metadata=pop0.asdict()
-            )
-        ]
-        dm = stdpopsim.DemographicModel(
-            id="",
-            description="",
-            long_description="",
-            generation_time=1,
-            population_configurations=pc_meta,
-        )
-        self.assertEqual(dm.populations[0].asdict(), pop0.asdict())
-
-    # Test construction of a Population object when provided neither a
-    # PopulationConfiguration list or a Population list
-    def test_population_construction_no_popconfig(self):
-        dm = stdpopsim.DemographicModel(
-            id="A", description="A", long_description="A", generation_time=1
-        )
-        self.assertEqual(dm.populations, [])
 
 
 class TestZigZagWarning(unittest.TestCase):

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -437,17 +437,18 @@ class TestWarningsAndErrors(unittest.TestCase):
         Used for testing that growth rates are handled appropriately.
         """
         r = math.log(N0 / N1) / T
+        pop0 = stdpopsim.models.Population(id="pop0", description="")
         return stdpopsim.DemographicModel(
             id="exp_decline",
             description="exp_decline",
             long_description="exp_decline",
-            populations=[stdpopsim.models._pop0],
+            populations=[pop0],
             generation_time=1,
             population_configurations=[
                 msprime.PopulationConfiguration(
                     initial_size=N0,
                     growth_rate=r,
-                    metadata=stdpopsim.models._pop0.asdict(),
+                    metadata=pop0.asdict(),
                 )
             ],
             demographic_events=[

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -178,8 +178,8 @@ class TestGetContig(unittest.TestCase):
         for x in [0.125, 1.0, 2.0]:
             contig2 = self.species.get_contig("chr22", length_multiplier=x)
             self.assertEqual(
-                contig1.recombination_map.get_positions()[-1] * x,
-                contig2.recombination_map.get_positions()[-1],
+                round(contig1.recombination_map.position[-1] * x),
+                contig2.recombination_map.position[-1],
             )
 
     def test_length_multiplier_on_empirical_map(self):
@@ -191,7 +191,7 @@ class TestGetContig(unittest.TestCase):
     def test_genetic_map(self):
         # TODO we should use a different map here so we're not hitting the cache.
         contig = self.species.get_contig("chr22", genetic_map="HapMapII_GRCh37")
-        self.assertIsInstance(contig.recombination_map, msprime.RecombinationMap)
+        self.assertIsInstance(contig.recombination_map, msprime.RateMap)
 
     def test_contig_options(self):
         with self.assertRaises(ValueError):
@@ -226,7 +226,7 @@ class TestGetContig(unittest.TestCase):
     def test_generic_contig(self):
         L = 1e6
         contig = self.species.get_contig(length=L)
-        self.assertTrue(contig.recombination_map.get_length() == L)
+        self.assertTrue(contig.recombination_map.sequence_length == L)
 
         chrom_ids = np.arange(1, 23).astype("str")
         Ls = [c.length for c in self.species.genome.chromosomes if c.id in chrom_ids]
@@ -243,6 +243,5 @@ class TestGetContig(unittest.TestCase):
 
         self.assertTrue(contig.mutation_rate == np.average(us, weights=Ls))
         self.assertTrue(
-            contig.recombination_map.mean_recombination_rate
-            == np.average(rs, weights=Ls)
+            contig.recombination_map.mean_rate == np.average(rs, weights=Ls)
         )


### PR DESCRIPTION
This is an initial pass at converting the codebase to use the msprime 1.0 Demography model, rather than the msprime 0.x model as we currently do.

This will be a messy change, but I think it's something we can do incrementally, which will also move us closer to demes (which will be the future basis for demography).

The first pass here is to just remove the model comparison code we have here, which is using internal msprime APIs, and use msprime's APIs instead. 

My proposal for the transition would be the following:

1. Remove the ``population_configurations``, ``demographic_events`` and ``migration_matrix`` replace with a ``demography`` object. (May get rid of the ``populations`` list as well, since this is redundant, but not in the first pass)
2. Go through all the catalog files and call ``Demography.from_old_style`` on all the places we create a model object.

This much should work, and we should be able to merge.

Once that's working, we can then start tweaking the model definitions to make them more idiomatic/more demes-like. Ultimately, I'd like to make some demes-like Demographys for the stuff in the catalog, where we use population splits etc rather than mass migrations. We then compare them with the qc models using the ``is_equivalent()`` method, which is able to take into account populations being reused, via a mapping of equivalent populations epoch-by-epoch. That way, we should be able to keep the QC models as they are, but incrementally modernise the catalog models.

Upgrading from the msprime demes-like Demography model should be straightforward enough then at a later date.

What do you think @grahamgower?