### PR TITLE
Bump numpy for Python>=3.8.

### DIFF
--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -16,7 +16,8 @@ appdirs==1.4.4
 humanize==3.13.1
 pyslim==0.700
 pandas==1.3.4
-numpy==1.21.5
+numpy==1.21.5; python_version=='3.7'
+numpy==1.22.0; python_version>='3.8'
 scikit-allel==1.3.5
 zarr==2.10.3
 biopython==1.79


### PR DESCRIPTION
Numpy 1.22.0 dropped support for Python 3.7.
Supercedes #1160.