### PR TITLE
Allow demographic models to store mutation rates

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -563,6 +563,7 @@ The demographic model function should follow this format:
         ]
 
         generation_time = "FILL ME"
+        mutation_rate = "FILL ME"
 
         # parameter value definitions based on published values
 
@@ -573,6 +574,7 @@ The demographic model function should follow this format:
             populations=populations,
             citations=citations,
             generation_time=generation_time,
+            mutation_rate=mutation_rate,
             population_configurations=["FILL ME"],
             migration_matrix=["FILL ME"],
             demographic_events=["FILL ME"],
@@ -602,7 +604,10 @@ The demographic model should include the following:
   a specified reason for citing this model.
 * ``generation_time``: The generation time for the species in years. If you are
   implementing a generic model, the generation time should default to 1.
-
+* ``mutation_rate``: The mutation rate assumed during the inference of this demographic
+  model, if a mutation rate was used. If no mutation rate is associated with this
+  demographic model, which is generally uncommon but possible, depending on the
+  inference method, the mutation rate should be set to ``None``.
 
 Every demographic model has a few necessary features or attributes. First of all,
 demographic models are defined by the population sizes, migration rates, split and
@@ -664,6 +669,8 @@ Now check that your new demographic model function has been imported:
     # Zigzag_1S14
     # AncientEurasia_9K19
     # PapuansOutOfAfrica_10J19
+    # AshkSub_7G19
+    # OutOfAfrica_4J17
 
 
 The example above lists the imported demographic models for humans.

--- a/stdpopsim/catalog/BosTau/demographic_models.py
+++ b/stdpopsim/catalog/BosTau/demographic_models.py
@@ -23,7 +23,6 @@ def _HolsteinFriesian_1M13():
             reasons={stdpopsim.CiteReason.DEM_MODEL},
         )
     ]
-
     return stdpopsim.DemographicModel(
         id=id,
         description=description,

--- a/stdpopsim/catalog/HomSap/demographic_models.py
+++ b/stdpopsim/catalog/HomSap/demographic_models.py
@@ -137,7 +137,7 @@ def _ooa_2():
     id = "OutOfAfrica_2T12"
     description = "Two population out-of-Africa"
     long_description = """
-        The model is derived from the Tennesen et al. analysis of the
+        The model is derived from the Tennessen et al. analysis of the
         jSFS from European Americans and African Americans.
         It describes the ancestral human population in Africa, the out of Africa event,
         and two distinct periods of subsequent European population growth over the past
@@ -292,7 +292,11 @@ def _america():
         demographic history to simulate an admixed population with admixture
         occurring 12 generations ago. The admixed population had an initial size
         of 30,000 and grew at a rate of 5% per generation, with 1/6 of the
-        population of African ancestry, 1/3 European, and 1/2 Asian.
+        population of African ancestry, 1/3 European, and 1/2 Asian. Note that this
+        demographic model was not inferred, and the assumed mutation rate is smaller
+        than used in the inference from Gravel et al. Resulting levels of diversity
+        may be considerably lower than observed in human population genetic data for
+        these populations.
     """
     populations = [
         stdpopsim.Population(id="AFR", description="Contemporary African population"),
@@ -598,6 +602,7 @@ def _zigzag():
     ]
 
     generation_time = 30
+
     N0 = 5 * 14312
 
     g_1 = 0.02302578256

--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -5,6 +5,7 @@ import attr
 import msprime
 import stdpopsim
 import numpy as np
+import math
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,19 @@ class Engine:
                 "sizes 5x lower than those in Schiffels & Durbin (2014). "
                 "The population sizes have now been corrected. For details see: "
                 "https://github.com/popsim-consortium/stdpopsim/issues/745"
+            )
+
+    def _warn_mutation_rate_mismatch(self, contig, demographic_model):
+        if demographic_model.mutation_rate is not None and not math.isclose(
+            demographic_model.mutation_rate, contig.mutation_rate
+        ):
+            warnings.warn(
+                "The demographic model has mutation rate "
+                f"{demographic_model.mutation_rate}, but this simulation used the "
+                f"contig's mutation rate {contig.mutation_rate}. Diversity levels "
+                "may be different than expected for this species. For details see "
+                "documentation at "
+                "https://stdpopsim.readthedocs.io/en/latest/tutorial.html"
             )
 
 
@@ -226,6 +240,7 @@ class _MsprimeEngine(Engine):
 
         # TODO: remove this after a release or two. See #745.
         self._warn_zigzag(demographic_model)
+        self._warn_mutation_rate_mismatch(contig, demographic_model)
 
         rng = np.random.default_rng(seed)
         seeds = rng.integers(1, 2 ** 31 - 1, size=2)

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -69,6 +69,9 @@ class DemographicModel:
     :ivar citations: A list of :class:`Citation`, that describe the primary
         reference(s) for the model.
     :vartype citations: list of :class:`Citation`
+    :ivar mutation_rate: The mutation rate associated with the demographic model.
+        If no mutation rate is given, the species' default mutation rate is used.
+    :vartype mutation_rate: float
     """
 
     def __init__(
@@ -86,11 +89,13 @@ class DemographicModel:
         population_id_map=None,
         populations=None,
         model=None,
+        mutation_rate=None,
     ):
         self.id = id
         self.description = description
         self.long_description = long_description
         self.generation_time = 1 if generation_time is None else generation_time
+        self.mutation_rate = mutation_rate
         self.citations = [] if citations is None else citations
         self.qc_model = qc_model
 
@@ -172,7 +177,7 @@ class DemographicModel:
             )
         if self.qc_model is not None:
             raise ValueError(f"QC model already registered for {self.id}.")
-        self.qc_model = qc_model.model
+        self.qc_model = qc_model
 
     def get_samples(self, *args):
         """

--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -247,7 +247,7 @@ def BrowningAmerica():
         id=id,
         description=id,
         long_description=id,
-        generation_time=_species.generation_time,
+        generation_time=25,
         populations=populations,
         # Set population sizes at T=0
         # pop0 is Africa, pop1 is Europe, pop2 is Asia, pop3 is admixed

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -1088,6 +1088,7 @@ class _SLiMEngine(stdpopsim.Engine):
 
         # TODO: remove this after a release or two. See #745.
         self._warn_zigzag(demographic_model)
+        self._warn_mutation_rate_mismatch(contig, demographic_model)
 
         run_slim = not slim_script
 

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -146,6 +146,7 @@ class Species:
         genetic_map=None,
         length_multiplier=1,
         length=None,
+        mutation_rate=None,
         inclusion_mask=None,
         exclusion_mask=None,
     ):
@@ -169,6 +170,8 @@ class Species:
             same chromosome-specific mutation and recombination rates.
             This option cannot currently be used in conjunction with the
             ``genetic_map`` argument.
+        :param float mutation_rate: The per-base mutation rate. If none is given,
+            the mutation rate defaults to the rate specified by species chromosomes.
         :param inclusion_mask: If specified, simulated genomes are subset to only
             inlude regions given by the mask. The mask can be specified by the
             path and file name of a bed file or as a list or array of intervals
@@ -211,10 +214,13 @@ class Species:
                     L_tot += chrom_data.length
                     r_tot += chrom_data.length * chrom_data.recombination_rate
                     u_tot += chrom_data.length * chrom_data.mutation_rate
-            u = u_tot / L_tot
+            if mutation_rate is None:
+                mutation_rate = u_tot / L_tot
             r = r_tot / L_tot
             recomb_map = msprime.RateMap.uniform(length, r)
-            ret = stdpopsim.Contig(recombination_map=recomb_map, mutation_rate=u)
+            ret = stdpopsim.Contig(
+                recombination_map=recomb_map, mutation_rate=mutation_rate
+            )
         else:
             if length is not None:
                 raise ValueError("Cannot specify sequence length for named contig")
@@ -255,9 +261,12 @@ class Species:
                 else:
                     exclusion_intervals = exclusion_mask
 
+            if mutation_rate is None:
+                mutation_rate = chrom.mutation_rate
+
             ret = stdpopsim.Contig(
                 recombination_map=recomb_map,
-                mutation_rate=chrom.mutation_rate,
+                mutation_rate=mutation_rate,
                 genetic_map=gm,
                 inclusion_mask=inclusion_intervals,
                 exclusion_mask=exclusion_intervals,


### PR DESCRIPTION
See #557.

The issue: implemented demographic models were originally inferred with certain assumptions about mutation rates, generation times, etc, which then are used to calibrate population size and demographic event timings. Since #556, #631, users can specify and simulate with contigs with user-defined mutation rates, so that mutation rates could be set to match what was assumed when a model was first inferred. However, unless a user is very familiar with the literature, they might not be aware that the species' default mutation rate does not match the model they want to use, so that outputs will have measures of diversity that are far too large or too small for that species without realizing it.

One solution, as proposed in #557, is to allow models to have their own mutation rates that can be stored and used instead of the default rate. The default behavior of this PR is to use the species' default rate if a mutation rate is not specified, but now mutation rates would be attributes of the demographic model that can be easily passed to `species.get_contig()`.

For example:
```python
import stdpopsim
species = stdpopsim.get_species("HomSap")
model = species.get_demographic_model("OutOfAfrica_3G09")
contig = species.get_contig("chr1", mutation_rate=model.mutation_rate)
```

This contig now has a mutation rate of 2.35e-8 instead of 1.29e-8. There are some models that don't have associated mutation rates (for example, they were calibrated using recombination rates), and those models can be left without mutation rates so that they use the species' default rate (`None` would default to species' default). This would require going back through and adding mutation rates to each species' demographic model and then have them be QC'd and verified, but I think it would be worth the effort.

I didn't make a ton of changes to each demographic model here or implement tests, since feedback would be really helpful here before spending the time to do that.