### PR TITLE
added qc-ed species to the catalog

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -40,9 +40,17 @@ page to learn about the process for adding new items to the catalog.
 Then, if you feel ready, make an issue on our
 `GitHub page <https://github.com/popgensims/stdpopsim/issues>`_.
 
+.. speciescatalog:: AedAeg
+
+.. speciescatalog:: AnaPla
+
+.. speciescatalog:: AnoCar
+
 .. speciescatalog:: AraTha
 
 .. speciescatalog:: CanFam
+
+.. speciescatalog:: ChlRei
 
 .. speciescatalog:: DroMel
 

--- a/tests/test_AnaPla.py
+++ b/tests/test_AnaPla.py
@@ -35,9 +35,7 @@ class TestGenomeData(test_species.GenomeTestBase):
 
     genome = stdpopsim.get_species("AnaPla").genome
 
-    # @pytest.mark.skip("Recombination rate QC not done yet")
-
-    # total map lengths fo chromosomes 1-18 taken from from Huang et al 2006
+    # total map lengths for chromosomes 1-18 taken from from Huang et al 2006
     # Table 1. See: https://academic.oup.com/view-large/280279985
     # The average rec rate for chroms 1-18 is this map length
     # divided by the physical length of the chromosome

--- a/tests/test_AnoCar.py
+++ b/tests/test_AnoCar.py
@@ -17,10 +17,6 @@ class TestSpeciesData(test_species.SpeciesTestBase):
     def test_common_name(self):
         assert self.species.common_name == "Anole lizard"
 
-    # QC Tests. These tests are performed by another contributor
-    # independently referring to the citations provided in the
-    # species definition, filling in the appropriate values
-    # and deleting the pytest "skip" annotations.
     def test_qc_population_size(self):
         assert self.species.population_size == 3.05e6
 

--- a/tests/test_ChlRei.py
+++ b/tests/test_ChlRei.py
@@ -17,10 +17,6 @@ class TestSpeciesData(test_species.SpeciesTestBase):
     def test_common_name(self):
         assert self.species.common_name == "Chlamydomonas reinhardtii"
 
-    # QC Tests. These tests are performed by another contributor
-    # independently referring to the citations provided in the
-    # species definition, filling in the appropriate values
-    # and deleting the pytest "skip" annotations.
     def test_qc_population_size(self):
         assert self.species.population_size == 1.4 * 1e-7
 


### PR DESCRIPTION
I've gone through the `tests/test_SpeciesName.py` files to see which had been QC'ed (is there a better way to do this?), and have added those QC'ed species to the catalog.

Along the way, I noticed that a few more of the older species are not as QC'ed as the current standard (mostly just that recombination rates aren't checked) beyond AraTha (#539) and PonAbe (#544):
- [CanFam](https://github.com/popsim-consortium/stdpopsim/blob/main/tests/test_CanFam.py)
- [DroMel](https://github.com/popsim-consortium/stdpopsim/blob/main/tests/test_DroMel.py#L36) - note it just tests if rates are nonzero

