### PR TITLE
added a function to test if a contig is neutral

### DIFF
--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -237,6 +237,12 @@ class _MsprimeEngine(Engine):
                 del kwargs["random_seed"]
             else:
                 raise ValueError("Cannot set both seed and random_seed")
+        # test to make sure contig is fully neutral
+        if not contig.is_neutral():
+            raise ValueError(
+                "Contig had non neutral mutation types "
+                "but you are using the msprime engine"
+            )
 
         # TODO: remove this after a release or two. See #745.
         self._warn_zigzag(demographic_model)

--- a/stdpopsim/ext/selection.py
+++ b/stdpopsim/ext/selection.py
@@ -95,6 +95,12 @@ class MutationType(object):
             "s": [],  # script types should just printout arguments
         }[self.distribution_type]
 
+    def is_neutral(self):
+        """
+        tests if the mutation type is strictly neutral
+        """
+        return self.distribution_type == "f" and self.distribution_args[0] == 0
+
 
 @attr.s
 class GenerationAfter(object):

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -436,6 +436,13 @@ class Contig:
             proportions=[1 if slim_mutations else 0],
         )
 
+    def is_neutral(self):
+        """
+        returns true if the contig has no non-neutral mutation
+        types
+        """
+        return all(mt.is_neutral() for mt in self.mutation_types)
+
     def __str__(self):
         gmap = "None" if self.genetic_map is None else self.genetic_map.id
         s = (

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -111,6 +111,69 @@ class TestContig:
         assert len(contig.genomic_element_types) == 2
         assert len(contig.mutation_types) == len(mt)
 
+    def test_is_neutral(self):
+        contig = stdpopsim.Contig.basic_contig(length=100)
+        contig.clear_genomic_mutation_types()
+        props = [0.3, 0.7]
+        mt = [
+            stdpopsim.ext.MutationType(distribution_type="f", distribution_args=[1])
+            for _ in props
+        ]
+        dfes = [
+            stdpopsim.DFE(
+                id=str(j),
+                description="test",
+                long_description="test test",
+                proportions=props,
+                mutation_types=mt,
+            )
+            for j in range(2)
+        ]
+        contig.add_DFE(intervals=np.array([[10, 30], [50, 100]]), DFE=dfes[0])
+        contig.add_DFE(intervals=np.array([[30, 40]]), DFE=dfes[1])
+        assert not contig.is_neutral()
+
+    def test_is_neutral2(self):
+        contig = stdpopsim.Contig.basic_contig(length=100)
+        contig.clear_genomic_mutation_types()
+        props = [0.3, 0.7]
+        mt = [stdpopsim.ext.MutationType() for _ in props]
+        dfes = [
+            stdpopsim.DFE(
+                id=str(j),
+                description="test",
+                long_description="test test",
+                proportions=props,
+                mutation_types=mt,
+            )
+            for j in range(2)
+        ]
+        contig.add_DFE(intervals=np.array([[10, 30], [50, 100]]), DFE=dfes[0])
+        contig.add_DFE(intervals=np.array([[30, 40]]), DFE=dfes[1])
+        assert contig.is_neutral()
+
+    def test_is_neutral3(self):
+        contig = stdpopsim.Contig.basic_contig(length=100)
+        contig.clear_genomic_mutation_types()
+        props = [0.3, 0.7]
+        mt = [
+            stdpopsim.ext.MutationType(distribution_type="e", distribution_args=[1])
+            for _ in props
+        ]
+        dfes = [
+            stdpopsim.DFE(
+                id=str(j),
+                description="test",
+                long_description="test test",
+                proportions=props,
+                mutation_types=mt,
+            )
+            for j in range(2)
+        ]
+        contig.add_DFE(intervals=np.array([[10, 30], [50, 100]]), DFE=dfes[0])
+        contig.add_DFE(intervals=np.array([[30, 40]]), DFE=dfes[1])
+        assert not contig.is_neutral()
+
 
 class TestAll_DFE_Models:
     """

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -965,6 +965,16 @@ class TestMutationTypes(PiecewiseConstantSizeMixin):
                     distribution_type="l", distribution_args=distribution_args
                 )
 
+    def test_netural_mutation_type(self):
+        assert stdpopsim.ext.MutationType().is_neutral()
+
+    def test_not_neutral_mutation_type(self):
+        mt = stdpopsim.ext.MutationType(
+            distribution_type="f",
+            distribution_args=[1],
+        )
+        assert not mt.is_neutral()
+
 
 @pytest.mark.skipif(IS_WINDOWS, reason="SLiM not available on windows")
 class TestDrawMutation(PiecewiseConstantSizeMixin):


### PR DESCRIPTION
this introduces a test of `contig` class objects to see if they contain non-neutral mutation types. 

I've added a test then onto `engine.simulate` to make sure when the msprime engine is invoked contigs are 100% neutral.

resolves #1016 