### PR TITLE
Genomic element refactor

### DIFF
--- a/stdpopsim/__init__.py
+++ b/stdpopsim/__init__.py
@@ -14,6 +14,7 @@ from .models import *  # NOQA
 from .species import *  # NOQA
 from .genomes import *  # NOQA
 from .annotations import *  # NOQA
+from .dfe import *  # NOQA
 from .cache import *  # NOQA
 from .citations import *  # NOQA
 from .engines import *  # NOQA

--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -1,0 +1,105 @@
+"""
+Common infrastructure for specifying DFEs.
+"""
+# import numpy as np
+import textwrap
+import attr
+import collections.abc
+from . import ext
+
+
+@attr.s(kw_only=True)
+class DFE:
+    """
+        Class representing a "Distribution of Fitness Effects", i.e., a DFE.
+
+        Instances of this class are constructed by DFE implementors, following the
+        :ref:`developer documentation <sec_development_dfe_model>`. To instead
+        obtain a pre-specified model as listed in the :ref:`sec_catalog`,
+        see :class:`Species.get_dfe`.
+
+    ``proportions`` and ``mutation_types`` must be lists of the same length,
+    and ``proportions should be nonnegative numbers summing to 1.
+
+        :ivar ~.mutation_types: a list of MutationTypes associated with the DFE.
+        :vartype ~.mutation_types: list
+        :ivar ~.proportions: a list of MutationTypes proportions
+        :vartype ~.proportions: list
+        :ivar ~.id: The unique identifier for this model. DFE IDs should be
+            short and memorable, and conform to the stdpopsim
+            :ref:`naming conventions <sec_development_naming_conventions>`
+            for DFE models.
+        :vartype ~.id: str
+        :ivar ~.description: A short description of this model as it would be used in
+            written text, e.g., "Lognormal DFE". This should
+            describe the DFE itself and not contain author or year information.
+        :vartype ~.description: str
+        :ivar long_description: A concise, but detailed, summary of the DFE model.
+        :vartype long_description: str
+        :ivar citations: A list of :class:`Citation`, that describe the primary
+            reference(s) for the DFE model.
+        :vartype citations: list of :class:`Citation`
+    """
+
+    id = attr.ib()
+    description = attr.ib()
+    long_description = attr.ib()
+    mutation_types = attr.ib(default=attr.Factory(list))
+    proportions = attr.ib(default=attr.Factory(list))
+    citations = attr.ib(default=attr.Factory(list))
+
+    def __attrs_post_init__(self):
+        self.citations = [] if self.citations is None else self.citations
+        if self.proportions == [] and len(self.mutation_types) == 1:
+            self.proportions = [1]
+
+        if not (
+            isinstance(self.proportions, collections.abc.Collection)
+            and isinstance(self.mutation_types, collections.abc.Collection)
+            and len(self.proportions) == len(self.mutation_types)
+        ):
+            raise ValueError(
+                "proportions and mutation_types must be lists of the same length."
+            )
+
+        for p in self.proportions:
+            if not isinstance(p, (float, int)) or p < 0:
+                raise ValueError("proportions must be nonnegative numbers.")
+        # sum_p = sum(self.proportions)
+        #    if not np.isclose(sum_p, 1):
+        #       raise ValueError("proportions must sum 1.0.")
+
+        for m in self.mutation_types:
+            if not isinstance(m, ext.MutationType):
+                raise ValueError(
+                    "mutation_types must be a list of MutationType objects."
+                )
+
+    def __str__(self):
+        long_desc_lines = [
+            line.strip()
+            for line in textwrap.wrap(textwrap.dedent(self.long_description))
+        ]
+        long_desc = "\n║                     ".join(long_desc_lines)
+        s = (
+            "DFE:\n"
+            f"║  id               = {self.id}\n"
+            f"║  description      = {self.description}\n"
+            f"║  long_description = {long_desc}\n"
+            f"║  citations        = {[cite.doi for cite in self.citations]}\n"
+        )
+        return s
+
+
+def neutral_DFE(convert_to_substitution=True):
+    id = "neutral"
+    description = "neutral DFE"
+    long_description = "strictly neutral mutations"
+    neutral = ext.MutationType(convert_to_substitution=convert_to_substitution)
+    return DFE(
+        id=id,
+        description=description,
+        long_description=long_description,
+        mutation_types=[neutral],
+        proportions=[1.0],
+    )

--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -238,7 +238,7 @@ class _MsprimeEngine(Engine):
             else:
                 raise ValueError("Cannot set both seed and random_seed")
         # test to make sure contig is fully neutral
-        if not contig.is_neutral():
+        if not contig.is_neutral:
             raise ValueError(
                 "Contig had non neutral mutation types "
                 "but you are using the msprime engine"

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -1,14 +1,10 @@
 """
 Common infrastructure for specifying demographic models.
 """
-import collections.abc
 import copy
-import numpy as np
 import textwrap
 
 import msprime
-
-from . import ext
 
 
 class Population:
@@ -303,91 +299,3 @@ class IsolationWithMigration(DemographicModel):
             model=model,
             generation_time=1,
         )
-
-
-class DFE:
-    """
-    Class representing a DFE.
-
-    Instances of this class are constructed by dfe implementors, following the
-    :ref:`developer documentation <sec_development_def_model>`. To instead
-    obtain a pre-specified model as listed in the :ref:`sec_catalog`,
-    see :class:`Species.get_dfe`.
-
-    :ivar ~.mutation_types: a list of MutationTypes associated with the DFE.
-    :vartype ~.mutation_types: list
-    :ivar ~.proportions: a list of MutationTypes proportions
-    :vartype ~.proportions: list
-    :ivar ~.id: The unique identifier for this model. DFE IDs should be
-        short and memorable, and conform to the stdpopsim
-        :ref:`naming conventions <sec_development_naming_conventions>`
-        for DFE models.
-    :vartype ~.id: str
-    :ivar ~.description: A short description of this model as it would be used in
-        written text, e.g., "Lognormal DFE". This should
-        describe the DFE itself and not contain author or year information.
-    :vartype ~.description: str
-    :ivar long_description: A concise, but detailed, summary of the DFE model.
-    :vartype long_description: str
-    :ivar citations: A list of :class:`Citation`, that describe the primary
-        reference(s) for the DFE model.
-    :vartype citations: list of :class:`Citation`
-    """
-
-    def __init__(
-        self,
-        *,
-        id,
-        description,
-        long_description,
-        mutation_types=None,
-        proportions=None,
-        citations=None,
-        # qc_model=None, # we may want to include qc of dfe in the future
-    ):
-        self.id = id
-        self.description = description
-        self.long_description = long_description
-        self.citations = [] if citations is None else citations
-        self.mutation_types = mutation_types
-        self.proportions = (
-            [1.0] if (proportions is None and len(mutation_types) == 1) else proportions
-        )
-        # self.qc_model = qc_model
-
-        if not (
-            isinstance(self.proportions, collections.abc.Collection)
-            and isinstance(self.mutation_types, collections.abc.Collection)
-            and len(self.proportions) == len(self.mutation_types)
-        ):
-            raise ValueError(
-                "proportions and mutation_types must be lists of the same length."
-            )
-
-        for p in self.proportions:
-            if not isinstance(p, (float, int)) or p < 0:
-                raise ValueError("proportions must be nonnegative numbers.")
-        sum_p = sum(self.proportions)
-        if not np.isclose(sum_p, 1):
-            raise ValueError("proportions must sum 1.0.")
-
-        for m in self.mutation_types:
-            if not isinstance(m, ext.MutationType):
-                raise ValueError(
-                    "mutation_types must be a list of MutationType objects."
-                )
-
-    def __str__(self):
-        long_desc_lines = [
-            line.strip()
-            for line in textwrap.wrap(textwrap.dedent(self.long_description))
-        ]
-        long_desc = "\n║                     ".join(long_desc_lines)
-        s = (
-            "DFE:\n"
-            f"║  id               = {self.id}\n"
-            f"║  description      = {self.description}\n"
-            f"║  long_description = {long_desc}\n"
-            f"║  citations        = {[cite.doi for cite in self.citations]}\n"
-        )
-        return s

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -111,7 +111,7 @@ class TestBehaviour:
         model = species.get_demographic_model("AshkSub_7G19")
         samples = model.get_samples(10)
         contig = stdpopsim.Contig.basic_contig(length=100)
-        contig.clear_genomic_mutation_types()
+        contig.clear_features()
         props = [1]
         mt = [stdpopsim.ext.MutationType(distribution_type="f", distribution_args=[1])]
         dfes = [
@@ -128,7 +128,7 @@ class TestBehaviour:
         with pytest.raises(ValueError):
             engine.simulate(model, contig, samples, seed=1)
         # okay now change selection coefficient to neutral
-        contig.clear_genomic_mutation_types()
+        contig.clear_features()
         props = [1]
         mt = [stdpopsim.ext.MutationType(distribution_type="f", distribution_args=[0])]
         dfes = [


### PR DESCRIPTION
here is a draft PR I'm working on to refactor out the genomic_element_type class from the selection API. there is a bunch of background in #1053 but the central goals here are:

- replace the old genomic_element class
- alter `Contig` to now carry a `dfe_list` which contains the DFE class objects and an `intevals` list which contains each of the intervals for each of the DFEs

currently i'm still putting in place the testing and have to alter the slim-engine.py but i wanted to share what i have now for input