### PR TITLE
Minimal changes for msprime 1.0 alpha.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,8 +77,9 @@ jobs:
       - name: install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          # Workaround weird issues on windows.
-          conda install --yes -c conda-forge msprime==1.0.0a6
+          # Install pre-release from non standard label until msprime
+          # 1.0 is tagged.
+          conda install -c conda-forge/label/mprime_rc -c conda-forge msprime
           conda install --yes --file=requirements/CI/conda.txt
           if [ "$RUNNER_OS" != "Windows" ]; then
             conda install --yes slim==${{ env.SLIM_TAG }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,8 @@ jobs:
       - name: install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          # Workaround weird issues on windows.
+          conda install --yes -c conda-forge msprime==1.0.0a6
           conda install --yes --file=requirements/CI/conda.txt
           if [ "$RUNNER_OS" != "Windows" ]; then
             conda install --yes slim==${{ env.SLIM_TAG }}

--- a/requirements/CI/conda.txt
+++ b/requirements/CI/conda.txt
@@ -1,2 +1,3 @@
-msprime==1.0.0a6
+# Uncomment when 1.0 is released.
+# msprime==1.0.0
 numcodecs==0.7.3

--- a/requirements/CI/conda.txt
+++ b/requirements/CI/conda.txt
@@ -1,2 +1,2 @@
-msprime==0.7.4
+msprime==1.0.0a6
 numcodecs==0.7.3

--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -8,7 +8,7 @@ sphinx-argparse==0.2.5
 sphinx-issues==1.2.0
 sphinx_rtd_theme==0.5.1
 sphinxcontrib-programoutput==0.16
-msprime==0.7.4
+msprime==1.0.0a6
 attrs==20.3.0
 appdirs==1.4.4
 humanize==3.2.0

--- a/requirements/conda-minimal.txt
+++ b/requirements/conda-minimal.txt
@@ -1,9 +1,0 @@
-nose
-msprime
-kastore
-tskit
-humanize
-attrs
-appdirs
-pandas
-zarr

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,12 +10,12 @@ sphinx-argparse
 sphinx-issues
 sphinx_rtd_theme
 sphinxcontrib-programoutput
-msprime
+msprime>=1.0.0a6
 attrs
 appdirs
 humanize
 pre-commit
-pyslim>=0.500
+pyslim>=0.600
 pandas
 numpy
 scikit-allel

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
     python_requires=">=3.7",
     # NOTE: make sure this is the 'attrs' package, not 'attr'!
     install_requires=[
-        "msprime>=0.7.1",
+        "msprime>=1.0.0a6",
         "attrs>=19.1.0",
         "appdirs",
         "humanize",
-        "pyslim>=0.401",
+        "pyslim>=0.600",
         "pandas",
         "zarr",
         "numpy",


### PR DESCRIPTION
Bump slim to version 3.5

Another version of #770, trying to rule out weird cache issues. Conda can't seem to find the msprime packages on Windows (but can for other OSs)