### PR TITLE
Remove time deltas from AmericanAdmixture_4B11

### DIFF
--- a/stdpopsim/catalog/HomSap/__init__.py
+++ b/stdpopsim/catalog/HomSap/__init__.py
@@ -656,30 +656,24 @@ def _america():
             time=Tadmix, source=3, destination=0, proportion=1.0 / 6.0
         ),
         msprime.MassMigration(
-            time=Tadmix + 0.0001, source=3, destination=1, proportion=2.0 / 5.0
+            time=Tadmix, source=3, destination=1, proportion=2.0 / 5.0
         ),
-        msprime.MassMigration(
-            time=Tadmix + 0.0002, source=3, destination=2, proportion=1.0
-        ),
+        msprime.MassMigration(time=Tadmix, source=3, destination=2, proportion=1.0),
     ]
     # Asia and Europe split
     eu_event = [
         msprime.MigrationRateChange(time=Teu, rate=0.0),
-        msprime.MassMigration(
-            time=Teu + 0.0001, source=2, destination=1, proportion=1.0
-        ),
+        msprime.MassMigration(time=Teu, source=2, destination=1, proportion=1.0),
         msprime.PopulationParametersChange(
-            time=Teu + 0.0002, initial_size=Nb, growth_rate=0.0, population_id=1
+            time=Teu, initial_size=Nb, growth_rate=0.0, population_id=1
         ),
-        msprime.MigrationRateChange(time=Teu + 0.0003, rate=mafb, matrix_index=(0, 1)),
-        msprime.MigrationRateChange(time=Teu + 0.0003, rate=mafb, matrix_index=(1, 0)),
+        msprime.MigrationRateChange(time=Teu, rate=mafb, matrix_index=(0, 1)),
+        msprime.MigrationRateChange(time=Teu, rate=mafb, matrix_index=(1, 0)),
     ]
     # Out of Africa event
     ooa_event = [
         msprime.MigrationRateChange(time=Tooa, rate=0.0),
-        msprime.MassMigration(
-            time=Tooa + 0.0001, source=1, destination=0, proportion=1.0
-        ),
+        msprime.MassMigration(time=Tooa, source=1, destination=0, proportion=1.0),
     ]
     # initial population size
     init_event = [

--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -257,35 +257,35 @@ def BrowningAmerica():
                 time=T_ADMIX0, source=3, destination=0, proportion=mm_AF1
             ),
             msprime.MassMigration(
-                time=T_ADMIX0 + 0.0001, source=3, destination=1, proportion=mm_CEU0
+                time=T_ADMIX0, source=3, destination=1, proportion=mm_CEU0
             ),
             msprime.MassMigration(
-                time=T_ADMIX0 + 0.0002, source=3, destination=2, proportion=mm_CHB0
+                time=T_ADMIX0, source=3, destination=2, proportion=mm_CHB0
             ),
             # Zero out migration rate (desn't matter but added for equality to prod.)
             msprime.MigrationRateChange(time=T_CEU_CHB, rate=0.0),
             # CEU and CHB coalesce and set population to OOA size (T_CEU_CHB)
             msprime.MassMigration(
-                time=T_CEU_CHB + 0.0001, source=2, destination=1, proportion=1.0
+                time=T_CEU_CHB, source=2, destination=1, proportion=1.0
             ),
             msprime.PopulationParametersChange(
-                time=T_CEU_CHB + 0.0002,
+                time=T_CEU_CHB,
                 initial_size=N_OOA,
                 growth_rate=0.0,
                 population_id=1,
             ),
             # Set OOA <--> AF migration rate (T_CEU_CHB)
             msprime.MigrationRateChange(
-                time=T_CEU_CHB + 0.0003, rate=m_AF1_OOA, matrix_index=(0, 1)
+                time=T_CEU_CHB, rate=m_AF1_OOA, matrix_index=(0, 1)
             ),
             msprime.MigrationRateChange(
-                time=T_CEU_CHB + 0.0003, rate=m_AF1_OOA, matrix_index=(1, 0)
+                time=T_CEU_CHB, rate=m_AF1_OOA, matrix_index=(1, 0)
             ),
             # Zero out migration rate
             msprime.MigrationRateChange(time=T_AF1_OOA, rate=0.0),
             # OOA and AF1 coalesce (T_OOA)
             msprime.MassMigration(
-                time=T_AF1_OOA + 0.0001, source=1, destination=0, proportion=1.0
+                time=T_AF1_OOA, source=1, destination=0, proportion=1.0
             ),
             # AF1 -> AF0 population size change (T_AF0_AF1)
             msprime.PopulationParametersChange(


### PR DESCRIPTION
These are not necessary and make comparing the model with other implementations impossible.

I guess we should consider changelog updates for things like this, but I think it's such an inconsequential change for users we probably don't need to bother.