### PR TITLE
Catalog mutation rates

### DIFF
--- a/docs/parameter_tables/AraTha/African2Epoch_1H18.csv
+++ b/docs/parameter_tables/AraTha/African2Epoch_1H18.csv
@@ -1,3 +1,5 @@
 Population size,"746,148",Ancestral pop. size
 Population size,"100,218",Pop. size during second epoch
 Epoch Time (gen.),"568,344",Time of second epoch
+Generation time (yrs.),1,Average generation interval
+Mutation rate,7e-9,Per-base per-generation mutation rate

--- a/docs/parameter_tables/AraTha/African3Epoch_1H18.csv
+++ b/docs/parameter_tables/AraTha/African3Epoch_1H18.csv
@@ -3,3 +3,5 @@ Population size,"24,076",Pop. size during second epoch
 Population size,"203,077",Pop. size during Third epoch
 Epoch Time (gen.),"7,420",Time of second epoch
 Epoch Time (gen.),"14,534",Time of third epoch
+Generation time (yrs.),1,Average generation interval
+Mutation rate,7e-9,Per-base per-generation mutation rate

--- a/docs/parameter_tables/AraTha/SouthMiddleAtlas_1D17.csv
+++ b/docs/parameter_tables/AraTha/SouthMiddleAtlas_1D17.csv
@@ -39,3 +39,5 @@ Time (yrs.),"91,648",Begining of 17th time interval
 Time (yrs.),"75,958",Begining of 18th time interval
 Time (yrs.),"62,544",Begining of 19th time interval
 Time (yrs.),"51,077",Begining of 20th time interval
+Generation time (yrs.),1,Average generation interval
+Mutation rate,7.1e-9,Per-base per-generation mutation rate

--- a/docs/parameter_tables/BosTau/HolsteinFriesian_1M13.csv
+++ b/docs/parameter_tables/BosTau/HolsteinFriesian_1M13.csv
@@ -24,3 +24,4 @@ Time (gen.),"12",Begining of 10th time interval
 Time (gen.),"6",Begining of 11th time interval
 Time (gen.),"3",Begining of 12th time interval
 Generation time (yrs.),5,Generation time
+Mutation rate,1e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/DroMel/African3Epoch_1S16.csv
+++ b/docs/parameter_tables/DroMel/African3Epoch_1S16.csv
@@ -5,3 +5,4 @@ Population size,"544,200",Recent pop. size
 Epoch Time (gen.),"2,200,000",Onset of bottleneck
 Epoch Time (gen.),"200,000",Population expansion
 Generation time (yrs.),0.1,Generation time
+Mutation rate,8.4e-9,Per-base per-generation mutation rate

--- a/docs/parameter_tables/DroMel/OutOfAfrica_2L06.csv
+++ b/docs/parameter_tables/DroMel/OutOfAfrica_2L06.csv
@@ -6,3 +6,4 @@ Epoch Time (gen.),"600,000",Expansion of population in Africa
 Epoch Time (gen.),"158,000",African-European divergence
 Epoch Time (gen.),"154,600",European pop. Expansion
 Generation time (yrs.),0.1,Generation time
+Mutation rate,1.45e-9,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/Africa_1T12.csv
+++ b/docs/parameter_tables/HomSap/Africa_1T12.csv
@@ -5,3 +5,4 @@ Growth rate (per gen.),0.0166,AFR pop. growth rate 1st expansion
 Epoch Time (gen.),"5,920",Expansion time of ancestral pop.
 Epoch Time (gen.),204.6,Beginning of AFR growth period
 Generation time (yrs.),25,Generation time
+Mutation rate,2.36e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/AmericanAdmixture_4B11.csv
+++ b/docs/parameter_tables/HomSap/AmericanAdmixture_4B11.csv
@@ -19,3 +19,4 @@ ADMIX percentage, 1/6,Amount African admixture
 ADMIX percentage, 1/3,Amount European admixture
 ADMIX percentage, 1/2,Amount Asian admixture
 Generation time (yrs.),25,Generation time
+Mutation rate,2.36e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/AncientEurasia_9K19.csv
+++ b/docs/parameter_tables/HomSap/AncientEurasia_9K19.csv
@@ -28,3 +28,4 @@ Time (yrs.),"24,000",Time of MAl'ta samples
 Time (yrs.),"45,000",Time of Ust'-Ishim samples
 Time (yrs.),"50,000",Time of Neanderthal samples
 Generation time (yrs.),25,Generation time
+Mutation rate,1.22e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/AshkSub_7G19.csv
+++ b/docs/parameter_tables/HomSap/AshkSub_7G19.csv
@@ -17,3 +17,4 @@ Epoch Time (gen.),"14",Time of Eastern-Western AJ split
 Epoch Time (gen.),"13",Time of AJ growth (not inferred)
 ADMIX percentage, 0.17, European to AJ gene flow
 Generation time (yrs.),25,Generation time
+Mutation rate,2.5e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/OutOfAfrica_2T12.csv
+++ b/docs/parameter_tables/HomSap/OutOfAfrica_2T12.csv
@@ -15,3 +15,4 @@ Epoch Time (gen.),"2,040",Time of OOA event
 Epoch Time (gen.),920,Beginning of 1st EU growth period
 Epoch Time (gen.),204.6,Beginning of 2nd EU/1st AFR growth period
 Generation time (yrs.),25,Generation time
+Mutation rate,2.36e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/OutOfAfrica_3G09.csv
+++ b/docs/parameter_tables/HomSap/OutOfAfrica_3G09.csv
@@ -13,3 +13,4 @@ Epoch Time (gen.),"8,800",Expansion time of ancestral pop.
 Epoch Time (gen.),"5,600",Time of OOA event
 Epoch Time (gen.),848,Time of CEU-CHB split
 Generation time (yrs.),25,Generation time
+Mutation rate,2.35e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/OutOfAfrica_4J17.csv
+++ b/docs/parameter_tables/HomSap/OutOfAfrica_4J17.csv
@@ -20,3 +20,4 @@ Epoch Time (thousands of years ago),119,Time of OOA event
 Epoch Time (thousands of years ago),46,Time of CEU-CHB split
 Epoch Time (thousands of years ago),9,Time of CHB-JPT split
 Generation time (years),29,Years per generation
+Mutation rate,1.44e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/HomSap/PapuansOutOfAfrica_10J19.csv
+++ b/docs/parameter_tables/HomSap/PapuansOutOfAfrica_10J19.csv
@@ -1,4 +1,3 @@
-Generation time (yrs.),29,Generation time
 Population size,"48,433",African pop. size
 Population size,"6,962",European pop. size
 Population size,"9,025",East Asian pop. size
@@ -51,3 +50,5 @@ Migration rate (x10^-4),5.72,(European + East Asian)--Papuan migration rate
 Migration rate (x10^-4),4.42,(European + East Asian)--Ghost migration rate
 Time (yrs.),"37,497",(European + East Asian)--Papuan migration begins
 Time (yrs.),"37,497",(European + East Asian)--Ghost migration begins
+Generation time (yrs.),29,Generation time
+Mutation rate,1.4e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/PonAbe/TwoSpecies_2L11.csv
+++ b/docs/parameter_tables/PonAbe/TwoSpecies_2L11.csv
@@ -5,3 +5,4 @@ Population size,"8,805",Modern Pongo pygmaeus pop. size
 Population size,"37,661",Modern Pongo abelii pop. size
 Epoch Time (gen.),"20,157",Species divergence time
 Generation time (yrs.),20,Generation time
+Mutation rate,2e-8,Per-base per-generation mutation rate

--- a/stdpopsim/catalog/AnoGam/demographic_models.py
+++ b/stdpopsim/catalog/AnoGam/demographic_models.py
@@ -487,7 +487,9 @@ def _GAS_sp():
                 reasons={stdpopsim.CiteReason.DEM_MODEL},
             )
         ],
+        # generation times and mutation rate given at bottom of page 32 in supp info
         generation_time=1 / 11,
+        mutation_rate=3.5e-9,
         demographic_events=demographic_events,
         population_configurations=[
             msprime.PopulationConfiguration(

--- a/stdpopsim/catalog/AraTha/demographic_models.py
+++ b/stdpopsim/catalog/AraTha/demographic_models.py
@@ -125,6 +125,7 @@ def _sma_1pop():
             )
         ],
         generation_time=1,
+        mutation_rate=7.1e-9,
         demographic_events=demographic_events,
         population_configurations=[
             msprime.PopulationConfiguration(
@@ -167,6 +168,7 @@ def _afr_2epoch():
             )
         ],
         generation_time=1,
+        mutation_rate=7e-9,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_0, metadata=populations[0].asdict()
@@ -218,6 +220,7 @@ def _afr_3epoch():
             )
         ],
         generation_time=1,
+        mutation_rate=7e-9,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_3, metadata=populations[0].asdict()

--- a/stdpopsim/catalog/BosTau/demographic_models.py
+++ b/stdpopsim/catalog/BosTau/demographic_models.py
@@ -30,6 +30,7 @@ def _HolsteinFriesian_1M13():
         populations=populations,
         citations=citations,
         generation_time=_species.generation_time,
+        mutation_rate=1e-8,
         population_configurations=[
             #      3 generations at    90,     1-     3
             msprime.PopulationConfiguration(

--- a/stdpopsim/catalog/DroMel/demographic_models.py
+++ b/stdpopsim/catalog/DroMel/demographic_models.py
@@ -40,6 +40,7 @@ def _afr_3epoch():
         )
     ]
     generation_time = _species.generation_time
+    mutation_rate = 8.4e-9
 
     # Parameter values from "Simulating Data" section
     # these are assumptions, not estimates
@@ -62,6 +63,7 @@ def _afr_3epoch():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_R, metadata=populations[0].asdict()
@@ -94,6 +96,7 @@ def _ooa_2():
     populations = [_afr_population, _eur_population]
     citations = [_LiAndStephan.because(stdpopsim.CiteReason.DEM_MODEL)]
     generation_time = _species.generation_time
+    mutation_rate = 1.45e-9  # using the average mutation rate (see citation Methods)
 
     # African Parameter values from "Demographic History of the African
     # Population" section
@@ -114,6 +117,7 @@ def _ooa_2():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_A0, metadata=populations[0].asdict()

--- a/stdpopsim/catalog/HomSap/demographic_models.py
+++ b/stdpopsim/catalog/HomSap/demographic_models.py
@@ -57,6 +57,7 @@ def _ooa_3():
     ]
 
     generation_time = 25
+    mutation_rate = 2.35e-8
 
     # First we set out the maximum likelihood values of the various parameters
     # given in Table 1.
@@ -89,6 +90,7 @@ def _ooa_3():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         # Population IDs correspond to their indexes in the population
         # configuration array. Therefore, we have 0=YRI, 1=CEU and 2=CHB
         # initially.
@@ -158,6 +160,7 @@ def _ooa_2():
     ]
 
     generation_time = 25
+    mutation_rate = 2.36e-8  # from Gravel et al, 2011, PNAS
 
     T_AF = 148e3 / generation_time
     T_OOA = 51e3 / generation_time
@@ -191,6 +194,7 @@ def _ooa_2():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_AF, growth_rate=r_AF, metadata=populations[0].asdict()
@@ -243,6 +247,7 @@ def _african():
     citations = [_tennessen_et_al]
 
     generation_time = 25
+    mutation_rate = 2.36e-8  # from Gravel et al, 2011, PNAS
 
     T_AF = 148e3 / generation_time
     T_EG = 5115 / generation_time
@@ -264,6 +269,7 @@ def _african():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_AF, growth_rate=r_AF, metadata=populations[0].asdict()
@@ -293,10 +299,9 @@ def _america():
         occurring 12 generations ago. The admixed population had an initial size
         of 30,000 and grew at a rate of 5% per generation, with 1/6 of the
         population of African ancestry, 1/3 European, and 1/2 Asian. Note that this
-        demographic model was not inferred, and the assumed mutation rate is smaller
-        than used in the inference from Gravel et al. Resulting levels of diversity
-        may be considerably lower than observed in human population genetic data for
-        these populations.
+        demographic model was not inferred, and the mutation rate that Browning et al.
+        used for simulation is smaller than used for inferring the model,
+        so the mutation rate provided here is that from Gravel et al.
     """
     populations = [
         stdpopsim.Population(id="AFR", description="Contemporary African population"),
@@ -308,13 +313,20 @@ def _america():
     citations = [
         stdpopsim.Citation(
             author="Browning et al.",
-            year=2011,
+            year=2018,
             doi="http://dx.doi.org/10.1371/journal.pgen.1007385",
             reasons={stdpopsim.CiteReason.DEM_MODEL},
-        )
+        ),
+        stdpopsim.Citation(
+            author="Gravel et al.",
+            year=2011,
+            doi="https://doi.org/10.1073/pnas.1019276108",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
     ]
 
     generation_time = 25
+    mutation_rate = 2.36e-8
 
     # Model code was ported from Supplementary File 1.
     N0 = 7310  # initial population size
@@ -401,6 +413,7 @@ def _america():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=population_configurations,
         migration_matrix=migration_matrix,
         demographic_events=demographic_events,
@@ -454,6 +467,10 @@ def _ooa_archaic():
     # In the published model, the authors used a generation time of 29 years to
     # convert from genetic to physical units
     generation_time = 29
+    # calibration of this demographic model used the recombination instead of mutation
+    # rate - as such, levels of diversity using the species default rate may not match
+    # expectations or observations in human data
+    mutation_rate = None
 
     T_AF = 300e3 / generation_time
     T_B = 60.7e3 / generation_time
@@ -572,6 +589,7 @@ def _ooa_archaic():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=population_configurations,
         migration_matrix=migration_matrix,
         demographic_events=demographic_events,
@@ -602,6 +620,9 @@ def _zigzag():
     ]
 
     generation_time = 30
+    # In the original ms from Schiffels & Durbin, a mutation rate of 1.25e-8 was used.
+    # Here, we set the rate to None, as this is not a model inferred from data.
+    mutation_rate = None
 
     N0 = 5 * 14312
 
@@ -647,6 +668,7 @@ def _zigzag():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=population_configurations,
         demographic_events=demographic_events,
     )
@@ -733,7 +755,8 @@ def _kamm_ancient_eurasia():
 
     # Times are provided in years, so we convert into generations.
     generation_time = 25
-    # Mutation_rate in Kamm et al. = 1.22e-8
+    mutation_rate = 1.22e-8
+
     # Effective population sizes
     N_Losch = 1920
     N_Mbu = 17300
@@ -893,6 +916,7 @@ def _kamm_ancient_eurasia():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=population_configurations,
         demographic_events=demographic_events,
     )
@@ -959,8 +983,8 @@ def _papuans_10j19():
     ]
 
     # Inherited from Malaspinas et al., which gives the following refs:
-    generation_time = 29  # Fenner 2005
-    # mutation_rate = 1.25e-8  # per gen per site, Scally & Durbin 2012
+    generation_time = 29
+    mutation_rate = 1.4e-8
 
     N_YRI = 48433
     N_Ghost = 8516
@@ -1211,6 +1235,7 @@ def _papuans_10j19():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=population_configurations,
         migration_matrix=migration_matrix,
         demographic_events=demographic_events,
@@ -1262,6 +1287,7 @@ def _AJ():
     ]
 
     generation_time = 25
+    mutation_rate = 2.5e-8
 
     # parameter value definitions based on mode from ABC
     # found in Table S3 of Gladstein and Hammer 2019
@@ -1300,6 +1326,7 @@ def _AJ():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=NYRI, metadata=populations[0].asdict()
@@ -1395,6 +1422,7 @@ def _ooa_4pop():
     ]
 
     generation_time = 29
+    mutation_rate = 1.44e-8  # from Gravel et al. 2013 (Plos Gen)
 
     # Parameter values from Table 4 (in bold)
 
@@ -1512,6 +1540,7 @@ def _ooa_4pop():
         populations=populations,
         citations=citations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=population_configurations,
         migration_matrix=migration_matrix,
         demographic_events=demographic_events,

--- a/stdpopsim/catalog/PonAbe/demographic_models.py
+++ b/stdpopsim/catalog/PonAbe/demographic_models.py
@@ -40,6 +40,8 @@ def _orangutan():
     T_split_years = 403149
     # get split time in units of generations
     generation_time = _species.generation_time
+    mutation_rate = 2e-8
+
     T_split = T_split_years / generation_time
 
     # proportion of ancestral pop to branch B
@@ -72,6 +74,7 @@ def _orangutan():
         citations=citations,
         populations=populations,
         generation_time=generation_time,
+        mutation_rate=mutation_rate,
         population_configurations=[
             msprime.PopulationConfiguration(
                 initial_size=N_B, growth_rate=r_B, metadata=populations[0].asdict()

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -150,6 +150,7 @@ class DemographicModel:
             f"║  description      = {self.description}\n"
             f"║  long_description = {long_desc}\n"
             f"║  generation_time  = {self.generation_time}\n"
+            f"║  mutation_rate    = {self.mutation_rate}\n"
             f"║  citations        = {[cite.doi for cite in self.citations]}\n"
             f"║{self.model}"
         )

--- a/stdpopsim/qc/AraTha.py
+++ b/stdpopsim/qc/AraTha.py
@@ -122,6 +122,7 @@ def Durvasula2017MSMC():
         population_configurations=population_configurations,
         demographic_events=demographic_events,
         population_id_map=[{"SouthMiddleAtlas": 0}] * 33,
+        mutation_rate=7.1e-9,
     )
 
 
@@ -157,6 +158,9 @@ def HuberTwoEpoch():
             ),
         ],
         population_id_map=[{"SouthMiddleAtlas": 0}] * 2,
+        # Huber et al say "7e-9" but then refer to Ossowski,
+        # which Durvasula reported as giving 7.1e-9
+        mutation_rate=7e-9,
     )
 
 
@@ -197,6 +201,9 @@ def HuberThreeEpoch():
             ),
         ],
         population_id_map=[{"SouthMiddleAtlas": 0}] * 3,
+        # Huber et al say "7e-9" but then refer to Ossowski,
+        # which Durvasula reported as giving 7.1e-9
+        mutation_rate=7e-9,
     )
 
 

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -60,6 +60,7 @@ def LiStephanTwoPopulation():
             {"AFR": 0, "EUR": 1},
             {"AFR": 0, "EUR": 1},
         ],
+        mutation_rate=1.450e-9,
     )
 
 
@@ -109,6 +110,7 @@ def SheehanSongThreeEpic():
             ),
         ],
         population_id_map=[{"AFR": 0}] * 3,
+        mutation_rate=8.4e-9,
     )
 
 

--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -80,6 +80,9 @@ def TennessenOnePopAfrica():
             {"AFR": 0},
             {"AFR": 0},
         ],
+        # I'm guessing the took the mutation rate to be the same as in Gravel et al 2011,
+        # (doi: 10.1073/pnas.1019276108), where they got the demographic model from
+        mutation_rate=2.36e-8,
     )
 
 
@@ -193,6 +196,9 @@ def TennessenTwoPopOutOfAfrica():
             {"AFR": 0, "EUR": 1},
             {"AFR": 0, "EUR": 1},
         ],
+        # I'm guessing the took the mutation rate to be the same as in Gravel et al 2011,
+        # (doi: 10.1073/pnas.1019276108), where they got the demographic model from
+        mutation_rate=2.36e-8,
     )
 
 
@@ -317,6 +323,8 @@ def BrowningAmerica():
             {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
             {"AFR": 0, "EUR": 1, "ASIA": 2, "ADMIX": 3},
         ],
+        # the model derives from Gravel et al, who used this rate
+        mutation_rate=2.36e-8,
     )
 
 
@@ -473,6 +481,12 @@ def RagsdaleArchaic():
             {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
             {"YRI": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
         ],
+        # the method depends on recombination rate, not mutation rate: "This
+        # normalization removes all dependence of the statistics on the overall
+        # mutation rate, so that estimates of split times and population sizes
+        # are calibrated by the recombination rate per generation instead of
+        # the mutation rate"
+        mutation_rate=None,
     )
 
 
@@ -684,6 +698,8 @@ def KammAncientSamples():
         # population IDs in this model.
         # Note: we'll be updating this map as the model is modernised.
         population_id_map=[pop_id_map] * 13,
+        # this is a prediction of the paper rather than an assumption
+        mutation_rate=1.22e-8,
     )
 
 
@@ -990,6 +1006,7 @@ def DenisovanAncestryInPapuans():
         # population IDs in this model.
         # Note: we'll be updating this map as the model is modernised.
         population_id_map=[pop_id_map] * 19,
+        mutation_rate=1.4e-8,
     )
 
 
@@ -1076,6 +1093,7 @@ def GutenkunstOOA():
             {"YRI": 0, "CEU": 1, "CHB": 2},
             {"YRI": 0, "CEU": 1, "CHB": 2},
         ],
+        mutation_rate=2.35e-8,
     )
 
 
@@ -1168,6 +1186,7 @@ def GladsteinAshkSubstructure():
             {"YRI": 0, "CHB": 1, "CEU": 2, "ME": 3, "J": 4, "WAJ": 5, "EAJ": 6},
         ]
         * 10,
+        mutation_rate=2.5e-8,
     )
 
 
@@ -1231,6 +1250,8 @@ def ZigZag():
         population_configurations=population_configurations,
         demographic_events=de,
         population_id_map=[{"generic": 0}] * 7,
+        # This is a test model, not inferred from actual data.
+        mutation_rate=None,
     )
 
 

--- a/stdpopsim/qc/PonAbe.py
+++ b/stdpopsim/qc/PonAbe.py
@@ -18,6 +18,7 @@ def LockePongo():
     # decay allowed in each population after the split. They assumed a
     # generation time of 20 years and a mutation rate of 2e-8 per bp per gen
     generation_time = 20
+    mutation_rate = 2e-8
 
     # Parameters given in Table S21-2
     Ne = 17934
@@ -57,6 +58,7 @@ def LockePongo():
             {"Bornean": 0, "Sumatran": 1},
             {"Bornean": 0, "Sumatran": 1},
         ],
+        mutation_rate=mutation_rate,
     )
 
 

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -111,7 +111,9 @@ class TestMasking(unittest.TestCase):
         # check we get the right number of trees (simulated with no recomb)
         self.assertTrue(ts_mask.num_trees == len(intervals) * 2 - 1)
         # check that positions of mutations in ts_mask are within mask
-        positions = np.array([m.position for m in ts_mask.mutations()])
+        positions = np.array(
+            [ts_mask.site(m.site).position for m in ts_mask.mutations()]
+        )
         self.assertTrue(np.all(np.logical_and(100 <= positions, positions < 200)))
 
 
@@ -136,7 +138,7 @@ class TestSimulate(unittest.TestCase):
                 demographic_model=model, contig=contig, samples=samples
             )
             # check that positions of mutations are within mask
-            positions = np.array([m.position for m in ts.mutations()])
+            positions = np.array([ts.site(m.site).position for m in ts.mutations()])
             self.assertTrue(np.all(positions >= L // 2))
 
             # test engine with inclusion mask
@@ -146,5 +148,5 @@ class TestSimulate(unittest.TestCase):
                 demographic_model=model, contig=contig, samples=samples
             )
             # check that positions of mutations are within mask
-            positions = np.array([m.position for m in ts.mutations()])
+            positions = np.array([ts.site(m.site).position for m in ts.mutations()])
             self.assertTrue(np.all(positions < L // 2))


### PR DESCRIPTION
Add mutation rates to the cataloged demographic models for each species and the parameter tables in docs.

I'm not sure the best way to do this, but each QC model will also need to have mutation rates added. It took me maybe a half hour to follow the doi in each demographic model to the source publication to find the mutation rate used in inference, and *most* were quite obvious. Perhaps someone would be willing to do the same for the QC models and commit to this same PR, so that tests will make sure that mutation rates match between models and their QCs? Any takers? :slightly_smiling_face: