### PR TITLE
fix zigzag parameter table

### DIFF
--- a/docs/parameter_tables/HomSap/Zigzag_1S14.csv
+++ b/docs/parameter_tables/HomSap/Zigzag_1S14.csv
@@ -1,5 +1,5 @@
-Population size,"1,431",Ancient pop. size
-Population size,"14,312",Recent pop. size
+Population size,"7,156",Ancient pop. size
+Population size,"71,560",Recent pop. size
 Growth rate (per gen.),"8.99448 x 10^(-5)",Growth rate for 1st growth
 Growth rate (per gen.),-0.00035977,Growth rate for 1st decline
 Growth rate (per gen.),0.0014391,Growth rate for 2nd growth


### PR DESCRIPTION
During the fix to the population sizes in the ZigZag model (detailed in #745), the parameter table in the docs weren't updated to reflect that the ancient and recent population sizes should be 5x higher