### PR TITLE
doc: catalog now includes pop name (#1128)

### DIFF
--- a/docs/_ext/speciescatalog.py
+++ b/docs/_ext/speciescatalog.py
@@ -214,7 +214,7 @@ class SpeciesCatalogDirective(SphinxDirective):
             row += entry
 
             entry = nodes.entry()
-            entry += nodes.paragraph(text=population.id)
+            entry += nodes.paragraph(text=population.name)
             row += entry
 
             entry = nodes.entry()
@@ -412,7 +412,7 @@ class SpeciesCatalogDirective(SphinxDirective):
         import matplotlib.pyplot as plt
 
         mid = self.get_demographic_model_id(species, model)
-        _, ax = plt.subplots(1, 1, figsize=(4, 4), tight_layout=True)
+        _, ax = plt.subplots(1, 1, figsize=(4.5, 4), tight_layout=True)
         # Conversion into demes object for easier plotting
         graph = model.model.to_demes()
         ax = demesdraw.tubes(graph, ax=ax, log_time=True)

--- a/stdpopsim/catalog/HomSap/demographic_models.py
+++ b/stdpopsim/catalog/HomSap/demographic_models.py
@@ -220,7 +220,7 @@ def _ooa_nea_extended_pulse():
         description="Three population out-of-Africa with an extended pulse of \
         Neandertal admixture into Europeans",
         long_description="""
-        Demographic model af an extended admixture pulse from Neandertals into
+        Demographic model of an extended admixture pulse from Neandertals into
         Europenas taken from Iasi et al. (2021).
         This model simulates 3 populations: Africans, Europeans and Neandertals
         with an Out-of-Africa event. The population sizes are constant


### PR DESCRIPTION
This PR addresses a couple of small fixes for the documentation: 
1.  Now all population names in the population table correspond to the `demesdraw` images
2. Small typo in the description of model `OutOfAfricaExtendedNeandertalAdmixturePulse_3I21` in `HomSap`

