### PR TITLE
Fix ComeronCrossoverV2_dm6 and add tests.

### DIFF
--- a/stdpopsim/catalog/DroMel/genetic_maps.py
+++ b/stdpopsim/catalog/DroMel/genetic_maps.py
@@ -55,7 +55,7 @@ _gm = stdpopsim.GeneticMap(
         "DroMel/comeron2012v2_maps.tar.gz"
     ),
     sha256="79484e6042c36b06946af672cabf2ec3012b6bfc6e0018517c8e7be4769cd334",
-    file_pattern="genetic_map_comeron2012v2_dm6_chr{id}.txt",
+    file_pattern="comeron2012v2_maps/genetic_map_comeron2012v2_dm6_chr{id}.txt",
     citations=[
         stdpopsim.Citation(
             author="Comeron et al",

--- a/stdpopsim/genetic_maps.py
+++ b/stdpopsim/genetic_maps.py
@@ -101,7 +101,13 @@ class GeneticMap:
         # needs to be redownloaded.
         map_file = self.map_cache_dir / self.file_pattern.format(id=chrom.id)
         if map_file.exists():
-            recomb_map = msprime.RateMap.read_hapmap(map_file)
+            recomb_map = msprime.RateMap.read_hapmap(
+                map_file,
+                rate_col=2,
+                # TODO: set the sequence length. Unfortunately, some of our
+                # maps are shorter than our chromosomes, so this will fail.
+                # sequence_length=chrom.length
+            )
         else:
             warnings.warn(
                 "Recombination map not found for chromosome: '{}'"

--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -109,7 +109,7 @@ def untar(filename, path):
             # Due to security concerns, we only extract tarballs containing a
             # very restrictive set of file types. See the warning here:
             # https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
-            if not info.isfile():
+            if not (info.isfile() or info.isdir()):
                 raise ValueError(f"Tarball format error: member {info.name} not a file")
             if info.name.startswith("/") or info.name.startswith(".."):
                 raise ValueError(f"Refusing to extract {info.name} outside of {path}")


### PR DESCRIPTION
This lifts the restriction of not allowing directories in the
recombination map tarballs. We add a test for each genetic map,
which is not perfect, but at least completes in a reasonable amount
of time.

Closes #845.