### PR TITLE
Recalculate DroMel average chromosome rate

### DIFF
--- a/stdpopsim/catalog/DroMel/species.py
+++ b/stdpopsim/catalog/DroMel/species.py
@@ -35,16 +35,20 @@ _ComeronEtAl = stdpopsim.Citation(
     year=2012,
 )
 
-# Mean chromosomal rates, calculated from the Comeron 2012 map.
-# Chromosome 4 isn't in this map, so the weighted mean of 2L, 2R, 3L and 3R
-# was used instead.
+# Mean chromosomal rates, calculated by taking the
+# average of all rates in the
+# "ComeronCrossoverV2_dm6" genetic map, weighted by
+# their respective interval lengths.
+# Chromosome 4 isn't in this map, so the average of
+# 2L, 2R, 3L and 3R weighted by their respective
+# chromosome lengths was used instead.
 _recombination_rate_data = {
-    "2L": 2.4125016027908946e-08,
-    "2R": 2.2366522822806982e-08,
-    "3L": 1.7985794693631893e-08,
-    "3R": 1.7165556232922828e-08,
-    "4": 2.0085234464525437e-08,
-    "X": 2.9151053903465754e-08,
+    "2L": 2.40462600791e-08,
+    "2R": 2.23458641776e-08,
+    "3L": 1.79660308862e-08,
+    "3R": 1.71642045777e-08,
+    "4": 2.00579550709e-08,
+    "X": 2.89650687913e-08,
     "Y": 0,
     "mitochondrion_genome": 0,
 }

--- a/stdpopsim/catalog/DroSec/species.py
+++ b/stdpopsim/catalog/DroSec/species.py
@@ -27,17 +27,20 @@ _LegrandEtAl = stdpopsim.Citation(
     },
 )
 
-# We used recombination rates estimated in DroMel.
-# Mean chromosomal rates, calculated from the Comeron 2012 map.
-# Chromosome 4 isn't in this map, so the weighted mean of 2L, 2R, 3L and 3R
-# was used instead.
+# Mean chromosomal rates, calculated by taking the
+# average of all rates in the
+# "ComeronCrossoverV2_dm6" genetic map, weighted by
+# their respective interval lengths.
+# Chromosome 4 isn't in this map, so the average of
+# 2L, 2R, 3L and 3R weighted by their respective
+# chromosome lengths was used instead.
 _recombination_rate = {
-    "2L": 2.4125016027908946e-08,
-    "2R": 2.2366522822806982e-08,
-    "3L": 1.7985794693631893e-08,
-    "3R": 1.7165556232922828e-08,
-    "X": 2.9151053903465754e-08,
-    "4": 2.0085234464525437e-08,
+    "2L": 2.40462600791e-08,
+    "2R": 2.23458641776e-08,
+    "3L": 1.79660308862e-08,
+    "3R": 1.71642045777e-08,
+    "4": 2.00579550709e-08,
+    "X": 2.89650687913e-08,
 }
 
 # Mutation rate is set to that used by
@@ -68,7 +71,6 @@ _genome = stdpopsim.Genome.from_data(
         _LegrandEtAl,
     ],
 )
-
 
 # Generation time was set to that used by
 # by Legrand et al. in an ABC selection of demographic


### PR DESCRIPTION
- Recalculated the average chromosome recombination rate for DroMel based off of the newer liftover map, "ComeronCrossoverV2_dm6". 
- Added a description to explain how this was done and which map was used. 
- Changed the rates in DroSec to reflect these changes.