### PR TITLE
QC for  Heliconius melpomene

### DIFF
--- a/stdpopsim/catalog/HelMel/species.py
+++ b/stdpopsim/catalog/HelMel/species.py
@@ -78,7 +78,7 @@ _species = stdpopsim.Species(
     name="Heliconius melpomene",
     common_name="Heliconius melpomene",
     genome=_genome,
-    generation_time=9.5 / 100,
+    generation_time=1 / 10,
     population_size=2.1e6,
     citations=[
         stdpopsim.Citation(

--- a/tests/test_HelMel.py
+++ b/tests/test_HelMel.py
@@ -21,27 +21,73 @@ class TestSpeciesData(test_species.SpeciesTestBase):
     # independently referring to the citations provided in the
     # species definition, filling in the appropriate values
     # and deleting the pytest "skip" annotations.
-    @pytest.mark.skip("Population size QC not done yet")
     def test_qc_population_size(self):
-        assert self.species.population_size == -1
+        assert self.species.population_size == 2.1e06
 
-    @pytest.mark.skip("Generation time QC not done yet")
     def test_qc_generation_time(self):
-        assert self.species.generation_time == -1
+        assert self.species.generation_time == 1 / 10
 
 
 class TestGenomeData(test_species.GenomeTestBase):
 
     genome = stdpopsim.get_species("HelMel").genome
 
-    @pytest.mark.skip("Recombination rate QC not done yet")
-    @pytest.mark.parametrize(["name", "rate"], {}.items())
+    @pytest.mark.parametrize(
+        ["name", "rate"],
+        {
+            "1": 3.17e-08,
+            "2": 5.61e-08,
+            "3": 5.10e-08,
+            "4": 4.97e-08,
+            "5": 5.15e-08,
+            "6": 3.40e-08,
+            "7": 3.76e-08,
+            "8": 5.28e-08,
+            "9": 5.31e-08,
+            "10": 3.16e-08,
+            "11": 4.47e-08,
+            "12": 3.13e-08,
+            "13": 3.08e-08,
+            "14": 5.47e-08,
+            "15": 4.78e-08,
+            "16": 4.71e-08,
+            "17": 3.94e-08,
+            "18": 3.16e-08,
+            "19": 3.11e-08,
+            "20": 3.45e-08,
+            "21": 3.71e-08,
+        }.items(),
+    )
     def test_recombination_rate(self, name, rate):
         assert rate == pytest.approx(
             self.genome.get_chromosome(name).recombination_rate
         )
 
-    @pytest.mark.skip("Mutation rate QC not done yet")
-    @pytest.mark.parametrize(["name", "rate"], {}.items())
+    @pytest.mark.parametrize(
+        ["name", "rate"],
+        {
+            "1": 2.9e-09,
+            "2": 2.9e-09,
+            "3": 2.9e-09,
+            "4": 2.9e-09,
+            "5": 2.9e-09,
+            "6": 2.9e-09,
+            "7": 2.9e-09,
+            "8": 2.9e-09,
+            "9": 2.9e-09,
+            "10": 2.9e-09,
+            "11": 2.9e-09,
+            "12": 2.9e-09,
+            "13": 2.9e-09,
+            "14": 2.9e-09,
+            "15": 2.9e-09,
+            "16": 2.9e-09,
+            "17": 2.9e-09,
+            "18": 2.9e-09,
+            "19": 2.9e-09,
+            "20": 2.9e-09,
+            "21": 2.9e-09,
+        }.items(),
+    )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)


### PR DESCRIPTION
Hi @percyfal, thanks for adding the _Heliconius melpomene_ to the catalog.
I started doing the QC for this species.

 It seems that there is only one parameter that we disagree with. It is the generation time. I saw in [Pardo Diaz et al. 2012](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1002752) that they assumed 35 days as the generation time (Material&Methods), but in the table legend, they assumed ten generations per year (almost the same thing). I guess we disagree in how we did the calculations: you approximated as (9.5/100)*365 = 34.675 days/year; I did as (1/10)*365 = 36.5/year. Both are ok as the differences are negligible. What do you think?