### PR TITLE
added MutationType and reference tables to the API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,6 +4,37 @@
 API
 ===
 
+***************
+Quick reference
+***************
+
+Functions to get things:
+
+.. autosummary::
+
+    stdpopsim.get_species
+    stdpopsim.Species.get_contig
+    stdpopsim.Species.get_demographic_model
+    stdpopsim.Species.get_dfe
+    stdpopsim.Species.get_annotations
+    stdpopsim.Contig.add_dfe
+    stdpopsim.get_engine
+
+Classes of objects:
+
+.. autosummary::
+
+   stdpopsim.Species
+   stdpopsim.Genome
+   stdpopsim.Chromosome
+   stdpopsim.Contig
+   stdpopsim.Citation
+   stdpopsim.Annotation
+   stdpopsim.DFE
+   stdpopsim.MutationType
+   stdpopsim.DemographicModel
+   stdpopsim.Population
+
 .. _sec_api_species_definitions:
 
 *******************
@@ -64,6 +95,9 @@ that applies to the entire Contig.
 
 
 .. autoclass:: stdpopsim.DFE()
+    :members:
+
+.. autoclass:: stdpopsim.MutationType()
     :members:
 
 .. _sec_api_generic_models:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ release = "0.1.1"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",

--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -168,7 +168,8 @@ class DFE:
     ``proportions`` and ``mutation_types`` must be lists of the same length,
     and ``proportions`` should be nonnegative numbers summing to 1.
 
-    :ivar ~.mutation_types: A list of MutationTypes associated with the DFE.
+    :ivar ~.mutation_types: A list of :class:`.MutationType` objects associated
+        with the DFE.
     :vartype ~.mutation_types: list
     :ivar ~.proportions: A list of the proportions of new mutations that
         fall in to each of the mutation types (must sum to 1).


### PR DESCRIPTION
I noticed some classes were missing from the API, and added a table up top to make it easier to find things. The table looks like this:
![Screenshot from 2021-12-20 22-24-12](https://user-images.githubusercontent.com/1046249/146881761-97ec8c57-c69e-4724-8dff-0cb4631a522d.png)
