### PR TITLE
Add Ragsdale DroMel DFE

### DIFF
--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -48,3 +48,71 @@ def _HuberDFE():
 
 
 _species.add_dfe(_HuberDFE())
+
+
+def _RagsdaleDFE():
+    id = "LognormalPlusPositive_R16"
+    description = "Deleterious log-normal and beneficial mixed DFE"
+    long_description = """
+    Return deleterious and beneficial MutationType()s representing a drosophila DFE
+    from Ragsdale et al. (2016), https://doi.org/10.1534/genetics.115.184812.
+    DFE parameters are given in Table S1, with deleterious mutations drawn from a
+    log-normal distribution and a point mass of positive selection. The DFE was
+    inferred assuming synonymous variants are neutral and a relative mutation
+    rate ratio of 2.5 nonsynonymous to 1 synonymous mutation. Results are given as
+    scaled parameters, so that S = 2*N*s, so an estimate of Ne is required to
+    convert the scaled selection coefficients to unscaled coefficients. Because the
+    original study did not report an estimated effective population size, we use
+    the estimate from Huber et al. (2017) of Ne=2.8e6, which was estimated from
+    observed genome-wide synonymous mutation diversity and assuming a mutation rate
+    of 3e-9.
+    """
+    citations = [
+        stdpopsim.Citation(
+            author="Ragsdale et al.",
+            year=2016,
+            doi="https://doi.org/10.1534/genetics.115.184812",
+            reasons={stdpopsim.CiteReason.DFE},
+        )
+    ]
+    # the effective population size is used to rescale genetic to physical units
+    # and Ne here comes from Huber et al (2017), which used the same dataset to
+    # estimate Ne and a different parameterization of the DFE
+    Ne = 2.8e6
+
+    # mutation proportions
+    p_syn = 1 / (1 + 2.5)  # proportion of neutral
+    p_non = 1 - p_syn
+    p_positive = 0.0079 * p_non
+    p_negative = (1 - 0.0079) * p_non
+
+    # selection strengths
+    S_positive = 39.9
+    s_positive = S_positive / 2 / Ne
+    scale_negative = 5.42 / 2 / Ne
+    shape_negative = 3.36
+    h = 0.5
+
+    synonymous = stdpopsim.MutationType()
+    negative = stdpopsim.MutationType(
+        dominance_coeff=h,
+        distribution_type="l",  # log-normal distribution
+        distribution_args=[-scale_negative, shape_negative],
+    )
+    positive = stdpopsim.MutationType(
+        dominance_coeff=h,
+        distribution_type="f",
+        distribution_args=[s_positive],
+    )
+
+    return stdpopsim.DFE(
+        id=id,
+        description=description,
+        long_description=long_description,
+        mutation_types=[synonymous, negative, positive],
+        proportions=[p_syn, p_negative, p_positive],
+        citations=citations,
+    )
+
+
+_species.add_dfe(_RagsdaleDFE())

--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -27,9 +27,9 @@ def is_valid_dfe_id(model_id):
     Returns True if the specified string is a valid dfe model ID. This must
     be a string with the following pattern:
 
-    {something descriptive of model}_{First author initial}{2 digit year}.
+    {CamelCaseName}_{First author initial}{2 digit year}.
     """
-    regex = re.compile(r"[A-Z][a-z]*_[A-Z]*\d\d")
+    regex = re.compile(r"[A-Z][A-Za-z]*_[A-Z]*\d\d")
     return regex.fullmatch(model_id) is not None
 
 


### PR DESCRIPTION
This adds the D melanogaster DFE inferred in [Ragsdale et al, 2016](https://doi.org/10.1534/genetics.115.184812) - see Table S1. The inferred DFE assumed negatively selected mutations are drawn from a log-normal with a given proportion, and positively selected mutations all have a fixed selection coefficient with the remaining proportion.

The re-scaling of the log-normal scale parameter should be double-checked, since the mean of the log-normal is given as 2Ne*s. Pretty sure I just need to divide the scale by 2Ne, but this is based on the scipy definition of the log-normal (which should be standard), and I'm not 100% sure if there are differences in the implementation here.

As an aside, since this was fit on top of an inferred single-population demographic history (using the Zambian DPGP3 data), it might make sense to also add that demographic model in a separate PR. (Edit: which I am happy to do.)