### PR TITLE
Fixup of PanTro QC (closes #1220)

### DIFF
--- a/stdpopsim/catalog/PanTro/species.py
+++ b/stdpopsim/catalog/PanTro/species.py
@@ -60,7 +60,7 @@ _species = stdpopsim.Species(
     name="Pan troglodytes",
     common_name="Chimpanzee",
     genome=_genome,
-    generation_time=25.0,
+    generation_time=24.6,
     population_size=16781,
     citations=[
         _langergraber2012.because(stdpopsim.CiteReason.GEN_TIME),

--- a/tests/test_PanTro.py
+++ b/tests/test_PanTro.py
@@ -18,15 +18,9 @@ class TestSpecies(test_species.SpeciesTestBase):
     def test_common_name(self):
         assert self.species.common_name == "Chimpanzee"
 
-    # QC Tests. These tests are performed by another contributor
-    # independently referring to the citations provided in the
-    # species definition, filling in the appropriate values
-    # and deleting the pytest "skip" annotations.
-    @pytest.mark.skip("Population size QC not done yet")
     def test_qc_population_size(self):
         assert self.species.population_size == 16781
 
-    @pytest.mark.skip("Generation time QC not done yet")
     def test_qc_generation_time(self):
         assert self.species.generation_time == 24.6
 
@@ -35,18 +29,15 @@ class TestGenome(test_species.GenomeTestBase):
 
     genome = stdpopsim.get_species("PanTro").genome
 
-    @pytest.mark.skip("Number of chromosomes QC not done yet")
     def test_basic_attributes(self):
         assert len(self.genome.chromosomes) == 25
 
-    @pytest.mark.skip("Recombination rate QC not done yet")
     @pytest.mark.parametrize("chr_id", [chrom.id for chrom in genome.chromosomes])
     def test_recombination_rate(self, chr_id, rate=1.2e-8):
         assert rate == pytest.approx(
             self.genome.get_chromosome(chr_id).recombination_rate
         )
 
-    @pytest.mark.skip("Mutation rate QC not done yet")
     @pytest.mark.parametrize("chr_id", [chrom.id for chrom in genome.chromosomes])
     def test_mutation_rate(self, chr_id, rate=1.6e-8):
         assert rate == pytest.approx(self.genome.get_chromosome(chr_id).mutation_rate)


### PR DESCRIPTION
My bad - I merged #1291 over-hastily, forgetting to remove the pytest.mark.skip's. This fixes that and makes the generation time agree, as discussed in #1220.