### PR TITLE
Synonyms

### DIFF
--- a/stdpopsim/catalog/AedAeg/species.py
+++ b/stdpopsim/catalog/AedAeg/species.py
@@ -63,7 +63,7 @@ _genome = stdpopsim.Genome.from_data(
         _KeightleyEtAl,
     ],
 )
-
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="AedAeg",

--- a/stdpopsim/catalog/AnaPla/species.py
+++ b/stdpopsim/catalog/AnaPla/species.py
@@ -167,6 +167,7 @@ _genome = stdpopsim.Genome.from_data(
         _HuangEtAl2006,
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="AnaPla",

--- a/stdpopsim/catalog/AnoCar/species.py
+++ b/stdpopsim/catalog/AnoCar/species.py
@@ -68,6 +68,7 @@ _genome = stdpopsim.Genome.from_data(
     mutation_rate=_mutation_rate,
     citations=[_BourgeoisEtAl],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="AnoCar",

--- a/stdpopsim/catalog/AnoGam/species.py
+++ b/stdpopsim/catalog/AnoGam/species.py
@@ -58,6 +58,7 @@ _genome = stdpopsim.Genome.from_data(
         _PombiEtAl,
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="AnoGam",

--- a/stdpopsim/catalog/AraTha/species.py
+++ b/stdpopsim/catalog/AraTha/species.py
@@ -49,6 +49,7 @@ _genome = stdpopsim.Genome(
         ),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="AraTha",

--- a/stdpopsim/catalog/BosTau/species.py
+++ b/stdpopsim/catalog/BosTau/species.py
@@ -78,6 +78,7 @@ _genome = stdpopsim.Genome(
         _MaEtAl,
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="BosTau",

--- a/stdpopsim/catalog/CanFam/species.py
+++ b/stdpopsim/catalog/CanFam/species.py
@@ -102,6 +102,7 @@ _genome = stdpopsim.Genome(
         _LindbladTohEtAl.because(stdpopsim.CiteReason.ASSEMBLY),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="CanFam",

--- a/stdpopsim/catalog/ChlRei/species.py
+++ b/stdpopsim/catalog/ChlRei/species.py
@@ -77,6 +77,7 @@ _genome = stdpopsim.Genome.from_data(
         ),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="ChlRei",

--- a/stdpopsim/catalog/DroMel/species.py
+++ b/stdpopsim/catalog/DroMel/species.py
@@ -66,7 +66,6 @@ for name, data in genome_data.data["chromosomes"].items():
         )
     )
 
-
 _genome = stdpopsim.Genome(
     chromosomes=_chromosomes,
     assembly_name=genome_data.data["assembly_name"],
@@ -78,6 +77,7 @@ _genome = stdpopsim.Genome(
         _ComeronEtAl.because(stdpopsim.CiteReason.REC_RATE),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="DroMel",

--- a/stdpopsim/catalog/DroSec/species.py
+++ b/stdpopsim/catalog/DroSec/species.py
@@ -71,6 +71,7 @@ _genome = stdpopsim.Genome.from_data(
         _LegrandEtAl,
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 # Generation time was set to that used by
 # by Legrand et al. in an ABC selection of demographic

--- a/stdpopsim/catalog/EscCol/species.py
+++ b/stdpopsim/catalog/EscCol/species.py
@@ -48,7 +48,7 @@ _genome = stdpopsim.Genome(
         _blattner_et_al.because(stdpopsim.CiteReason.ASSEMBLY),
     ],
 )
-
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="EscCol",
@@ -69,6 +69,5 @@ _species = stdpopsim.Species(
         _hartl_et_al.because(stdpopsim.CiteReason.POP_SIZE),
     ],
 )
-
 
 stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/HelMel/species.py
+++ b/stdpopsim/catalog/HelMel/species.py
@@ -70,6 +70,7 @@ _genome = stdpopsim.Genome.from_data(
         ),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="HelMel",

--- a/stdpopsim/catalog/HomSap/species.py
+++ b/stdpopsim/catalog/HomSap/species.py
@@ -87,6 +87,7 @@ _genome = stdpopsim.Genome(
         _hapmap2007.because(stdpopsim.CiteReason.REC_RATE),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="HomSap",

--- a/stdpopsim/catalog/PonAbe/species.py
+++ b/stdpopsim/catalog/PonAbe/species.py
@@ -67,6 +67,7 @@ _genome = stdpopsim.Genome(
     assembly_accession=genome_data.data["assembly_accession"],
     citations=[_nater2017],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 _species = stdpopsim.Species(
     id="PonAbe",

--- a/stdpopsim/catalog/StrAga/species.py
+++ b/stdpopsim/catalog/StrAga/species.py
@@ -57,6 +57,7 @@ _genome = stdpopsim.Genome.from_data(
         _DaCunha_et_al.because(stdpopsim.CiteReason.MUT_RATE),
     ],
 )
+stdpopsim.utils.append_common_synonyms(_genome)
 
 # Generation time :
 #  No estimation was done for S agalactiae, but we can use estimates from E coli (which

--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -148,3 +148,25 @@ def mask_tree_sequence(ts, mask_intervals, exclude):
     else:
         ts = ts.delete_intervals(mask_intervals)
     return ts
+
+
+def append_common_synonyms(genome):
+    """
+    For common chromosome IDs, add their obvious synonyms if they do not exist already.
+    The input is a stdpopsim.Genome object, and synonyms are appended in place.
+    """
+
+    def add_if_unique(chrom, syn):
+        if syn not in chrom.synonyms:
+            chrom.synonyms.append(syn)
+
+    for chrom in genome.chromosomes:
+        # "1" -> "chr1" and "2L" -> "chr2L"
+        if chrom.id[0].isdigit():
+            add_if_unique(chrom, "chr" + chrom.id)
+        # sex chroms
+        if chrom.id in ["X", "Y", "W", "Z"]:
+            add_if_unique(chrom, "chr" + chrom.id)
+        # Mt
+        if chrom.id == "MT":
+            add_if_unique(chrom, "chr" + "M")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import tarfile
 import tempfile
 
 from stdpopsim import utils
+from stdpopsim import Chromosome, Genome
 
 
 class TestValidDemographicModelId(unittest.TestCase):
@@ -372,3 +373,64 @@ class TestUntar(unittest.TestCase):
                     utils.untar(tar, dest)
                 rm_f(filename)
                 rm_f(tar)
+
+
+class TestSynonyms(unittest.TestCase):
+    def test_add_digit_autosomes(self):
+        chroms = [
+            Chromosome(
+                id="1",
+                length=100,
+                synonyms=[],
+                mutation_rate=1e-8,
+                recombination_rate=1e-8,
+            )
+        ]
+        genome = Genome(chroms)
+        utils.append_common_synonyms(genome)
+        self.assertTrue("chr1" in genome.chromosomes[0].synonyms)
+
+    def test_add_drosophila_like_synonyms(self):
+        chroms = [
+            Chromosome(
+                id="1a",
+                length=100,
+                synonyms=[],
+                mutation_rate=1e-8,
+                recombination_rate=1e-8,
+            )
+        ]
+        genome = Genome(chroms)
+        utils.append_common_synonyms(genome)
+        self.assertTrue("chr1a" in genome.chromosomes[0].synonyms)
+
+    def test_add_sex_chrom_synonyms(self):
+        chroms = [
+            Chromosome(
+                id=s,
+                length=100,
+                synonyms=[],
+                mutation_rate=1e-8,
+                recombination_rate=1e-8,
+            )
+            for s in ["X", "Y", "Z", "W"]
+        ]
+        genome = Genome(chroms)
+        utils.append_common_synonyms(genome)
+        for chrom in genome.chromosomes:
+            self.assertTrue("chr" + chrom.id in chrom.synonyms)
+
+    def test_add_only_unique_synonyms(self):
+        chroms = [
+            Chromosome(
+                id="1",
+                length=100,
+                synonyms=["chr1"],
+                mutation_rate=1e-8,
+                recombination_rate=1e-8,
+            )
+        ]
+        genome = Genome(chroms)
+        utils.append_common_synonyms(genome)
+        self.assertTrue("chr1" in genome.chromosomes[0].synonyms)
+        self.assertEqual(len(genome.chromosomes[0].synonyms), 1)


### PR DESCRIPTION
An idea (WIP) to tackle #902. Would fill chromosome synonyms if the chrom.id is a common name (e.g. "1" -> "chr1", "2L" -> "chr2L", "MT" -> "chrM"). It's fairly automated, should be fairly universal, and protects against common synonym errors when ensembl doesn't fill that field.