### PR TITLE
fixing neutral mutations

### DIFF
--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -223,6 +223,10 @@ class DFE:
                     "mutation_types must be a list of MutationType objects."
                 )
 
+    @property
+    def is_neutral(self):
+        return all([m.is_neutral for m in self.mutation_types])
+
     def __str__(self):
         long_desc_lines = [
             line.strip()

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -623,11 +623,11 @@ def get_msp_and_slim_mutation_rate_maps(contig):
             sum(
                 [
                     p
-                    for p, mt in zip(g.proportions, g.mutation_types)
-                    if not mt.is_neutral
+                    for p, mt in zip(d.proportions, d.mutation_types)
+                    if (not mt.is_neutral)
                 ]
             )
-            for g in contig.dfe_list
+            for d in contig.dfe_list
         ]
         + [0]
     )  # append 0 for the -1 labels
@@ -637,7 +637,6 @@ def get_msp_and_slim_mutation_rate_maps(contig):
     msp_mutation_rate_map = msprime.RateMap(
         position=breaks, rate=contig.mutation_rate * (1 - slim_fractions[dfe_labels])
     )
-
     return (msp_mutation_rate_map, (slim_breaks, slim_rates))
 
 
@@ -944,13 +943,10 @@ def slim_makescript(
                 printsc(f"    m{mid}.convertToSubstitution = F;")
         mut_types = ", ".join([str(mt) for mt in mut_type_list])
         mut_props_list = [
-            prop if (not mt.is_neutral) else 0.0
+            prop if (not mt.is_neutral) or d.is_neutral else 0.0
             for prop, mt in zip(d.proportions, d.mutation_types)
         ]
         mut_props = ", ".join(map(str, mut_props_list))
-        # SLiM does not let you define a GET with all 0 proportions
-        # if np.isclose(sum(mut_props_list), 0.0):
-        #    continue
         printsc(
             f"    initializeGenomicElementType({j}, c({mut_types}), c({mut_props}));"
         )

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -943,7 +943,14 @@ def slim_makescript(
                 # T is the default for WF simulations.
                 printsc(f"    m{mid}.convertToSubstitution = F;")
         mut_types = ", ".join([str(mt) for mt in mut_type_list])
-        mut_props = ", ".join([str(prop) for prop in d.proportions])
+        mut_props_list = [
+            prop if (not mt.is_neutral) else 0.0
+            for prop, mt in zip(d.proportions, d.mutation_types)
+        ]
+        mut_props = ", ".join(map(str, mut_props_list))
+        # SLiM does not let you define a GET with all 0 proportions
+        # if np.isclose(sum(mut_props_list), 0.0):
+        #    continue
         printsc(
             f"    initializeGenomicElementType({j}, c({mut_types}), c({mut_props}));"
         )

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -263,6 +263,7 @@ class TestDFE:
                 assert a == b
             for a, b in zip(mt, dfe.mutation_types):
                 assert a == b
+        assert dfe.is_neutral
 
     def test_dfe_defaults(self):
         m1 = stdpopsim.MutationType()
@@ -278,6 +279,30 @@ class TestDFE:
         assert isinstance(dfe.proportions, list)
         assert len(dfe.proportions) == 1
         assert dfe.proportions[0] == 1
+        assert dfe.is_neutral
+
+    def test_dfe_is_neutral(self):
+        for neutral in (True, False):
+            for dist in ("f", "e"):
+                props = [0.3, 0.7]
+                if neutral:
+                    s = 0
+                else:
+                    s = 0.1
+                mt = [
+                    stdpopsim.MutationType(
+                        distribution_type=dist, distribution_args=[s]
+                    )
+                    for _ in props
+                ]
+                dfe = stdpopsim.DFE(
+                    id=0,
+                    description="test",
+                    long_description="test test",
+                    proportions=props,
+                    mutation_types=mt,
+                )
+                assert dfe.is_neutral is (neutral and dist == "f")
 
     @pytest.mark.usefixtures("capsys")
     def test_printing_dfe(self, capsys):

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1037,7 +1037,8 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             all_neutral = all(
                 [mtype_id in neutral_ids for mtype_id in ge["mutationTypes"]]
             )
-            # checking that the neutral mutations have 0.0 proportion
+            # checking that the neutral mutations have 0.0 proportion unless
+            # all the mutations are neutral in this dfe
             for mtype_id, prop in zip(ge["mutationTypes"], ge["mutationFractions"]):
                 if mtype_id in neutral_ids:
                     if all_neutral:

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1277,7 +1277,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         ge_types = self.slim_metadata_key0(
             ts.metadata["SLiM"]["user_metadata"], "genomicElementTypes"
         )
-        assert np.allclose(ge_types["1"][0]["mutationFractions"], [0.0, 1.0])
+        assert np.allclose(ge_types["1"][0]["mutationFractions"], [0.0, 0.1])
         assert np.allclose(
             ts.metadata["SLiM"]["user_metadata"]["mutationRates"][0]["rates"],
             [contig.mutation_rate * 0.1 * Q],


### PR DESCRIPTION
Fix to #1149

We were simulating neutral mutations within SLiM before. The fix was not as straightforward as @petrelharp pointed in the issue because we cannot have a genomic element type with all 0.0 proportions in SLiM. I added tests to this behavior (one of which is redundant, but is more obviously correct so I thought it wouldn't hurt? Also made some minor cosmetic changes throughout...