### PR TITLE
Updated BosTau Holstein demography mut rate #579

### DIFF
--- a/stdpopsim/catalog/BosTau/demographic_models.py
+++ b/stdpopsim/catalog/BosTau/demographic_models.py
@@ -30,7 +30,7 @@ def _HolsteinFriesian_1M13():
         populations=populations,
         citations=citations,
         generation_time=_species.generation_time,
-        mutation_rate=1e-8,
+        mutation_rate=0.94e-8,
         population_configurations=[
             #      3 generations at    90,     1-     3
             msprime.PopulationConfiguration(


### PR DESCRIPTION
Updated BosTau Holstein demography mut rate #579 to match the supplement https://academic.oup.com/mbe/article/30/9/2209/1002512 value since we use supplement Ne estimates - the supplement mutation rate is meant to be the sequence error anyway, which is what the simulation gives.

@igronau It would be great if you can merge this in. Thanks!