### PR TITLE
Annot fixup

### DIFF
--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -3,3 +3,4 @@ Code used for internal maintenance tasks.
 """
 from .ensembl import *  # noqa
 from .ncbi import *  # noqa
+from .annotation_maint import *  # noqa

--- a/maintenance/main.py
+++ b/maintenance/main.py
@@ -16,6 +16,7 @@ import daiquiri
 import stdpopsim
 from . import ensembl
 from . import ncbi
+from . import annotation_maint
 
 logger = logging.getLogger("maint")
 
@@ -387,6 +388,16 @@ def add_species_ncbi(ncbi_id, force):
     """
     writer = DataWriter()
     writer.add_species_ncbi(ncbi_id, force=force)
+
+
+@cli.command()
+def process_annotations():
+    """
+    downloads annotations in catalog and preps them for
+    upload to aws
+    """
+    click.echo("downloading annotations")
+    annotation_maint.download_process_annotations()
 
 
 def main():

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -26,3 +26,4 @@ zarr>=2.4
 biopython
 demes==0.1.2
 demesdraw==0.1.4
+boto3

--- a/stdpopsim/annotations.py
+++ b/stdpopsim/annotations.py
@@ -2,35 +2,12 @@
 Infrastructure for defining information about genome annotation.
 """
 import logging
-
+import os
 import attr
-import pandas
-import zarr
-
+import numpy as np
 import stdpopsim
 
 logger = logging.getLogger(__name__)
-
-
-def zarr_to_dataframe(path):
-    """
-    converts zarr annotation file to
-    pandas dataframe for manipulations
-    """
-    z = zarr.open(path)
-    df = pandas.DataFrame(
-        {
-            "seqid": z["seqid"],
-            "source": z["source"],
-            "type": z["type"],
-            "start": z["start"],
-            "end": z["end"],
-            "score": z["score"],
-            "strand": z["strand"],
-            "phase": z["phase"],
-        }
-    )
-    return df
 
 
 @attr.s(kw_only=True)
@@ -42,28 +19,33 @@ class Annotation:
     :ivar species: The species to which this annotation applies.
     :vartype species: :class:`.Species`
     :ivar str url: The URL where the packed and compressed GFF3 can be found.
-    :ivar str zarr_url: The URL of the zarr cache of the GFF3.
-    :ivar str zarr_sha256: The SHA256 checksum of the zarr cache.
+    :ivar str intervals_url: The URL of the intervals cache of the annotations.
+    :ivar str intervals_sha256: The SHA256 checksum of the annotations cache.
     :ivar str ~.description: One line description of the annotation.
     :ivar citations: List of citations for the annotation.
     :vartype citations: list of :class:`.Citation`
+    :ivar file_pattern: The pattern used to map individual chromosome id strings
+        to files
     """
 
     id = attr.ib()
     species = attr.ib()
     url = attr.ib()
-    zarr_url = attr.ib()
-    zarr_sha256 = attr.ib()
+    gff_sha256 = attr.ib()
+    intervals_url = attr.ib()
+    intervals_sha256 = attr.ib()
     description = attr.ib()
     citations = attr.ib(factory=list)
+    file_pattern = attr.ib()
 
     def __attrs_post_init__(self):
         self._cache = stdpopsim.CachedData(
-            namespace=f"annotations/{self.species.id}",
-            url=self.zarr_url,
-            sha256=self.zarr_sha256,
-            extract=False,
+            namespace=f"annotations/{self.species.id}/{self.id}",
+            url=self.intervals_url,
+            sha256=self.intervals_sha256,
+            extract=True,
         )
+        # logging.info(f"annotation namespace = {self._cache.namespace}")
 
     @property
     def cache_path(self):
@@ -74,7 +56,7 @@ class Annotation:
         s += "\tspecies   = {}\n".format(self.species.name)
         s += "\tid        = {}\n".format(self.id)
         s += "\turl       = {}\n".format(self.url)
-        s += "\tzarr url  = {}\n".format(self.zarr_url)
+        s += "\tintervals url  = {}\n".format(self.intervals_url)
         s += "\tcached    = {}\n".format(self.is_cached())
         s += "\tcache_path = {}\n".format(self.cache_path)
         return s
@@ -87,41 +69,19 @@ class Annotation:
 
     def download(self):
         """
-        Downloads the zarr URL and stores it in the cache directory.
+        Downloads the intervals URL and stores it in the cache directory.
         """
         self._cache.download()
 
     def get_chromosome_annotations(self, id):
         """
-        Returns the pandas dataframe for the chromosome with the specified id.
+        Returns the numpy interval array for the chromosome with the specified id.
         """
         chrom = self.species.genome.get_chromosome(id)
         if not self.is_cached():
             self.download()
-        bed = zarr_to_dataframe(str(self.cache_path))
-        assert type(bed) == pandas.DataFrame
-        ret = bed[bed.seqid == chrom.id]
+        file_path = os.path.join(self.cache_path, self.file_pattern.format(id=chrom.id))
+        ret = np.loadtxt(file_path)
         if len(ret) == 0:
             raise ValueError(f"No annotations found for {id}")
         return ret
-
-    def get_annotation_type_from_chromomosome(self, a_type, chrom_id, full_table=False):
-        """
-        Returns all elements of type a_type from chromosome specified
-        """
-        annots = self.get_chromosome_annotations(chrom_id)
-        subset = annots[annots.type == a_type]
-        if subset.empty:
-            raise ValueError(
-                f"annotation type '{a_type}' not found on chrom {chrom_id}"
-            )
-        if full_table:
-            return subset
-        else:
-            return subset[["start", "end"]]
-
-    def get_genes_from_chromosome(self, chrom_id, full_table=False):
-        """
-        Returns all elements of type gene from annotation
-        """
-        return self.get_annotation_type_from_chromomosome("gene", chrom_id, full_table)

--- a/stdpopsim/catalog/HomSap/annotations.py
+++ b/stdpopsim/catalog/HomSap/annotations.py
@@ -15,7 +15,7 @@ _an = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/HomSap/Ensembl_GRCh38_104_gff3.tar.gz"
     ),
-    intervals_sha256="1a2de33beaf2dada376654769db8370e649ff6f67dd0ec74287544eb52f850b2",
+    intervals_sha256="b0e864ec87274f3084e0d93161c8ed959b845c97a42cbad5bfe33f54c862716d",
     citations=[
         stdpopsim.Citation(
             year=2018,

--- a/stdpopsim/catalog/HomSap/annotations.py
+++ b/stdpopsim/catalog/HomSap/annotations.py
@@ -4,16 +4,18 @@ _species = stdpopsim.get_species("HomSap")
 
 _an = stdpopsim.Annotation(
     species=_species,
-    id="Ensembl_GRCh38_gff3",
+    id="Ensembl_GRCh38_104_gff3",
     description="Ensembl GFF3 annotations on GRCh38",
     url=(
-        "ftp://ftp.ensembl.org/pub/release-101/"
-        "gff3/homo_sapiens/Homo_sapiens.GRCh38.101.gff3.gz"
+        "ftp://ftp.ensembl.org/pub/release-104/"
+        "gff3/homo_sapiens/Homo_sapiens.GRCh38.104.gff3.gz"
     ),
-    zarr_url=(
-        "https://stdpopsim.s3-us-west-2.amazonaws.com/annotations/HomSap.GRCh38.zip"
+    gff_sha256="313ad46bd4af78b45b9f5d8407bbcbd3f87f4be0747060e84b3b5eb931530ec1",
+    intervals_url=(
+        "https://stdpopsim.s3-us-west-2.amazonaws.com/"
+        "annotations/HomSap/HomSap.GRCh38.104.tar.gz"
     ),
-    zarr_sha256="929c52dc5e5172d4a96a776d066f014f8f207f1477a21f7b88626f81a7142d0b",
+    intervals_sha256="1a2de33beaf2dada376654769db8370e649ff6f67dd0ec74287544eb52f850b2",
     citations=[
         stdpopsim.Citation(
             year=2018,
@@ -22,6 +24,6 @@ _an = stdpopsim.Annotation(
             reasons={stdpopsim.CiteReason.ANNOTATION},
         )
     ],
+    file_pattern="ensembl_havana_exons_{id}.txt",
 )
-# XXX: zarr deleted from amazon
-# _species.add_annotations(_an)
+_species.add_annotations(_an)

--- a/stdpopsim/catalog/HomSap/annotations.py
+++ b/stdpopsim/catalog/HomSap/annotations.py
@@ -13,7 +13,7 @@ _an = stdpopsim.Annotation(
     gff_sha256="313ad46bd4af78b45b9f5d8407bbcbd3f87f4be0747060e84b3b5eb931530ec1",
     intervals_url=(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
-        "annotations/HomSap/HomSap.GRCh38.104.tar.gz"
+        "annotations/HomSap/Ensembl_GRCh38_104_gff3.tar.gz"
     ),
     intervals_sha256="1a2de33beaf2dada376654769db8370e649ff6f67dd0ec74287544eb52f850b2",
     citations=[

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -144,7 +144,7 @@ class TestAnnotationDownload(tests.CacheWritingTest):
         # TODO: The HomSap annotations are huge. Once we include a smaller
         # annotation set, we should instead use that, so tests are faster.
         species = stdpopsim.get_species("HomSap")
-        an = species.get_annotations("Ensembl_GRCh38_gff3")
+        an = species.get_annotations("Ensembl_GRCh38_104_gff3")
         an.download()
         assert an.is_cached()
         an.download()
@@ -162,7 +162,7 @@ class TestGetChromosomeAnnotations(tests.CacheReadingTest):
     @classmethod
     def setup_class(cls):
         species = stdpopsim.get_species("HomSap")
-        cls.an = species.get_annotations("Ensembl_GRCh38_gff3")
+        cls.an = species.get_annotations("Ensembl_GRCh38_104_gff3")
 
     def test_known_chromosome(self):
         cm = self.an.get_chromosome_annotations("21")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -818,7 +818,7 @@ class TestDryRun:
                 filename = path / "output.trees"
                 cmd = (
                     f"{sys.executable} -m stdpopsim -q HomSap -D -L 1000 "
-                    "-o {filename} 2"
+                    f"-o {filename} 2"
                 )
                 subprocess.run(cmd, stderr=stderr, shell=True, check=True)
                 assert stderr.tell() == 0

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -6,7 +6,6 @@ import json
 import urllib
 import urllib.request
 
-
 import maintenance as maint
 
 


### PR DESCRIPTION
okay here is a PR that fixes up the Annotation class to return non-overlapping intervals using @grahamgower's approach from the Analysis2 repo. 

basics points to this PR:

1. refactored the data type stored to be a numpy array of intervals. the `Annotation.get_chromosome_annotations()` returns this array for use with SLiM
2. the annotation_maint.py script now does the download of the GFF and the interval merge, before tarring stuff up for aws

things to do:
1. i don't know how fragile the `gff.source == "ensembl_havana"` requirement is. should we worry?
2. the way things are written now, species can have more than one annotation. it would be cool to extend this to other choices
3. add a front end for doing the download of genome annotations in the same way that we have for genome assemblies