### PR TITLE
Fix the dominance coefficient in Kim DFE

### DIFF
--- a/docs/selection_example.py
+++ b/docs/selection_example.py
@@ -167,7 +167,7 @@ def KimDFE():
     neutral = stdpopsim.ext.MutationType()
     gamma_shape = 0.186  # shape
     gamma_mean = -0.01314833  # expected value
-    h = 0.5 / (1 - 7071.07 * gamma_mean)  # dominance coefficient
+    h = 0.5  # dominance coefficient
     negative = stdpopsim.ext.MutationType(
         dominance_coeff=h,
         distribution_type="g",

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -906,7 +906,7 @@ and MutationTypes have the same arguments as in SLiM.
         neutral = stdpopsim.ext.MutationType()
         gamma_shape = 0.186  # shape
         gamma_mean = -0.01314833  # expected value
-        h = 0.5 / (1 - 7071.07 * gamma_mean)  # dominance coefficient
+        h = 0.5  # dominance coefficient
         negative = stdpopsim.ext.MutationType(
             dominance_coeff=h,
             distribution_type="g",  # gamma distribution


### PR DESCRIPTION
The Kim et al paper simulated under multiple DFEs, some with fixed dominance and some where h is a function of s. Stdpopsim currently only supports fixed h for a given class of selected mutations, but the current parameterization copies the DFE with an h(s) function. Maybe h=0.5 is a better option here, or h could be a an argument of the DFE function. (See popsim-consortium/analysis2#5)