### PR TITLE
adding gene conversion support

### DIFF
--- a/stdpopsim/catalog/EscCol/species.py
+++ b/stdpopsim/catalog/EscCol/species.py
@@ -33,6 +33,8 @@ for name, data in genome_data.data["chromosomes"].items():
             # from synonymous substitutions over 40,000 generations.
             mutation_rate=8.9e-11,
             recombination_rate=0.0,
+            gene_conversion_rate=8.9e-11,
+            gene_conversion_length=345,
         )
     )
 

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -248,6 +248,14 @@ def get_species_help(species_id):
     species_text += (
         f"Recombination rate: {species.genome.mean_recombination_rate:.4g}\n"
     )
+    species_text += (
+        f"Gene conversion rate: {species.genome.mean_gene_conversion_rate:.4g}\n"
+    )
+    species_text += (
+        f"Gene conversion tract length: "
+        f"{species.genome.range_gene_conversion_lengths}\n"
+    )
+
     return species_text
 
 

--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -254,6 +254,8 @@ class _MsprimeEngine(Engine):
         ts = msprime.sim_ancestry(
             samples=samples,
             recombination_rate=contig.recombination_map,
+            gene_conversion_rate=contig.gene_conversion_rate,
+            gene_conversion_tract_length=contig.gene_conversion_length,
             demography=demographic_model.model,
             ploidy=2,
             random_seed=seeds[0],

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -170,6 +170,9 @@ class Species:
         length_multiplier=1,
         length=None,
         mutation_rate=None,
+        use_species_gene_conversion=False,
+        gene_conversion_rate=None,
+        gene_conversion_length=None,
         inclusion_mask=None,
         exclusion_mask=None,
     ):
@@ -195,6 +198,19 @@ class Species:
             ``genetic_map`` argument.
         :param float mutation_rate: The per-base mutation rate. If none is given,
             the mutation rate defaults to the rate specified by species chromosomes.
+        :param bool use_species_gene_conversion: If set to True the parameters for gene
+            conversion of the species chromosome are used if available. For "generic"
+            contigs the gene conversion rate is given by the (mean) rate specified by
+            species chromosomes and the gene conversion length defaults to the mean
+            length specified by species chromosomes.
+        :param float gene_conversion_rate: The per-base gene conversion rate. Can only
+            be set together with gene_conversion_length and if
+            use_species_gene_conversion is False; If none is given, and
+            use_species_gene_conversion is True the gene conversion rate specified by
+            species chromosomes is used. If none and use_species_gene_conversion is
+            False gene conversion is disabled.
+        :param float gene_conversion_length: The mean gene conversion length.
+            May only be provided if gene_conversion_rate is also specified.
         :param inclusion_mask: If specified, simulated genomes are subset to only
             inlude regions given by the mask. The mask can be specified by the
             path and file name of a bed file or as a list or array of intervals
@@ -217,6 +233,9 @@ class Species:
             length_multiplier=length_multiplier,
             length=length,
             mutation_rate=mutation_rate,
+            use_species_gene_conversion=use_species_gene_conversion,
+            gene_conversion_rate=gene_conversion_rate,
+            gene_conversion_length=gene_conversion_length,
             inclusion_mask=inclusion_mask,
             exclusion_mask=exclusion_mask,
         )

--- a/tests/test_EscCol.py
+++ b/tests/test_EscCol.py
@@ -26,3 +26,12 @@ class TestGenome(test_species.GenomeTestBase):
 
     def test_basic_attributes(self):
         assert len(self.genome.chromosomes) == 1
+
+    def test_mutation_rate(self):
+        assert self.genome.get_chromosome("Chromosome").mutation_rate == 8.9e-11
+
+    def test_gene_conversion_rate(self):
+        assert self.genome.get_chromosome("Chromosome").gene_conversion_rate == 8.9e-11
+
+    def test_gene_conversion_length(self):
+        assert self.genome.get_chromosome("Chromosome").gene_conversion_length == 345

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,7 +254,7 @@ class TestEndToEnd:
         self.verify(cmd, num_samples=7)
 
     def test_lapierre_constant(self):
-        cmd = "EscCol -L 100 2"
+        cmd = "EscCol -L 1000 2"
         self.verify(cmd, num_samples=2)
 
 
@@ -985,10 +985,10 @@ class TestNoQCWarning:
                 capture_output(stdpopsim.cli.stdpopsim_main, cmd.split())
 
     def test_noQC_warning(self):
-        self.verify_noQC_warning("EscCol -d FakeModel -D 10 -L 10")
+        self.verify_noQC_warning("EscCol -d FakeModel -D 10 -L 1000")
 
     def test_noQC_warning_quiet(self):
-        self.verify_noQC_warning("-q EscCol -d FakeModel -D 10 -L 10")
+        self.verify_noQC_warning("-q EscCol -d FakeModel -D 10 -L 1000")
 
     def verify_noQC_citations_not_written(self, cmd, caplog):
         # Non-QCed models shouldn't be used in publications, so citations
@@ -1011,14 +1011,14 @@ class TestNoQCWarning:
     @pytest.mark.usefixtures("caplog")
     def test_noQC_citations_not_written(self, caplog):
         self.verify_noQC_citations_not_written(
-            "EscCol -d FakeModel -D 10 -L 10", caplog
+            "EscCol -d FakeModel -D 10 -L 1000", caplog
         )
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.QCMissingWarning")
     @pytest.mark.usefixtures("caplog")
     def test_noQC_citations_not_written_verbose(self, caplog):
         self.verify_noQC_citations_not_written(
-            "-vv EscCol -d FakeModel -D 10 -L 10", caplog
+            "-vv EscCol -d FakeModel -D 10 -L 1000", caplog
         )
 
 

--- a/validation.py
+++ b/validation.py
@@ -42,6 +42,8 @@ def irradiate(contig, x=20):
     """
     return stdpopsim.Contig(
         recombination_map=contig.recombination_map,
+        gene_conversion_rate=contig.gene_conversion_rate,
+        gene_conversion_length=contig.gene_conversion_length,
         mutation_rate=x * contig.mutation_rate,
         genetic_map=contig.genetic_map,
     )


### PR DESCRIPTION
This adds a mean gene conversion rate and gene conversion tract length to the chromosome class, as discussed in #846 .
In addition, the corresponding gene conversion parameters for EscCol are added which closes #847 .

It should now be possible to define the gene conversion rates and tract lengths for other species.
So far I did not notice any complications with the existing species and models.

However, the ploidy of the msprime engine is currently hardcoded and set to 2, which doubles the population size of EscCol.
But as integrating the ploidy into stdpopsim is much more entangled with the other species and demographic models, I did not touch the ploidy in this PR. I will open another issue for the ploidy generalization.