### PR TITLE
fixup docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # stdpopsim
 
-[![Docs](https://readthedocs.org/projects/stdpopsim/badge/?version=latest&style=flat)](https://stdpopsim.readthedocs.io/en/latest/)[![CircleCI](https://circleci.com/gh/popsim-consortium/stdpopsim.svg?style=svg)](https://circleci.com/gh/popsim-consortium/stdpopsim)[![codecov](https://codecov.io/gh/popsim-consortium/stdpopsim/branch/main/graph/badge.svg)](https://codecov.io/gh/popsim-consortium/stdpopsim)[![Appveyor](https://ci.appveyor.com/api/projects/status/4ugxq19ql80gcpio?svg=true)](https://ci.appveyor.com/project/popsim-consortium/stdpopsim)[![TravisCI](https://travis-ci.org/popsim-consortium/stdpopsim.svg?branch=main)](https://travis-ci.org/popsim-consortium/stdpopsim)
+(https://circleci.com/gh/popsim-consortium/stdpopsim)[![codecov](https://codecov.io/gh/popsim-consortium/stdpopsim/branch/main/graph/badge.svg)](https://codecov.io/gh/popsim-consortium/stdpopsim)[![Appveyor](https://ci.appveyor.com/api/projects/status/4ugxq19ql80gcpio?svg=true)](https://ci.appveyor.com/project/popsim-consortium/stdpopsim)[![TravisCI](https://travis-ci.org/popsim-consortium/stdpopsim.svg?branch=main)](https://travis-ci.org/popsim-consortium/stdpopsim)
 
 
 A community-maintained library of standard population genetic simulation models.
-Please see the [documentation](https://stdpopsim.readthedocs.io/en/latest/) for further details.
+Please see the [stable documentation](https://popsim-consortium.github.io/stdpopsim-docs/stable/index.html) for further details.
+(That's the link to docs for the last stable release,
+for in-development docs, see [this link](https://popsim-consortium.github.io/stdpopsim-docs/latest/index.html).)
 
 Click [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/popsim-consortium/stdpopsim/main?filepath=stdpopsim_example.ipynb) to start an interactive Jupyter Notebook and start playing with `stdpopsim` now!
 
 If you use ``stdpopsim`` in your work, please cite our
 [paper](https://elifesciences.org/articles/54967).
-See [here](https://stdpopsim.readthedocs.io/en/latest/introduction.html#citations) for
-full citation details.
+See [here](https://popsim-consortium.github.io/stdpopsim-docs/stable/introduction.html#citations)
+for full citation details.

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 **Standard library of population genetic simulations**
 
 Stdpopsim is a community-maintained standard library of population genetic models.
-Please see the `documentation <https://stdpopsim.readthedocs.org/en/stable/>`_
+Please see the `documentation <https://popsim-consortium.github.io/stdpopsim-docs/stable/index.html>`_
 for details.
 
 Stdpopsim is highly portable, and provides a number of
-`installation options <https://stdpopsim.readthedocs.org/en/stable/installation.html>`_.
+`installation options <https://popsim-consortium.github.io/stdpopsim-docs/stable/installation.html>`_.
 
 To start an interactive Jupyter Notebook and start playing with ``stdpopsim`` now click
 
@@ -16,5 +16,5 @@ To start an interactive Jupyter Notebook and start playing with ``stdpopsim`` no
 
 If you use ``stdpopsim`` in your work, please cite our
 `manuscript <https://doi.org/10.1101/2019.12.20.885129>`_ .
-See `here <https://stdpopsim.readthedocs.io/en/latest/introduction.html#citations>`__ for
+See `here <https://popsim-consortium.github.io/stdpopsim-docs/stable/introduction.html#citations>`__ for
 full citation details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,8 +197,9 @@ epub_exclude_files = ["search.html"]
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "https://docs.python.org/": None,
-    "tskit": ("https://tskit.readthedocs.io/en/stable", None),
-    "msprime": ("https://msprime.readthedocs.io/en/stable", None),
+    "tskit": ("https://tskit.dev/tskit/docs/stable", None),
+    "msprime": ("https://tskit.dev/msprime/docs/stable", None),
+    "pyslim": ("https://tskit.dev/pyslim/docs/latest", None),
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -80,7 +80,7 @@ environment and then should be able to install the development requirements usin
 
 
 We do require ``msprime``, so please see the the `installation notes
-<https://msprime.readthedocs.io/en/stable/installation.html>`_ if you
+<https://tskit.dev/msprime/docs/stable/installation.html>`_ if you
 encounter problems with it.
 
 .. Note:: If you have trouble installing any of the requirements, your ``pip`` may be the wrong version.
@@ -488,8 +488,7 @@ Steps for adding a new demographic model:
 5. `Submit a Pull Request on GitHub`_
 
 If this is your first time implementing a demographic model in `stdpopsim`, it's a good
-idea to take some time browsing the
-`Catalog <https://stdpopsim.readthedocs.io/en/latest/catalog.html>`_
+idea to take some time browsing the :ref:`sec_catalog`
 and species' demographic models in the
 source code to see how existing models are typically written and documented. If you have
 any questions or confusion about formatting or implementing demographic models, please
@@ -620,7 +619,7 @@ parameters that give the maximum likelihood fit), which are translated into
 ``population_configurations``, ``migration_matrix``, and ``demographic_events``. If this
 is your first time specifying a model using `msprime`, it's worth taking some time to
 read through the `msprime`
-`documentation and tutorials <https://msprime.readthedocs.io/en/stable/tutorial.html>`_.
+`documentation and tutorials <https://tskit.dev/msprime/docs/stable/quickstart.html>`_.
 
 
 ---------------------
@@ -921,7 +920,7 @@ Each chromosome should be placed in a separate file and with the chromosome id i
 file name in such a way that it can be programatically parsed out. IMPORTANT: chromosome
 ids must match those provided in the genome definition exactly! Below is an example start
 to a recombination map file (see `here
-<https://msprime.readthedocs.io/en/stable/api.html#msprime.RecombinationMap.read_hapmap>`_
+<https://tskit.dev/msprime/docs/stable/api.html#msprime.RateMap.read_hapmap>`_
 for more details)::
 
     Chromosome Position(bp) Rate(cM/Mb) Map(cM)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -84,11 +84,11 @@ line interface. See `here
 <https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site>`_
 for details on what this means and how to do it.
 
-We use `msprime <https://msprime.readthedocs.io/>`_ as the
+We use `msprime <https://tskit.dev/msprime>`_ as the
 default simulation engine, which has some system level dependencies
 and requires a functioning compiler. Please see the msprime
 `installation documentation
-<https://msprime.readthedocs.io/en/stable/installation.html>`_ for
+<https://tskit.dev/msprime/docs/stable/installation.html>`_ for
 instructions if you encounter errors during installation.
 
 .. _sec_installation_running_cli:

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -14,9 +14,9 @@ genetic simulation models.
 We designed ``stdpopsim`` to make it easier for you to run reproducible, bug-free
 simulations of genetic datasets from published demographic histories.
 Under the hood, ``stdpopsim`` relies on
-`msprime <https://msprime.readthedocs.io/en/stable/>`_ and
+`msprime <https://tskit.dev/msprime/>`_ and
 `SLiM 3 <https://messerlab.org/slim/>`_ to generate sample datasets in the
-`tree sequence <https://tskit.readthedocs.io/en/latest/>`_ format.
+`tree sequence <https://tskit.dev/learn.html#what>`_ format.
 
 
 First steps

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -83,7 +83,7 @@ To save time we will specify that the simulation use
 chromosome 22, using the ``-c`` option. We also specify that the resulting
 tree-sequence formatted output should be written to the file ``foo.ts`` with the
 ``-o`` option. For more information on how to use tree-sequence files see
-`tskit <https://tskit.readthedocs.io/en/latest/>`_ .
+`tskit <https://tskit.dev/tskit/docs/stable/introduction.html>`__.
 
 .. code-block:: console
 
@@ -172,7 +172,7 @@ a compact and efficient format for storing both genealogies and genome sequence.
 Some examples of analyzing tree sequences are given
 :ref:`below <sec_tute_analyses>`.
 If desired, these can be converted to VCF on the command line if the
-`tskit <https://tskit.readthedocs.io/>`__ package is installed,
+`tskit <https://tskit.dev/tskit/>`__ package is installed,
 with the ``tskit vcf`` command:
 
 .. code-block:: console
@@ -212,7 +212,7 @@ Using the SLiM simulation engine
 
 The default "simulation engine" -
 i.e., the program that actually does the simulating -
-is `msprime <https://msprime.readthedocs.io/en/stable/>`__,
+is `msprime <https://tskit.dev/msprime/>`__,
 a coalescent simulator.
 However, it is also possible to swap this out for
 `SLiM <https://messerlab.org/slim/>`__,
@@ -349,7 +349,7 @@ Running stdpopsim with the Python interface (API)
 Nearly all the functionality of ``stdpopsim`` is available through the CLI,
 but for complex situations it may be desirable to use python.
 Furthermore, downstream analysis may happen in python,
-using the `tskit <https://tskit.readthedocs.io>`__ tools for working
+using the `tskit <https://tskit.dev/tskit/>`__ tools for working
 with tree sequences.
 In order to use the ``stdpopsim`` API the ``stdpopsim`` package must be
 installed (see :ref:`Installation <sec_installation>`).
@@ -586,7 +586,7 @@ Sanity check the tree sequence output
 
 Now, we do some simple checks that our simulation worked with
 `tskit
-<https://tskit.readthedocs.io>`__.
+<https://tskit.dev/tskit/>`__.
 
 .. code-block:: python
 
@@ -646,7 +646,7 @@ However, ``stdpopsim`` also has the ability to produce
 simulations with SLiM, a forwards-time, individual-based simulator.
 Using SLiM provides us with a few more options.
 You may also want to install the
-`pyslim <https://pyslim.readthedocs.io/>`__ package
+`pyslim <https://tskit.dev/pyslim/>`__ package
 to extract the additional SLiM-specific information
 in the tree sequences that are produced.
 
@@ -719,7 +719,7 @@ the amount of time before the first demographic model change that SLiM begins si
 in units of N generations, where N is the population size at the first demographic model change.
 By default, this is set to 10, which is fairly safe.
 History before this period is simulated with an ``msprime`` coalescent simulation,
-called `"recapitation" <https://pyslim.readthedocs.io/en/latest/tutorial.html#recapitation>`__
+called `"recapitation" <https://tskit.dev/pyslim/docs/latest/tutorial.html#recapitation>`__
 because it attaches tops to any trees that have not yet coalesced.
 For instance, the ``Africa_1T12`` model
 `(Tennesen et al 2012) <https://doi.org/10.1126/science.1219240>`__
@@ -853,7 +853,7 @@ The first, and most essential step, is undoing the rescaling of time
 that the ``slim_scaling_factor`` has introduced.
 Next is "recapitation",
 for which the rationale and method is described in detail in the
-`pyslim documentation <https://pyslim.readthedocs.io/en/latest/tutorial.html#recapitation>`__.
+`pyslim documentation <https://tskit.dev/pyslim/docs/latest/tutorial.html#recapitation>`__.
 The third (and least crucial) step is to *simplify* the tree sequence.
 If as above we ask for 200 samples from a population whose final size is
 1,450 individuals (after rescaling),
@@ -868,7 +868,7 @@ because the size of the tree sequence grows very slowly with the number of sampl
 However, for many analyses you will probably want to extract samples
 of realistic size for real data.
 Again, methods to do this are discussed in the
-`pyslim documentation <https://pyslim.readthedocs.io/en/latest/tutorial.html#simplification>`__.
+`pyslim documentation <https://tskit.dev/pyslim/docs/latest/tutorial.html#simplification>`__.
 
 
 .. _sec_tute_selection:
@@ -1315,7 +1315,7 @@ Calculating genetic divergence
 ==============================
 
 Next we'll give an example of computing some summaries of the simulation output.
-The `tskit <https://tskit.readthedocs.io/en/latest/>`_  documentation
+The `tskit <https://tskit.dev/tskit/docs/stable/>`__  documentation
 has details on many more statistics that you can compute using the tree sequences.
 We will simulate some samples of human chromosomes
 from different populations,
@@ -1386,7 +1386,7 @@ These quantities can be computed directly from our sample using tskit's
 :meth:`tskit.TreeSequence.divergence`.
 
 By looking at
-`the documentation <https://tskit.readthedocs.io/en/latest/python-api.html#tskit.TreeSequence.divergence>`_
+:meth:`the documentation <tskit.TreeSequence.divergence>`
 for this method, we can see that we'll need two inputs: ``sample_sets`` and
 ``indexes``.
 In our case, we want ``sample_sets`` to give the list
@@ -1615,7 +1615,7 @@ The somewhat mysterious ``polarised=True`` option indicates that we wish to
 calculate the AFS for derived alleles only, without "folding" the spectrum,
 and the ``span_normalise=False`` option disables tskit's
 default behaviour of dividing by the sequence length. See
-`tskit's documentation <https://tskit.readthedocs.io/en/latest/stats.html#interface>`__
+`tskit's documentation <https://tskit.dev/tskit/docs/stable/stats.html#interface>`__
 for more information on these options.
 
 We will do further analysis in the next section, but you might first wish to convince

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -392,7 +392,9 @@ def add_simulate_species_parser(parser, species):
             help=(
                 "Specify a particular genetic map. By default, a chromosome-specific "
                 "uniform recombination rate is used. These default rates are listed in "
-                "the catalog: <https://stdpopsim.readthedocs.io/en/latest/catalog.html> "
+                "the catalog: "
+                "<https://popsim-consortium.github.io/stdpopsim-docs/"
+                "stable/catalog.html> "
                 "Available maps: "
                 f"{', '.join(choices)}. "
             ),
@@ -544,8 +546,8 @@ def add_simulate_species_parser(parser, species):
                     "and the model described in the original publication. "
                     "More information about the QC process can be found in "
                     "the developer documentation. "
-                    "https://stdpopsim.readthedocs.io/en/latest/development.html"
-                    "#demographic-model-review-process"
+                    "https://popsim-consortium.github.io/stdpopsim-docs/"
+                    "latest/development.html#demographic-model-review-process"
                 )
             )
 

--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -123,7 +123,7 @@ class Engine:
                 f"contig's mutation rate {contig.mutation_rate}. Diversity levels "
                 "may be different than expected for this species. For details see "
                 "documentation at "
-                "https://stdpopsim.readthedocs.io/en/latest/tutorial.html"
+                "https://popsim-consortium.github.io/stdpopsim-docs/stable/tutorial.html"
             )
 
 


### PR DESCRIPTION
We've moved docs over to github pages; this fixes the links to readthedocs.