### PR TITLE
QC for Drosophila Sec adding tests

### DIFF
--- a/tests/test_DroSec.py
+++ b/tests/test_DroSec.py
@@ -21,27 +21,44 @@ class TestSpeciesData(test_species.SpeciesTestBase):
     # independently referring to the citations provided in the
     # species definition, filling in the appropriate values
     # and deleting the pytest "skip" annotations.
-    @pytest.mark.skip("Population size QC not done yet")
     def test_qc_population_size(self):
-        assert self.species.population_size == -1
+        assert self.species.population_size == 100000
 
     @pytest.mark.skip("Generation time QC not done yet")
     def test_qc_generation_time(self):
-        assert self.species.generation_time == -1
+        assert self.species.generation_time == 20
 
 
 class TestGenomeData(test_species.GenomeTestBase):
 
     genome = stdpopsim.get_species("DroSec").genome
 
-    @pytest.mark.skip("Recombination rate QC not done yet")
-    @pytest.mark.parametrize(["name", "rate"], {}.items())
+    @pytest.mark.parametrize(
+        ["name", "rate"],
+        {
+            "2L": 2.39,
+            "2R": 2.66,
+            "3L": 1.79,
+            "3R": 1.96,
+            "X": 2.95,
+            "4": 0,
+        }.items(),
+    )
     def test_recombination_rate(self, name, rate):
         assert rate == pytest.approx(
             self.genome.get_chromosome(name).recombination_rate
         )
 
-    @pytest.mark.skip("Mutation rate QC not done yet")
-    @pytest.mark.parametrize(["name", "rate"], {}.items())
+    @pytest.mark.parametrize(
+        ["name", "rate"],
+        {
+            "2L": 1.5e-09,
+            "2R": 1.5e-09,
+            "3L": 1.5e-09,
+            "3R": 1.5e-09,
+            "X": 1.5e-09,
+            "4": 1.5e-09,
+        }.items(),
+    )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)


### PR DESCRIPTION
Hi @jradrion, thanks for adding Drosophila sechellia to the catalog. 
I have just done the QC for this species #873, and we only disagree on the recombination map. 
I got my results from this:
https://petrov.stanford.edu/cgi-bin/recombination-rates_updateR5.pl

I know you uploaded some reference that has the recombination map for Drosophila Melanogaster: https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1002905
Can you tell me how you reached your values from this source? 

Thank you very much. 