### PR TITLE
fix file name in QC docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -734,7 +734,7 @@ follow these steps for it to be officially supported by stdpopsim:
        assigned/volunteers to do a blind implementation of the model.
 
     3. Developer B creates a blind implementation of the model in the
-       ``stdpopsim/qc/species_name_qc.py`` file, remembering to register the
+       ``stdpopsim/qc/species_name.py`` file, remembering to register the
        QC model implementation (see other QC models for examples).  Note that
        if you are adding a new species you will have to add a new import to
        ``stdpopsim/qc/__init__.py``.


### PR DESCRIPTION
... as suggested by @igronau in #552:
```
I just QC'd my first model and it went fairly smooth. Adding more details to the docs would help, but not critical. One thing I found confusing was the species file in the qc dir. The doc says:

    Developer B creates a blind implementation of the model in the stdpopsim/qc/species_name_qc.py file

So I thought that the file name should have a _qc in the end. Maybe this should be changed to:

    Developer B creates a blind implementation of the model in the stdpopsim/qc/species_name.py file
```