### PR TITLE
DFE command line interface

### DIFF
--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -24,7 +24,7 @@ def _HuberDFE():
             author="Huber et al.",
             year=2017,
             doi="https://doi.org/10.1073/pnas.1619508114",
-            reasons="to be defined",  # include the dfe_model reason
+            reasons={stdpopsim.CiteReason.DFE},  # include the dfe_model reason
         )
     ]
     neutral = stdpopsim.MutationType()

--- a/stdpopsim/catalog/HomSap/dfes.py
+++ b/stdpopsim/catalog/HomSap/dfes.py
@@ -21,7 +21,7 @@ def _KimDFE():
             author="Kim et al.",
             year=2017,
             doi="https://doi.org/10.1534/genetics.116.197145",
-            reasons="to be defined",  # include the dfe_model reason
+            reasons={stdpopsim.CiteReason.DFE},  # include the dfe_model reason
         )
     ]
     neutral = stdpopsim.MutationType()

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -22,6 +22,7 @@ class CiteReason:
     REC_RATE = "recombination rate"
     ASSEMBLY = "genome assembly"
     ANNOTATION = "genome annotation"
+    DFE = "distribution of fitness effects"
     STDPOPSIM = "stdpopsim"
 
 


### PR DESCRIPTION
So here is the first attempt to include selection (DFE) in the CLI and simulations. 
The way I do so is to allow the user to do the following:
if `-dfe (or --dfe-model)` is equal to **None**:
- then simulations will be done as previously (**without selection**). 
if `-dfe (or --dfe-model)` is equal to a specified model but demography is None:
- then selection is included and a single population constant size model is used for the demographic scenario.
if `-dfe (or --dfe-model)` and `--demographic-model` is defined by our smart user:
- then both parameters are taken into consideration.

There is a specific [place](https://github.com/popsim-consortium/stdpopsim/compare/main...izabelcavassim:DFE-CLI-new?diff=unified#diff-a2f706ab045cd6f2975f074024f6793138850eee3db24a9434a55f79c3c7230aR642), in which @andrewkern would work on getting the annotation specified.

This is at least what I wanted to do, glad to receive any comments from people @petrelharp @andrewkern @jeromekelleher 


Thanks