### PR TITLE
Do not simulate neutral mutations

### DIFF
--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -224,6 +224,10 @@ class DFE:
                     "mutation_types must be a list of MutationType objects."
                 )
 
+    @property
+    def is_neutral(self):
+        return all([m.is_neutral for m in self.mutation_types])
+
     def __str__(self):
         long_desc_lines = [
             line.strip()

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -263,6 +263,7 @@ class TestDFE:
                 assert a == b
             for a, b in zip(mt, dfe.mutation_types):
                 assert a == b
+        assert dfe.is_neutral
 
     def test_dfe_defaults(self):
         m1 = stdpopsim.MutationType()
@@ -278,6 +279,30 @@ class TestDFE:
         assert isinstance(dfe.proportions, list)
         assert len(dfe.proportions) == 1
         assert dfe.proportions[0] == 1
+        assert dfe.is_neutral
+
+    def test_dfe_is_neutral(self):
+        for neutral in (True, False):
+            for dist in ("f", "e"):
+                props = [0.3, 0.7]
+                if neutral:
+                    svals = [0.0, 0.0]
+                else:
+                    svals = [0.0, 0.1]
+                mt = [
+                    stdpopsim.MutationType(
+                        distribution_type=dist, distribution_args=[s]
+                    )
+                    for s in svals
+                ]
+                dfe = stdpopsim.DFE(
+                    id=0,
+                    description="test",
+                    long_description="test test",
+                    proportions=props,
+                    mutation_types=mt,
+                )
+                assert dfe.is_neutral is (neutral and dist == "f")
 
     @pytest.mark.usefixtures("capsys")
     def test_printing_dfe(self, capsys):


### PR DESCRIPTION
This is a merge of #1151 and #1152 by @mufernando, with minor changes. Closes #1149.

Here's where we're at:

This PR makes it so SLiM does not simulate neutral mutation types, leaving those for msprime.
This is verified, in part, by saving information about mutation types to top-level metadata, when `verbosity=3`, in `ts.metadata['SLiM']['user_metadata']`.

We would *also* like to have stdpopsim store information in top-level metadata (e.g., under `ts.metadata['stdpopsim']`); for instance, which mutation types go with which DFE? @mufernando made a start at this in #1152. But, that's *separate* because (1) we'll be sticking that information in a different slot in metadata (SLiM can only put stuff in `["SLiM"]["user_metadata"]`); (2) we want to put *more* information than what we have easily available within SLiM (e.g., names of DFEs); (3) our use of metadata here is us asking SLiM to tell us exactly what it's doing, for unit testing, and that's just a different thing than the goal of putting useful information for downstream users in metadata. (But - the SLiM-produced metadata will totally be useful for testing the stdpopsim metadata, when we get that in.)

So - I think we should merge this, and build on #1152 to fix up #1148. (And, I think this was @mufernando's intention?)

Could you have a look at the justification and the code, @mufernando?