### PR TITLE
Add missed migration parameters for PonAbe model in documentation

### DIFF
--- a/docs/parameter_tables/PonAbe/TwoSpecies_2L11.csv
+++ b/docs/parameter_tables/PonAbe/TwoSpecies_2L11.csv
@@ -4,7 +4,7 @@ Population size,"7,317",Pongo abelii pop. size at split
 Population size,"8,805",Modern Pongo pygmaeus pop. size
 Population size,"37,661",Modern Pongo abelii pop. size
 Migration rate (x10^-5),"1.10",Pongo abelii - Pongo pygmaeus migration rate (per gen.)
-Migration rate (x10^-5),"0.66",Pongo pygmaeus - Pongo abelii migration rate (per gen.)
+Migration rate (x10^-5),"0.67",Pongo pygmaeus - Pongo abelii migration rate (per gen.)
 Epoch Time (gen.),"20,157",Species divergence time
 Generation time (yrs.),20,Generation time
 Mutation rate,2e-8,Per-base per-generation mutation rate

--- a/docs/parameter_tables/PonAbe/TwoSpecies_2L11.csv
+++ b/docs/parameter_tables/PonAbe/TwoSpecies_2L11.csv
@@ -3,6 +3,8 @@ Population size,"10,617",Pongo pygmaeus pop. size at split
 Population size,"7,317",Pongo abelii pop. size at split
 Population size,"8,805",Modern Pongo pygmaeus pop. size
 Population size,"37,661",Modern Pongo abelii pop. size
+Migration rate (x10^-5),"1.10",Pongo abelii - Pongo pygmaeus migration rate (per gen.)
+Migration rate (x10^-5),"0.66",Pongo pygmaeus - Pongo abelii migration rate (per gen.)
 Epoch Time (gen.),"20,157",Species divergence time
 Generation time (yrs.),20,Generation time
 Mutation rate,2e-8,Per-base per-generation mutation rate


### PR DESCRIPTION
I found that the migration rates are missed in the documentation for the demographic model of Pongo abelii. The description of the model is correct. I checked the paper and model code in `stdpopsim` - both includes migrations. Thus, I just add descriptions in the docs table.