### PR TITLE
simplify logfile code

### DIFF
--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -534,13 +534,9 @@ _slim_logfile = """
     defineConstant("log", sim.createLogFile("$logfile", logInterval=NULL));
     log.addGeneration();
     for (pop in sim.subpopulations.id) {
-        log.addCustomColumn(
-            "mean_fitness_p" + pop,
-            "mean(p" + pop + ".cachedFitness(NULL));"
-        );
-        log.addCustomColumn(
-            "sd_fitness_p" + pop,
-            "sd(p" + pop + ".cachedFitness(NULL));"
+        log.addMeanSDColumns(
+            "fitness_p" + pop,
+            "p" + pop + ".cachedFitness(NULL);"
         );
     }
 }

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1333,8 +1333,8 @@ class TestLogfile(PiecewiseConstantSizeMixin):
             header = f.readline().strip().split(",")
             data = np.loadtxt(f, delimiter=",")
         assert header[0] == "generation"
-        assert header[1][:12] == "mean_fitness"
-        assert header[2][:10] == "sd_fitness"
+        assert header[1][:8] == "fitness_"
+        assert header[2][:8] == "fitness_"
         # neutral model, should have no fitness variation
         assert np.all(data[:, 1] == 1.0)
         assert np.all(data[:, 2] == 0.0)


### PR DESCRIPTION
I'd forgotten about SLiM's `LogFile.addMeanAndSDColumn( )` function and done the mean and SD of fitness myself. This simplifies the code, but does change the name of the columns - before they were `mean_fitness_pX` and `sd_fitness_pX` for population `X`; but now they are `fitness_pX_mean` and `fitness_pX_sd` - I think the only person this might affect is @izabelcavassim.