### PR TITLE
Prototype for transforming the catalog to yaml

### DIFF
--- a/catalog/AedAeg.yaml
+++ b/catalog/AedAeg.yaml
@@ -1,0 +1,65 @@
+id: AedAeg
+name: Aedes aegypti
+common_name: Yellow fever mosquito
+generation_time: 0.06666666666666667
+population_size: 1000000.0
+ensembl_id: aedes_aegypti_lvpagwg
+genome:
+  assembly_name: AaegL5
+  assembly_accession: GCA_002204515.1
+  citations:
+  - doi: https://doi.org/10.1126/science.1138878
+    author: Nene et al.
+    year: 2007
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1371/journal.pntd.0002652
+    author: Juneja et al.
+    year: 2014
+    reasons:
+    - recombination rate
+  - doi: https://doi.org/10.1186/s12915-017-0351-0
+    author: Crawford et al.
+    year: 2017
+    reasons:
+    - population size
+    - mutation rate
+    - generation time
+  - doi: https://doi.org/10.1101/gr.091231.109
+    author: Keightley et al.
+    year: 2009
+    reasons:
+    - mutation rate
+  chromosomes:
+    '1':
+      length: 310827022
+      recombination_rate: 3.06e-09
+      mutation_rate: 3.5e-09
+      synonyms:
+      - chr1
+    '2':
+      length: 474425716
+      recombination_rate: 2.49e-09
+      mutation_rate: 3.5e-09
+      synonyms:
+      - chr2
+    '3':
+      length: 409777670
+      recombination_rate: 2.91e-09
+      mutation_rate: 3.5e-09
+      synonyms:
+      - chr3
+    MT:
+      length: 16790
+      recombination_rate: 0
+      mutation_rate: 3.5e-09
+      synonyms:
+      - chrM
+citations:
+- doi: https://doi.org/10.1186/s12915-017-0351-0
+  author: Crawford et al.
+  year: 2017
+  reasons:
+  - population size
+  - mutation rate
+  - generation time

--- a/catalog/AnaPla.yaml
+++ b/catalog/AnaPla.yaml
@@ -1,0 +1,280 @@
+id: AnaPla
+name: Anas platyrhynchos
+common_name: Mallard
+generation_time: 4
+population_size: 156000
+ensembl_id: anas_platyrhynchos
+genome:
+  assembly_name: ASM874695v1
+  assembly_accession: GCA_008746955.1
+  citations:
+  - doi: https://doi.org/10.1111/mec.15343
+    author: Lavretsky et al.
+    year: 2019
+    reasons:
+    - mutation rate
+    - generation time
+  - doi: https://dx.doi.org/10.1534%2Fgenetics.105.053256
+    author: Huang et al.
+    year: 2006
+    reasons:
+    - recombination rate
+  chromosomes:
+    '1':
+      length: 208326429
+      recombination_rate: 1.52e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr1
+    '2':
+      length: 162939446
+      recombination_rate: 1.39e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr2
+    '3':
+      length: 119723720
+      recombination_rate: 9.35e-09
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr3
+    '4':
+      length: 77626585
+      recombination_rate: 1.2e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr4
+    '5':
+      length: 64988622
+      recombination_rate: 1.22e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr5
+    '6':
+      length: 39543408
+      recombination_rate: 3.03e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr6
+    '7':
+      length: 37812880
+      recombination_rate: 2.59e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr7
+    '8':
+      length: 33348632
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr8
+    '9':
+      length: 26742597
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr9
+    '10':
+      length: 22933227
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr10
+    '11':
+      length: 22193879
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr11
+    '12':
+      length: 22338721
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr12
+    '13':
+      length: 21714986
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr13
+    '14':
+      length: 20320564
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr14
+    '15':
+      length: 18227546
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr15
+    '16':
+      length: 16053328
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr16
+    '17':
+      length: 15319648
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr17
+    '18':
+      length: 13333155
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr18
+    '19':
+      length: 12198306
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr19
+    '20':
+      length: 12091001
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr20
+    '21':
+      length: 8553409
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr21
+    '22':
+      length: 16160689
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr22
+    '23':
+      length: 7977799
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr23
+    '24':
+      length: 7737077
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr24
+    '25':
+      length: 7574731
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr25
+    '26':
+      length: 6918023
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr26
+    '27':
+      length: 6270716
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr27
+    '28':
+      length: 5960150
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr28
+    '29':
+      length: 1456683
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr29
+    '30':
+      length: 1872559
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr30
+    Z:
+      length: 81233375
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chrZ
+    '31':
+      length: 2637124
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr31
+    '32':
+      length: 3473573
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr32
+    '33':
+      length: 2151773
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr33
+    '34':
+      length: 7214884
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr34
+    '35':
+      length: 5548691
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr35
+    '36':
+      length: 3997205
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr36
+    '37':
+      length: 3148754
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr37
+    '38':
+      length: 2836164
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr38
+    '39':
+      length: 2018729
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr39
+    '40':
+      length: 1354177
+      recombination_rate: 1.47e-08
+      mutation_rate: 4.83e-09
+      synonyms:
+      - chr40
+citations:
+- doi: https://doi.org/10.1111/mec.15343
+  author: Lavretsky et al.
+  year: 2019
+  reasons:
+  - mutation rate
+  - generation time
+- doi: https://doi.org/10.24272/j.issn.2095-8137.2020.133
+  author: Guo et al.
+  year: 2020
+  reasons:
+  - population size

--- a/catalog/AnoCar.yaml
+++ b/catalog/AnoCar.yaml
@@ -1,0 +1,108 @@
+id: AnoCar
+name: Anolis carolinensis
+common_name: Anole lizard
+generation_time: 1.5
+population_size: 3050000.0
+ensembl_id: anolis_carolinensis
+genome:
+  assembly_name: AnoCar2.0
+  assembly_accession: GCA_000090745.1
+  citations:
+  - doi: https://doi.org/10.1093/gbe/evz110
+    author: Pombi et al.
+    year: 2019
+    reasons:
+    - population size
+    - mutation rate
+    - recombination rate
+  chromosomes:
+    '1':
+      length: 263920458
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chr1
+    '2':
+      length: 199619895
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chr2
+    '3':
+      length: 204416410
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chr3
+    '4':
+      length: 156502444
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chr4
+    '5':
+      length: 150641573
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chr5
+    '6':
+      length: 80741955
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chr6
+    LGa:
+      length: 7025928
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    LGb:
+      length: 3271537
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    LGc:
+      length: 9478905
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    LGd:
+      length: 1094478
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    LGf:
+      length: 4257874
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    LGg:
+      length: 424765
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    LGh:
+      length: 248369
+      recombination_rate: 1e-08
+      mutation_rate: 2.1e-10
+      synonyms: []
+    MT:
+      length: 17223
+      recombination_rate: 0
+      mutation_rate: 2.1e-10
+      synonyms:
+      - chrM
+citations:
+- doi: https://doi.org/10.1093/ilar.45.1.54
+  author: Lovern et al.
+  year: 2004
+  reasons:
+  - generation time
+- doi: https://doi.org/10.1093/gbe/evz110
+  author: Pombi et al.
+  year: 2019
+  reasons:
+  - population size
+  - mutation rate
+  - recombination rate

--- a/catalog/AnoGam.yaml
+++ b/catalog/AnoGam.yaml
@@ -1,0 +1,71 @@
+id: AnoGam
+name: Anopheles gambiae
+common_name: Anopheles gambiae
+generation_time: 0.09090909090909091
+population_size: 6000000.0
+ensembl_id: anopheles_gambiae
+genome:
+  assembly_name: AgamP4
+  assembly_accession: GCA_000005575.1
+  citations:
+  - doi: https://doi.org/10.1186/gb-2007-8-1-r5
+    author: Sharakhova et al.
+    year: 2006
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1038/nature24995
+    author: Ag1000G Consortium
+    year: 2017
+    reasons:
+    - population size
+    - mutation rate
+    - generation time
+  - doi: https://doi.org/10.4269/ajtmh.2006.75.901
+    author: Pombi et al.
+    year: 2006
+    reasons:
+    - recombination rate
+  chromosomes:
+    2L:
+      length: 49364325
+      recombination_rate: 0
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr2L
+    2R:
+      length: 61545105
+      recombination_rate: 1.3e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr2R
+    3L:
+      length: 41963435
+      recombination_rate: 1.6e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr3L
+    3R:
+      length: 53200684
+      recombination_rate: 1.3e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr3R
+    X:
+      length: 24393108
+      recombination_rate: 1e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chrX
+    Mt:
+      length: 15363
+      recombination_rate: 0
+      mutation_rate: 5.49e-09
+      synonyms: []
+citations:
+- doi: https://doi.org/10.1038/nature24995
+  author: Ag1000G Consortium
+  year: 2017
+  reasons:
+  - population size
+  - mutation rate
+  - generation time

--- a/catalog/AraTha.yaml
+++ b/catalog/AraTha.yaml
@@ -1,0 +1,77 @@
+id: AraTha
+name: Arabidopsis thaliana
+common_name: A. thaliana
+generation_time: 1.0
+population_size: 10000
+ensembl_id: arabidopsis_thaliana
+genome:
+  assembly_name: TAIR10
+  assembly_accession: GCA_000001735.1
+  citations:
+  - doi: https://doi.org/10.1126/science.1180677
+    author: Ossowski et al.
+    year: 2010
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1093/molbev/msu247
+    author: Huber et al.
+    year: 2014
+    reasons:
+    - recombination rate
+  - doi: https://doi.org/10.1093/nar/gkm965
+    author: Swarbreck et al.
+    year: 2007
+    reasons:
+    - genome assembly
+  chromosomes:
+    '1':
+      length: 30427671
+      recombination_rate: 8.064516129032258e-10
+      mutation_rate: 7e-09
+      synonyms:
+      - chr1
+    '2':
+      length: 19698289
+      recombination_rate: 8.064516129032258e-10
+      mutation_rate: 7e-09
+      synonyms:
+      - chr2
+    '3':
+      length: 23459830
+      recombination_rate: 8.064516129032258e-10
+      mutation_rate: 7e-09
+      synonyms:
+      - chr3
+    '4':
+      length: 18585056
+      recombination_rate: 8.064516129032258e-10
+      mutation_rate: 7e-09
+      synonyms:
+      - chr4
+    '5':
+      length: 26975502
+      recombination_rate: 8.064516129032258e-10
+      mutation_rate: 7e-09
+      synonyms:
+      - chr5
+    Mt:
+      length: 366924
+      recombination_rate: 0
+      mutation_rate: 7e-09
+      synonyms: []
+    Pt:
+      length: 154478
+      recombination_rate: 0
+      mutation_rate: 7e-09
+      synonyms: []
+citations:
+- doi: https://doi.org/10.1890/0012-9658(2002)083[1006:GTINSO]2.0.CO;2
+  author: Donohue
+  year: 2002
+  reasons:
+  - generation time
+- doi: https://doi.org/10.1016/j.cell.2016.05.063
+  author: 1001GenomesConsortium
+  year: 2016
+  reasons:
+  - population size

--- a/catalog/BosTau.yaml
+++ b/catalog/BosTau.yaml
@@ -1,0 +1,219 @@
+id: BosTau
+name: Bos taurus
+common_name: Cattle
+generation_time: 5
+population_size: 90
+ensembl_id: bos_taurus
+genome:
+  assembly_name:
+  assembly_accession:
+  citations:
+  - doi: https://doi.org/10.1093/gigascience/giaa021
+    author: Rosen et al.
+    year: 2020
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1101/079863
+    author: Harland et al.
+    year: 2017
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1371/journal.pgen.1005387
+    author: Ma et al.
+    year: 2015
+    reasons:
+    - recombination rate
+  chromosomes:
+    '1':
+      length: 158534110
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr1
+    '2':
+      length: 136231102
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr2
+    '3':
+      length: 121005158
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr3
+    '4':
+      length: 120000601
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr4
+    '5':
+      length: 120089316
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr5
+    '6':
+      length: 117806340
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr6
+    '7':
+      length: 110682743
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr7
+    '8':
+      length: 113319770
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr8
+    '9':
+      length: 105454467
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr9
+    '10':
+      length: 103308737
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr10
+    '11':
+      length: 106982474
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr11
+    '12':
+      length: 87216183
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr12
+    '13':
+      length: 83472345
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr13
+    '14':
+      length: 82403003
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr14
+    '15':
+      length: 85007780
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr15
+    '16':
+      length: 81013979
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr16
+    '17':
+      length: 73167244
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr17
+    '18':
+      length: 65820629
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr18
+    '19':
+      length: 63449741
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr19
+    '20':
+      length: 71974595
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr20
+    '21':
+      length: 69862954
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr21
+    '22':
+      length: 60773035
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr22
+    '23':
+      length: 52498615
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr23
+    '24':
+      length: 62317253
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr24
+    '25':
+      length: 42350435
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr25
+    '26':
+      length: 51992305
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr26
+    '27':
+      length: 45612108
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr27
+    '28':
+      length: 45940150
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr28
+    '29':
+      length: 51098607
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chr29
+    X:
+      length: 139009144
+      recombination_rate: 9.26e-09
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chrX
+    MT:
+      length: 16338
+      recombination_rate: 0
+      mutation_rate: 1.2e-08
+      synonyms:
+      - chrM
+citations:
+- doi: https://doi.org/10.1093/molbev/mst125
+  author: MacLeod et al.
+  year: 2013
+  reasons:
+  - population size
+  - generation time

--- a/catalog/CaeEle.yaml
+++ b/catalog/CaeEle.yaml
@@ -1,0 +1,82 @@
+id: CaeEle
+name: Caenorhabditis elegans
+common_name: C. elegans
+generation_time: 0.01
+population_size: 10000
+ensembl_id: ''
+genome:
+  assembly_name: ce11
+  assembly_accession: GCA_000002985.3
+  citations:
+  - doi: https://doi.org/10.1126/science.282.5396.2012
+    author: The C. elegans Sequencing Consortium*
+    year: 1998
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1534/genetics.119.302054
+    author: Konrad et al.
+    year: 2019
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1093/molbev/msx051
+    author: Konrad et al.
+    year: 2017
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1371/journal.pgen.1000419
+    author: Rockman & Kruglyak
+    year: 2009
+    reasons:
+    - recombination rate
+  chromosomes:
+    I:
+      length: 15072434
+      recombination_rate: 3.330038e-11
+      mutation_rate: 1.84e-09
+      synonyms: []
+    II:
+      length: 15279421
+      recombination_rate: 3.999342e-11
+      mutation_rate: 1.84e-09
+      synonyms: []
+    III:
+      length: 13783801
+      recombination_rate: 4.484974e-11
+      mutation_rate: 1.84e-09
+      synonyms: []
+    IV:
+      length: 17493829
+      recombination_rate: 2.417689e-11
+      mutation_rate: 1.84e-09
+      synonyms: []
+    V:
+      length: 20924180
+      recombination_rate: 2.722476e-11
+      mutation_rate: 1.84e-09
+      synonyms: []
+    X:
+      length: 17718942
+      recombination_rate: 3.447911e-11
+      mutation_rate: 1.84e-09
+      synonyms: []
+    MtDNA:
+      length: 13794
+      recombination_rate: 0
+      mutation_rate: 1.84e-09
+      synonyms: []
+citations:
+- doi: https://doi.org/10.7554/eLife.05849
+  author: Frézal & Félix
+  year: 2015
+  reasons:
+  - generation time
+- doi: https://doi.org/10.1016/j.cub.2005.06.022
+  author: Barrière & Félix
+  year: 2005
+  reasons:
+  - population size
+- doi: https://doi.org/10.1534/genetics.105.048207
+  author: Cutter
+  year: 2006
+  reasons:
+  - population size

--- a/catalog/CanFam.yaml
+++ b/catalog/CanFam.yaml
@@ -1,0 +1,277 @@
+id: CanFam
+name: Canis familiaris
+common_name: Dog
+generation_time: 3
+population_size: 13000
+ensembl_id: canis_familiaris
+genome:
+  assembly_name: CanFam3.1
+  assembly_accession: GCA_000002285.2
+  citations:
+  - doi: https://doi.org/10.1016/j.cub.2015.04.019
+    author: Skoglund et al.
+    year: 2015
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1126/science.aaf3161
+    author: Franz et al.
+    year: 2016
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1534/g3.116.034678
+    author: Campbell et al.
+    year: 2016
+    reasons:
+    - recombination rate
+  - doi: https://doi.org/10.1038/nature04338
+    author: Lindblad-Toh et al.
+    year: 2005
+    reasons:
+    - genome assembly
+  chromosomes:
+    '1':
+      length: 122678785
+      recombination_rate: 7.636001498077e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr1
+    '2':
+      length: 85426708
+      recombination_rate: 8.798516284201015e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr2
+    '3':
+      length: 91889043
+      recombination_rate: 8.000868549297668e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr3
+    '4':
+      length: 88276631
+      recombination_rate: 8.052302321538563e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr4
+    '5':
+      length: 88915250
+      recombination_rate: 9.344333839828404e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr5
+    '6':
+      length: 77573801
+      recombination_rate: 8.192191165856811e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr6
+    '7':
+      length: 80974532
+      recombination_rate: 7.293465322857858e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr7
+    '8':
+      length: 74330416
+      recombination_rate: 8.291312822214086e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr8
+    '9':
+      length: 61074082
+      recombination_rate: 9.287722798450121e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr9
+    '10':
+      length: 69331447
+      recombination_rate: 9.107151930130527e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr10
+    '11':
+      length: 74389097
+      recombination_rate: 7.639449804041734e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr11
+    '12':
+      length: 72498081
+      recombination_rate: 7.761061128067527e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr12
+    '13':
+      length: 63241923
+      recombination_rate: 8.413015225299971e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr13
+    '14':
+      length: 60966679
+      recombination_rate: 9.028123091776737e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr14
+    '15':
+      length: 64190966
+      recombination_rate: 7.856754982030383e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr15
+    '16':
+      length: 59632846
+      recombination_rate: 8.614063697877811e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr16
+    '17':
+      length: 64289059
+      recombination_rate: 9.718834385033715e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr17
+    '18':
+      length: 55844845
+      recombination_rate: 1.029925446520415e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr18
+    '19':
+      length: 53741614
+      recombination_rate: 1.0425051705950442e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr19
+    '20':
+      length: 58134056
+      recombination_rate: 9.990971109010329e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr20
+    '21':
+      length: 50858623
+      recombination_rate: 1.0339033506095636e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr21
+    '22':
+      length: 61439934
+      recombination_rate: 8.61504863805126e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr22
+    '23':
+      length: 52294480
+      recombination_rate: 9.1266350068389e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chr23
+    '24':
+      length: 47698779
+      recombination_rate: 1.1146043069685935e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr24
+    '25':
+      length: 51628933
+      recombination_rate: 1.1543746646856006e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr25
+    '26':
+      length: 38964690
+      recombination_rate: 1.2084571786110922e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr26
+    '27':
+      length: 45876710
+      recombination_rate: 1.1260328390864541e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr27
+    '28':
+      length: 41182112
+      recombination_rate: 1.2463587044656355e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr28
+    '29':
+      length: 41845238
+      recombination_rate: 1.1013629677730708e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr29
+    '30':
+      length: 40214260
+      recombination_rate: 1.1687642441683382e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr30
+    '31':
+      length: 39895921
+      recombination_rate: 1.1397713284329192e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr31
+    '32':
+      length: 38810281
+      recombination_rate: 1.1555927931648279e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr32
+    '33':
+      length: 31377067
+      recombination_rate: 1.3339402745926785e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr33
+    '34':
+      length: 42124431
+      recombination_rate: 1.0483812411227089e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr34
+    '35':
+      length: 26524999
+      recombination_rate: 1.4299102611645524e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr35
+    '36':
+      length: 30810995
+      recombination_rate: 1.187517782077471e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr36
+    '37':
+      length: 30902991
+      recombination_rate: 1.3834580623461596e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr37
+    '38':
+      length: 23914537
+      recombination_rate: 1.4363726512881696e-08
+      mutation_rate: 4e-09
+      synonyms:
+      - chr38
+    X:
+      length: 123869142
+      recombination_rate: 9.506483722244087e-09
+      mutation_rate: 4e-09
+      synonyms:
+      - chrX
+    MT:
+      length: 16727
+      recombination_rate: 0
+      mutation_rate: 4e-09
+      synonyms:
+      - chrM
+citations:
+- doi: https://doi.org/10.1038/nature04338
+  author: Lindblad-Toh et al.
+  year: 2005
+  reasons:
+  - population size

--- a/catalog/ChlRei.yaml
+++ b/catalog/ChlRei.yaml
@@ -1,0 +1,139 @@
+id: ChlRei
+name: Chlamydomonas reinhardtii
+common_name: Chlamydomonas reinhardtii
+generation_time: 0.001141552511415525
+population_size: 1.3999999999999998e-07
+ensembl_id: chlamydomonas_reinhardtii
+genome:
+  assembly_name: Chlamydomonas_reinhardtii_v5.5
+  assembly_accession: GCA_000002595.3
+  citations:
+  - doi: https://doi.org/10.1126/science.1143609
+    author: Merchant et al
+    year: 2007
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.6084/m9.figshare.14608239.v1
+    author: Hasan and Ness
+    year: 2020
+    reasons:
+    - recombination rate
+  - doi: https://doi.org/10.6084/m9.figshare.14700156.v1
+    author: Ness et al
+    year: 2015
+    reasons:
+    - mutation rate
+  chromosomes:
+    '1':
+      length: 8033585
+      recombination_rate: 1.21e-10
+      mutation_rate: 9.74e-10
+      synonyms:
+      - chr1
+    '2':
+      length: 9223677
+      recombination_rate: 1.49e-10
+      mutation_rate: 8.62e-10
+      synonyms:
+      - chr2
+    '3':
+      length: 9219486
+      recombination_rate: 1.52e-10
+      mutation_rate: 9.5e-10
+      synonyms:
+      - chr3
+    '4':
+      length: 4091191
+      recombination_rate: 1.47e-10
+      mutation_rate: 9.66e-10
+      synonyms:
+      - chr4
+    '5':
+      length: 3500558
+      recombination_rate: 1.7e-10
+      mutation_rate: 1.17e-09
+      synonyms:
+      - chr5
+    '6':
+      length: 9023763
+      recombination_rate: 1.17e-10
+      mutation_rate: 9.12e-10
+      synonyms:
+      - chr6
+    '7':
+      length: 6421821
+      recombination_rate: 8.66e-11
+      mutation_rate: 9.14e-10
+      synonyms:
+      - chr7
+    '8':
+      length: 5033832
+      recombination_rate: 1.39e-10
+      mutation_rate: 8.98e-10
+      synonyms:
+      - chr8
+    '9':
+      length: 7956127
+      recombination_rate: 1.12e-10
+      mutation_rate: 9.17e-10
+      synonyms:
+      - chr9
+    '10':
+      length: 6576019
+      recombination_rate: 1.97e-10
+      mutation_rate: 9.27e-10
+      synonyms:
+      - chr10
+    '11':
+      length: 3826814
+      recombination_rate: 1.63e-10
+      mutation_rate: 1.03e-09
+      synonyms:
+      - chr11
+    '12':
+      length: 9730733
+      recombination_rate: 9.15e-11
+      mutation_rate: 9.55e-10
+      synonyms:
+      - chr12
+    '13':
+      length: 5206065
+      recombination_rate: 1.43e-10
+      mutation_rate: 7.56e-10
+      synonyms:
+      - chr13
+    '14':
+      length: 4157777
+      recombination_rate: 1.9e-10
+      mutation_rate: 8.96e-10
+      synonyms:
+      - chr14
+    '15':
+      length: 1922860
+      recombination_rate: 3.93e-10
+      mutation_rate: 6.91e-10
+      synonyms:
+      - chr15
+    '16':
+      length: 7783580
+      recombination_rate: 1.71e-10
+      mutation_rate: 9.59e-10
+      synonyms:
+      - chr16
+    '17':
+      length: 7188315
+      recombination_rate: 1.83e-10
+      mutation_rate: 1.05e-09
+      synonyms:
+      - chr17
+citations:
+- doi: https://doi.org/10.1093/molbev/msv272
+  author: Ness et al.
+  year: 2016
+  reasons:
+  - population size
+- doi: https://doi.org/10.1007/s00425-011-1427-7
+  author: Vitova et al.
+  year: 2011
+  reasons:
+  - generation time

--- a/catalog/DroMel.yaml
+++ b/catalog/DroMel.yaml
@@ -1,0 +1,85 @@
+id: DroMel
+name: Drosophila melanogaster
+common_name: D. melanogaster
+generation_time: 0.1
+population_size: 1720600
+ensembl_id: drosophila_melanogaster
+genome:
+  assembly_name: BDGP6.32
+  assembly_accession: GCA_000001215.4
+  citations:
+  - doi: https://doi.org/10.1534/genetics.113.151670
+    author: Schrider et al.
+    year: 2013
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1093/nar/gku1099
+    author: dos Santos et al.
+    year: 2015
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1101/gr.185579.114
+    author: Hoskins et al.
+    year: 2015
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1371/journal.pgen.1002905
+    author: Comeron et al
+    year: 2012
+    reasons:
+    - recombination rate
+  chromosomes:
+    2L:
+      length: 23513712
+      recombination_rate: 2.40462600791e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr2L
+    2R:
+      length: 25286936
+      recombination_rate: 2.23458641776e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr2R
+    3L:
+      length: 28110227
+      recombination_rate: 1.79660308862e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr3L
+    3R:
+      length: 32079331
+      recombination_rate: 1.71642045777e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr3R
+    '4':
+      length: 1348131
+      recombination_rate: 2.00579550709e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chr4
+    X:
+      length: 23542271
+      recombination_rate: 2.89650687913e-08
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chrX
+    Y:
+      length: 3667352
+      recombination_rate: 0
+      mutation_rate: 5.49e-09
+      synonyms:
+      - chrY
+    mitochondrion_genome:
+      length: 19524
+      recombination_rate: 0
+      mutation_rate: 5.49e-09
+      synonyms: []
+citations:
+- doi: https://doi.org/10.1371/journal.pgen.0020166
+  author: Li et al.
+  year: 2006
+  reasons:
+  - population size
+  - generation time

--- a/catalog/DroSec.yaml
+++ b/catalog/DroSec.yaml
@@ -1,0 +1,72 @@
+id: DroSec
+name: Drosophila sechellia
+common_name: Drosophila sechellia
+generation_time: 0.05
+population_size: 100000
+ensembl_id: drosophila_sechellia
+genome:
+  assembly_name: ASM438219v1
+  assembly_accession: GCA_004382195.1
+  citations:
+  - doi: https://doi.org/10.1101/gr.263442.120
+    author: Chakraborty et al.
+    year: 2021
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1371/journal.pgen.1002905
+    author: Comeron et al.
+    year: 2012
+    reasons:
+    - recombination rate
+  - doi: https://doi.org/10.1534/genetics.108.092080
+    author: Legrand et al.
+    year: 2009
+    reasons:
+    - population size
+    - mutation rate
+    - generation time
+  chromosomes:
+    2L:
+      length: 24956976
+      recombination_rate: 2.40462600791e-08
+      mutation_rate: 1.5e-09
+      synonyms:
+      - chr2L
+    2R:
+      length: 21536224
+      recombination_rate: 2.23458641776e-08
+      mutation_rate: 1.5e-09
+      synonyms:
+      - chr2R
+    3L:
+      length: 28131630
+      recombination_rate: 1.79660308862e-08
+      mutation_rate: 1.5e-09
+      synonyms:
+      - chr3L
+    3R:
+      length: 30464902
+      recombination_rate: 1.71642045777e-08
+      mutation_rate: 1.5e-09
+      synonyms:
+      - chr3R
+    X:
+      length: 22909512
+      recombination_rate: 2.89650687913e-08
+      mutation_rate: 1.5e-09
+      synonyms:
+      - chrX
+    '4':
+      length: 1277805
+      recombination_rate: 2.00579550709e-08
+      mutation_rate: 1.5e-09
+      synonyms:
+      - chr4
+citations:
+- doi: https://doi.org/10.1534/genetics.108.092080
+  author: Legrand et al.
+  year: 2009
+  reasons:
+  - population size
+  - mutation rate
+  - generation time

--- a/catalog/EscCol.yaml
+++ b/catalog/EscCol.yaml
@@ -1,0 +1,37 @@
+id: EscCol
+name: Escherichia coli
+common_name: E. coli
+generation_time: 3.805175e-05
+population_size: 180000000.0
+ensembl_id: escherichia_coli_str_k_12_substr_mg1655_gca_000005845
+genome:
+  assembly_name: ASM584v2
+  assembly_accession: GCA_000005845.2
+  citations:
+  - doi: https://doi.org/10.1534/g3.111.000406
+    author: Wielgoss et al.
+    year: 2011
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1126/science.277.5331.1453
+    author: Blattner et al.
+    year: 1997
+    reasons:
+    - genome assembly
+  chromosomes:
+    Chromosome:
+      length: 4641652
+      recombination_rate: 0.0
+      mutation_rate: 8.9e-11
+      synonyms: []
+citations:
+- doi: https://doi.org/10.1128/JB.01368-07
+  author: Sezonov et al.
+  year: 2007
+  reasons:
+  - generation time
+- doi: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1206133/
+  author: Hartl, Moriyama, and Sawyer
+  year: 1994
+  reasons:
+  - population size

--- a/catalog/GasAcu.yaml
+++ b/catalog/GasAcu.yaml
@@ -1,0 +1,147 @@
+id: GasAcu
+name: Gasterosteus aculeatus
+common_name: Gasterosteus aculeatus aculeatus (three-spined stickleback)
+generation_time: 0
+population_size: 0
+ensembl_id: '9307941'
+genome:
+  assembly_name: GAculeatus_UGA_version5
+  assembly_accession: GCF_016920845.1
+  citations:
+  - doi: ''
+    author: ''
+    year: -1
+    reasons:
+    - genome assembly
+  - doi: ''
+    author: ''
+    year: -1
+    reasons:
+    - recombination rate
+  - doi: ''
+    author: ''
+    year: -1
+    reasons:
+    - mutation rate
+  chromosomes:
+    '1':
+      length: '29619991'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '2':
+      length: '23686546'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '3':
+      length: '17759012'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '4':
+      length: '34181212'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '5':
+      length: '15550311'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '6':
+      length: '18825451'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '7':
+      length: '30776923'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '8':
+      length: '20553084'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '9':
+      length: '20843631'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '10':
+      length: '17985176'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '11':
+      length: '17651971'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '12':
+      length: '20694444'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '13':
+      length: '20748428'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '14':
+      length: '16147532'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '15':
+      length: '17318724'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '16':
+      length: '19507025'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '17':
+      length: '20195758'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '18':
+      length: '15939336'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '19':
+      length: '20580295'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '20':
+      length: '20445003'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '21':
+      length: '17421465'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    Y:
+      length: '15859692'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+citations:
+- doi: ''
+  author: ''
+  year: -1
+  reasons:
+  - population size
+- doi: ''
+  author: ''
+  year: -1
+  reasons:
+  - generation time

--- a/catalog/HelMel.yaml
+++ b/catalog/HelMel.yaml
@@ -1,0 +1,155 @@
+id: HelMel
+name: Heliconius melpomene
+common_name: Heliconius melpomene
+generation_time: 0.095
+population_size: 2100000.0
+ensembl_id: heliconius_melpomene
+genome:
+  assembly_name: Hmel2.5
+  assembly_accession:
+  citations:
+  - doi: https://doi.org/10.1002/evl3.12
+    author: Davey et al
+    year: 2017
+    reasons:
+    - genome assembly
+    - recombination rate
+  - doi: https://doi.org/10.1093/molbev/msu302
+    author: Keightley et al
+    year: 2015
+    reasons:
+    - mutation rate
+  chromosomes:
+    '1':
+      length: 17206585
+      recombination_rate: 3.17e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr1
+    '2':
+      length: 9045316
+      recombination_rate: 5.61e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr2
+    '3':
+      length: 10541528
+      recombination_rate: 5.1e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr3
+    '4':
+      length: 9662098
+      recombination_rate: 4.97e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr4
+    '5':
+      length: 9908586
+      recombination_rate: 5.15e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr5
+    '6':
+      length: 1405417
+      recombination_rate: 3.4e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr6
+    '7':
+      length: 1430885
+      recombination_rate: 3.76e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr7
+    '8':
+      length: 9320449
+      recombination_rate: 5.28e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr8
+    '9':
+      length: 8708747
+      recombination_rate: 5.31e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr9
+    '10':
+      length: 1796548
+      recombination_rate: 3.16e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr10
+    '11':
+      length: 1175927
+      recombination_rate: 4.47e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr11
+    '12':
+      length: 1632729
+      recombination_rate: 3.13e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr12
+    '13':
+      length: 1812731
+      recombination_rate: 3.08e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr13
+    '14':
+      length: 9174305
+      recombination_rate: 5.47e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr14
+    '15':
+      length: 1023575
+      recombination_rate: 4.78e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr15
+    '16':
+      length: 1008321
+      recombination_rate: 4.71e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr16
+    '17':
+      length: 1477329
+      recombination_rate: 3.94e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr17
+    '18':
+      length: 1680389
+      recombination_rate: 3.16e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr18
+    '19':
+      length: 1639934
+      recombination_rate: 3.11e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr19
+    '20':
+      length: 1487169
+      recombination_rate: 3.45e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr20
+    '21':
+      length: 1335969
+      recombination_rate: 3.71e-08
+      mutation_rate: 2.9e-09
+      synonyms:
+      - chr21
+citations:
+- doi: https://doi.org/10.1371/journal.pgen.1002752
+  author: Pardo-Diaz et al
+  year: 2012
+  reasons:
+  - population size
+  - generation time

--- a/catalog/HomSap.yaml
+++ b/catalog/HomSap.yaml
@@ -1,0 +1,187 @@
+id: HomSap
+name: Homo sapiens
+common_name: Human
+generation_time: 30
+population_size: 10000
+ensembl_id: homo_sapiens
+genome:
+  assembly_name: GRCh38.p13
+  assembly_accession: GCA_000001405.28
+  citations:
+  - doi: http://dx.doi.org/10.1038/35057062
+    author: International Human Genome Sequencing Consortium
+    year: 2001
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1016/j.ajhg.2019.09.012
+    author: Tian, Browning, and Browning
+    year: 2019
+    reasons:
+    - mutation rate
+  - doi: https://doi.org/10.1038/nature06258
+    author: The International HapMap Consortium
+    year: 2007
+    reasons:
+    - recombination rate
+  chromosomes:
+    '1':
+      length: 248956422
+      recombination_rate: 1.1485597641285933e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr1
+    '2':
+      length: 242193529
+      recombination_rate: 1.1054289277533446e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr2
+    '3':
+      length: 198295559
+      recombination_rate: 1.1279585624662551e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr3
+    '4':
+      length: 190214555
+      recombination_rate: 1.1231162636001008e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr4
+    '5':
+      length: 181538259
+      recombination_rate: 1.1280936570022824e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr5
+    '6':
+      length: 170805979
+      recombination_rate: 1.1222852661225285e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr6
+    '7':
+      length: 159345973
+      recombination_rate: 1.1764614397655721e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr7
+    '8':
+      length: 145138636
+      recombination_rate: 1.1478465778920576e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr8
+    '9':
+      length: 138394717
+      recombination_rate: 1.1780701596308656e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr9
+    '10':
+      length: 133797422
+      recombination_rate: 1.3365134257075317e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr10
+    '11':
+      length: 135086622
+      recombination_rate: 1.1719334320833283e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr11
+    '12':
+      length: 133275309
+      recombination_rate: 1.305017186986983e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr12
+    '13':
+      length: 114364328
+      recombination_rate: 1.0914860554958317e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr13
+    '14':
+      length: 107043718
+      recombination_rate: 1.119730771394731e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr14
+    '15':
+      length: 101991189
+      recombination_rate: 1.3835785893339787e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr15
+    '16':
+      length: 90338345
+      recombination_rate: 1.4834607113882717e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr16
+    '17':
+      length: 83257441
+      recombination_rate: 1.582489036239487e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr17
+    '18':
+      length: 80373285
+      recombination_rate: 1.5075956950023575e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr18
+    '19':
+      length: 58617616
+      recombination_rate: 1.8220141872466202e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr19
+    '20':
+      length: 64444167
+      recombination_rate: 1.7178269031631664e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr20
+    '21':
+      length: 46709983
+      recombination_rate: 1.3045214034879191e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr21
+    '22':
+      length: 50818468
+      recombination_rate: 1.4445022767788226e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chr22
+    X:
+      length: 156040895
+      recombination_rate: 1.164662223273842e-08
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chrX
+    Y:
+      length: 57227415
+      recombination_rate: 0.0
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chrY
+    MT:
+      length: 16569
+      recombination_rate: 0.0
+      mutation_rate: 1.29e-08
+      synonyms:
+      - chrM
+citations:
+- doi: https://doi.org/10.1086/302770
+  author: Tremblay and Vézina
+  year: 2000
+  reasons:
+  - generation time
+- doi: https://doi.org/10.1093/oxfordjournals.molbev.a039995
+  author: Takahata
+  year: 1993
+  reasons:
+  - population size

--- a/catalog/MusMus.yaml
+++ b/catalog/MusMus.yaml
@@ -1,0 +1,142 @@
+id: MusMus
+name: Mus musculus
+common_name: Mus musculus (house mouse)
+generation_time: 0
+population_size: 0
+ensembl_id: '7358741'
+genome:
+  assembly_name: GRCm39
+  assembly_accession: GCF_000001635.27
+  citations:
+  - doi: ''
+    author: ''
+    year: -1
+    reasons:
+    - genome assembly
+  - doi: ''
+    author: ''
+    year: -1
+    reasons:
+    - recombination rate
+  - doi: ''
+    author: ''
+    year: -1
+    reasons:
+    - mutation rate
+  chromosomes:
+    '1':
+      length: '195974786'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '2':
+      length: '181755017'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '3':
+      length: '159745316'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '4':
+      length: '156862662'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '5':
+      length: '153496487'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '6':
+      length: '149588044'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '7':
+      length: '145171164'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '8':
+      length: '130127694'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '9':
+      length: '124359700'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '10':
+      length: '130530862'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '11':
+      length: '121973369'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '12':
+      length: '120092757'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '13':
+      length: '120883175'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '14':
+      length: '125139656'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '15':
+      length: '104073951'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '16':
+      length: '98008968'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '17':
+      length: '95294699'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '18':
+      length: '90720763'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    '19':
+      length: '61420004'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    X:
+      length: '170035695'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+    Y:
+      length: '92212126'
+      recombination_rate: -1
+      mutation_rate: -1
+      synonyms: []
+citations:
+- doi: ''
+  author: ''
+  year: -1
+  reasons:
+  - population size
+- doi: ''
+  author: ''
+  year: -1
+  reasons:
+  - generation time

--- a/catalog/PonAbe.yaml
+++ b/catalog/PonAbe.yaml
@@ -1,0 +1,174 @@
+id: PonAbe
+name: Pongo abelii
+common_name: Sumatran orangutan
+generation_time: 20
+population_size: 17900.0
+ensembl_id: pongo_abelii
+genome:
+  assembly_name: PPYG2
+  assembly_accession:
+  citations:
+  - doi: https://doi.org/10.1016/j.cub.2017.09.047
+    author: Nater et al.
+    year: 2017
+    reasons:
+    - mutation rate
+    - recombination rate
+  chromosomes:
+    '1':
+      length: 229942017
+      recombination_rate: 5.19e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr1
+    2a:
+      length: 113028656
+      recombination_rate: 5.43e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr2a
+    2b:
+      length: 135000294
+      recombination_rate: 5.38e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr2b
+    '3':
+      length: 202140232
+      recombination_rate: 5.36e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr3
+    '4':
+      length: 198332218
+      recombination_rate: 5.43e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr4
+    '5':
+      length: 183952662
+      recombination_rate: 5.2e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr5
+    '6':
+      length: 174210431
+      recombination_rate: 5.22e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr6
+    '7':
+      length: 157549271
+      recombination_rate: 5.73e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr7
+    '8':
+      length: 153482349
+      recombination_rate: 5.67e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr8
+    '9':
+      length: 135191526
+      recombination_rate: 5.34e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr9
+    '10':
+      length: 133410057
+      recombination_rate: 5.91e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr10
+    '11':
+      length: 132107971
+      recombination_rate: 5.29e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr11
+    '12':
+      length: 136387465
+      recombination_rate: 5.44e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr12
+    '13':
+      length: 117095149
+      recombination_rate: 4.91e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr13
+    '14':
+      length: 108868599
+      recombination_rate: 4.7e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr14
+    '15':
+      length: 99152023
+      recombination_rate: 4.82e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr15
+    '16':
+      length: 77800216
+      recombination_rate: 6.12e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr16
+    '17':
+      length: 73212453
+      recombination_rate: 7.26e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr17
+    '18':
+      length: 94050890
+      recombination_rate: 4.57e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr18
+    '19':
+      length: 60714840
+      recombination_rate: 7.56e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr19
+    '20':
+      length: 62736349
+      recombination_rate: 5.83e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr20
+    '21':
+      length: 48394510
+      recombination_rate: 4.98e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr21
+    '22':
+      length: 46535552
+      recombination_rate: 6.03e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chr22
+    X:
+      length: 156195299
+      recombination_rate: 9.5e-09
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chrX
+    MT:
+      length: 16499
+      recombination_rate: 0
+      mutation_rate: 1.5e-08
+      synonyms:
+      - chrM
+citations:
+- doi: http://doi.org/10.1038/nature09687
+  author: Locke et al.
+  year: 2011
+  reasons:
+  - population size
+  - generation time

--- a/catalog/StrAga.yaml
+++ b/catalog/StrAga.yaml
@@ -1,0 +1,39 @@
+id: StrAga
+name: Streptococcus agalactiae
+common_name: Group B Streptococcus
+generation_time: 0.0027397260273972603
+population_size: 140000
+ensembl_id: NA
+genome:
+  assembly_name: GBCO_p1
+  assembly_accession: GCA_000689235.1
+  citations:
+  - doi: https://doi.org/10.1038/ncomms5544
+    author: Da Cunha et al
+    year: 2014
+    reasons:
+    - genome assembly
+  - doi: https://doi.org/10.1038/ncomms5544
+    author: Da Cunha et al
+    year: 2014
+    reasons:
+    - mutation rate
+  chromosomes:
+    '1':
+      length: 2065074
+      recombination_rate: 0
+      mutation_rate: 1.53e-09
+      synonyms:
+      - I
+      - chr1
+citations:
+- doi: https://doi.org/10.1038/ncomms5544
+  author: Da Cunha et al
+  year: 2014
+  reasons:
+  - population size
+- doi: https://doi.org/10.1086/284168
+  author: Savageau M.A.
+  year: 1983
+  reasons:
+  - generation time

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -44,6 +44,28 @@ class Citation:
     year = attr.ib(type=int, kw_only=True)
     reasons = attr.ib(factory=set, kw_only=True)
 
+    def asdict(self):
+        # FIXME the current encoding of "reasons" isn't well suited to static
+        # declaration. Probably the simplest thing to do is to required that
+        # "reason" be a key in the data model.
+        return {
+            "doi": self.doi,
+            "author": self.author,
+            "year": self.year,
+            "reasons": list(self.reasons),
+        }
+
+    @staticmethod
+    def fromdict(d):
+        return Citation(
+            doi=d["doi"], author=d["author"], year=d["year"], reasons=set(d["reasons"])
+        )
+
+    @staticmethod
+    def fromdictlist(lst):
+        # We usually get used as list of citations
+        return [Citation.fromdict(d) for d in lst]
+
     def __str__(self):
         return f"{self.author}, {self.year}: {self.doi}"
 

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -36,6 +36,26 @@ class Genome:
     assembly_accession = attr.ib(default=None, kw_only=True)
     citations = attr.ib(factory=list, kw_only=True)
 
+    def asdict(self):
+        return {
+            "assembly_name": self.assembly_name,
+            "assembly_accession": self.assembly_accession,
+            "citations": [citation.asdict() for citation in self.citations],
+            "chromosomes": {chrom.id: chrom.asdict() for chrom in self.chromosomes},
+        }
+
+    @staticmethod
+    def fromdict(d):
+        return Genome(
+            assembly_name=d["assembly_name"],
+            assembly_accession=d["assembly_accession"],
+            citations=stdpopsim.Citation.fromdictlist(d["citations"]),
+            chromosomes=[
+                Chromosome.fromdict(value, key)
+                for key, value in d["chromosomes"].items()
+            ],
+        )
+
     @staticmethod
     def from_data(genome_data, *, recombination_rate, mutation_rate, citations):
         """
@@ -141,6 +161,26 @@ class Chromosome:
     recombination_rate = attr.ib(type=float, kw_only=True)
     mutation_rate = attr.ib(type=float, kw_only=True)
     synonyms = attr.ib(factory=list, kw_only=True)
+
+    def asdict(self):
+        # Don't include ID here because it's used as a key - maybe not
+        # such a good idea
+        return {
+            "length": self.length,
+            "recombination_rate": self.recombination_rate,
+            "mutation_rate": self.mutation_rate,
+            "synonyms": self.synonyms,
+        }
+
+    @staticmethod
+    def fromdict(d, id_):
+        return Chromosome(
+            id=id_,
+            length=d["length"],
+            recombination_rate=d["recombination_rate"],
+            mutation_rate=d["mutation_rate"],
+            synonyms=d["synonyms"],
+        )
 
 
 @attr.s(kw_only=True)

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -148,6 +148,31 @@ class Species:
     genetic_maps = attr.ib(factory=list, kw_only=True)
     annotations = attr.ib(factory=list, kw_only=True)
 
+    def asdict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "common_name": self.common_name,
+            "generation_time": self.generation_time,
+            "population_size": self.population_size,
+            "ensembl_id": self.ensembl_id,
+            "genome": self.genome.asdict(),
+            "citations": [citation.asdict() for citation in self.citations],
+        }
+
+    @staticmethod
+    def fromdict(d):
+        return Species(
+            id=d["id"],
+            name=d["name"],
+            common_name=d["common_name"],
+            generation_time=d["generation_time"],
+            population_size=d["population_size"],
+            ensembl_id=d["ensembl_id"],
+            genome=stdpopsim.Genome.fromdict(d["genome"]),
+            citations=stdpopsim.Citation.fromdictlist(d["citations"]),
+        )
+
     def get_contig(
         self,
         chromosome=None,


### PR DESCRIPTION
This is a prototype in which we decouple the catalog from Python and instead encode our species descriptions declaratively using yaml. For example, this yaml:

```yaml
id: DroMel
name: Drosophila melanogaster
common_name: D. melanogaster
generation_time: 0.1
population_size: 1720600
ensembl_id: drosophila_melanogaster
genome:
  assembly_name: BDGP6.32
  assembly_accession: GCA_000001215.4
  chromosomes:
    2L:
      length: 23513712
      recombination_rate: 2.40462600791e-08
      mutation_rate: 5.49e-09
      synonyms:
      - chr2L
    2R:
      length: 25286936
      recombination_rate: 2.23458641776e-08
      mutation_rate: 5.49e-09
      synonyms:
      - chr2R
    3L:
      length: 28110227
      recombination_rate: 1.79660308862e-08
      mutation_rate: 5.49e-09
      synonyms:
      - chr3L
    3R:
      length: 32079331
      recombination_rate: 1.71642045777e-08
      mutation_rate: 5.49e-09
      synonyms:
      - chr3R
    '4':
      length: 1348131
      recombination_rate: 2.00579550709e-08
      mutation_rate: 5.49e-09
      synonyms:
      - chr4
    X:
      length: 23542271
      recombination_rate: 2.89650687913e-08
      mutation_rate: 5.49e-09
      synonyms:
      - chrX
    Y:
      length: 3667352
      recombination_rate: 0
      mutation_rate: 5.49e-09
      synonyms:
      - chrY
   mitochondrion_genome:
      length: 19524
      recombination_rate: 0
      mutation_rate: 5.49e-09
      synonyms: []
```

encodes the same information (excluding citations, which I've left out for clarity) as two Python files, with a lot less boiler plate. I think this is much more useful because it decouples the details of recording the information required to simulate a species from Python, and in particular from our frontend for msprime/slim.

We're missing (at least) two big things here: genetic maps and demographic models. The demographic models are already scheduled to be turned into static yaml in Demes format, so I think that works well. In practise, I think we'd structure the catalog like this:
```
catalog
    HomSap/
          species.yaml
          genetic_maps.yaml
          demography
               OutOfAfrica_3G09.yaml
               OutOfAfrica_2T12.yaml
               ....
```

The "genetic_maps.yaml" file could contain a list of the information about genetic maps, encoding the class structure like we're doing here - or we could simply merge this information into the species.yaml file, whatever is simpler.

The catalog then is *entirely* static and encoded in json/yaml, and we could therefore just think of it as a static website hosted at a URL somewhere. (Of course we could also thing of it as a JSON webservice, where this just gives the logical structure of the API - but let's not go there yet).

So, my proposal initially is that we take the species information out of Python, and we put it into a directory hierarchy like this. We can then instantiate the classes we need on demand, doing something like this:
```python
def get_species(name):
    species_yaml = config.catalog_path / name / species.yaml
    return Species.fromdict(yaml.load(species_yaml))
```
So, our startup times should be *much* faster, since we're not parsing all the species information on startup.

Most of the code in this PR is for transforming the current object model into JSON and back again. The following code generated the yaml in the included files (I've put then in here just so we can see what they'd look like) and checks that we can exactly recover the same information:

```python
from ruamel.yaml import YAML
import json
import stdpopsim

for species in stdpopsim.all_species():

    d = species.asdict()
    yaml = YAML() #typ="safe")
    with open(f"yamls/{species.id}.yaml", "w") as f:
        yaml.dump(d, f)

    species2 = stdpopsim.Species.fromdict(d)
    print(species.asdict() == species2.asdict())
```

What do we think?

