### PR TITLE
moving annotations to ints, requiring ints in intervals

### DIFF
--- a/stdpopsim/annotations.py
+++ b/stdpopsim/annotations.py
@@ -83,7 +83,7 @@ class Annotation:
         if not self.is_cached():
             self.download()
         file_path = os.path.join(self.cache_path, self.file_pattern.format(id=chrom.id))
-        ret = np.loadtxt(file_path)
+        ret = np.loadtxt(file_path, dtype="int32")
         if len(ret) == 0:
             raise ValueError(f"No annotations found for {id}")
         return ret

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -380,7 +380,7 @@ class Contig:
         :param array intervals: A valid set of intervals.
         :param DFE dfe: A DFE object.
         """
-        stdpopsim.utils.check_intervals_validity(intervals)
+        stdpopsim.utils._check_intervals_validity(intervals)
         for j, ints in enumerate(self.interval_list):
             self.interval_list[j] = stdpopsim.utils.mask_intervals(ints, intervals)
         self.dfe_list.append(DFE)


### PR DESCRIPTION
starting a PR to resolve #1079 

~~one outstanding item from that issue is that I haven't changed the method names of `check_intervals_validity` and `check_intervals_array_shape` to be e.g. `__check_intervals_validity` so that these are private methods~~