### PR TITLE
Use string `mutation_id` in place of integer `mutation_type_id` in extended events 

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1224,10 +1224,12 @@ of at least 0.8 by the end. Next, we'll walk through the steps required to do th
     this conditioning works by re-running the simulation until the condition is
     achieved, a nearly impossible condition will result in very long run times.
 
-First, we need to add a single site mutation in the middle of the contig.
-This represents a mutation of a single base pair, with associated fitness and
-dominance coefficients.  The single site mutation must have a unique string ID
-so that we can refer to it later.
+To set things up, we need to first add the site at which the selected mutation
+will occur.  This is like adding a DFE, except to a single site -- we're saying
+that there is a potential mutation at a particular site with defined fitness
+consequences. So that we can refer to the single site later, we give it a
+unique string ID. Here, we'll add the site in the middle of the contig, with ID
+"hard sweep".
 
 .. code-block:: python
 
@@ -1242,10 +1244,11 @@ so that we can refer to it later.
 
 .. note::
 
-    Note that single site mutations are internally stored as DFEs, and DFEs
-    cannot overlap. As a consequence, if a DFE is added to the contig over an
-    interval that contains an existing single site mutation, the latter will be
-    "overwritten" and an error will be raised by the simulation engine.
+    Note that single site mutations are internally stored as DFEs, and more
+    than one DFE cannot apply to the same segment of genome. As a consequence,
+    if another DFE is added to the contig over an interval that already
+    contains a single site mutation, the single site mutation will be
+    "overwritten" and an error will be raised in simulation.
 
 Next, we will set up the "extended events" which will modify the demography.
 The first extended event is the origination of the selected mutation, which
@@ -1261,7 +1264,6 @@ that the simulation can restart from that point if the mutation is lost.
             time=T_mut,
             single_site_id=mut_id,
             population_id=0,
-            save=True,
         )
     ]
 

--- a/stdpopsim/ext/selection.py
+++ b/stdpopsim/ext/selection.py
@@ -76,7 +76,7 @@ class DrawMutation(ExtendedEvent):
     """
 
     time = attr.ib(type=float)
-    mutation_type_id = attr.ib(type=int)
+    mutation_id = attr.ib(type=str)
     population_id = attr.ib(type=int)
     coordinate = attr.ib(type=int)
     save = attr.ib(type=bool, default=False)
@@ -100,7 +100,7 @@ class ChangeMutationFitness(ExtendedEvent):
 
     start_time = attr.ib(type=float)
     end_time = attr.ib(type=float)
-    mutation_type_id = attr.ib(type=int)
+    mutation_id = attr.ib(type=str)
     population_id = attr.ib(type=int)
     selection_coeff = attr.ib(type=float)
     dominance_coeff = attr.ib(type=float)
@@ -127,7 +127,7 @@ class ConditionOnAlleleFrequency(ExtendedEvent):
 
     start_time = attr.ib(type=float)
     end_time = attr.ib(type=float)
-    mutation_type_id = attr.ib(type=int)
+    mutation_id = attr.ib(type=str)
     population_id = attr.ib(type=int)
     op = attr.ib(type=str, default=None)
     allele_frequency = attr.ib(type=float, default=None)

--- a/stdpopsim/ext/selection.py
+++ b/stdpopsim/ext/selection.py
@@ -76,9 +76,8 @@ class DrawMutation(ExtendedEvent):
     """
 
     time = attr.ib(type=float)
-    mutation_id = attr.ib(type=str)
+    single_site_id = attr.ib(type=str)
     population_id = attr.ib(type=int)
-    coordinate = attr.ib(type=int)
     save = attr.ib(type=bool, default=False)
 
     def __attrs_post_init__(self):
@@ -100,7 +99,7 @@ class ChangeMutationFitness(ExtendedEvent):
 
     start_time = attr.ib(type=float)
     end_time = attr.ib(type=float)
-    mutation_id = attr.ib(type=str)
+    single_site_id = attr.ib(type=str)
     population_id = attr.ib(type=int)
     selection_coeff = attr.ib(type=float)
     dominance_coeff = attr.ib(type=float)
@@ -127,7 +126,7 @@ class ConditionOnAlleleFrequency(ExtendedEvent):
 
     start_time = attr.ib(type=float)
     end_time = attr.ib(type=float)
-    mutation_id = attr.ib(type=str)
+    single_site_id = attr.ib(type=str)
     population_id = attr.ib(type=int)
     op = attr.ib(type=str, default=None)
     allele_frequency = attr.ib(type=float, default=None)

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -462,7 +462,7 @@ class Contig:
             long_description=long_description,
         )
         self.add_dfe(
-            intervals=np.array([[coordinate - 1, coordinate]], dtype="int"),
+            intervals=np.array([[coordinate, coordinate + 1]], dtype="int"),
             DFE=dfe,
         )
 

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -386,6 +386,64 @@ class Contig:
         self.dfe_list.append(DFE)
         self.interval_list.append(intervals)
 
+    def add_single_site_mutation_type(self, id, selection_coeff=0.0, dominance_coeff=1.0):
+        """
+        Adds a DFE representing a mutation at a single site, contain a single
+        :class:`MutationType` with the provided parameters. The string ID of
+        the mutation may be referenced by extended events passed to the
+        simulation engine.
+
+        For instance, to simulate a selective sweep,
+        ```
+        contig.add_single_site_mutation_type(
+            id = "sweep_variant", 
+            selection_coef=0.1,
+        )
+        extended_events = [
+    	    stdpopsim.ext.DrawMutation(
+    	        time=mutation_time,
+    	        mutation_id="sweep_variant",
+    	        population_id=0,
+    	        coordinate=mutation_coordinate,
+    	        save=True,
+    	    ),
+    	    stdpopsim.ext.ConditionOnAlleleFrequency(
+    	        start_time=stdpopsim.ext.GenerationAfter(mutation_time),
+    	        end_time=0,
+    	        mutation_id="sweep_variant",
+    	        population_id=0,
+    	        op=">",
+    	        allele_frequency=0.0,
+    	    )
+        ]
+        engine = stdpopsim.get_engine("slim")
+        ts_sweep = engine.simulate(...,
+            extended_events=extended_events,
+        )
+        ```
+
+        :param str id: A unique identifier for the DFE representing the mutation.
+        :param float selection_coeff: The selection coefficient of the mutation, see :class:`MutationType`.
+        :param float dominance_coeff: The dominance coefficient of the mutation, see :class:`MutationType`.
+        """
+        mut_type = stdpopsim.MutationType(
+                distribution_type="f",
+                dominance_coeff=dominance_coeff,
+                distribution_args=[selection_coeff],
+                convert_to_substitution=False,
+        )
+        dfe = stdpopsim.DFE(
+            id=id,
+            mutation_types=[mut_type],
+            proportions=[1.0],
+            description="Single site mutation",
+            long_description="Added by 'Contig.add_single_site_mutation_type'",
+        )
+        self.add_dfe(
+            intervals=np.empty((0,2), dtype='int'), 
+            DFE=dfe,
+        )
+
     @property
     def is_neutral(self):
         """

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -462,7 +462,7 @@ class Contig:
             long_description=long_description,
         )
         self.add_dfe(
-            intervals=np.array([[coordinate, coordinate + 1]], dtype="int"),
+            intervals=np.array([[coordinate - 1, coordinate]], dtype="int"),
             DFE=dfe,
         )
 

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -386,35 +386,40 @@ class Contig:
         self.dfe_list.append(DFE)
         self.interval_list.append(intervals)
 
-    def add_single_site_mutation_type(
-        self, id, selection_coeff=0.0, dominance_coeff=1.0
+    def add_single_site(
+        self,
+        id,
+        coordinate,
+        selection_coeff=0.0,
+        dominance_coeff=0.5,
+        description=None,
+        long_description=None,
     ):
         """
-        Adds a DFE representing a mutation at a single site, contain a single
-        :class:`MutationType` with the provided parameters. The string ID of
-        the mutation may be referenced by extended events passed to the
-        simulation engine.
+        Adds a model of a single site mutation at the provided coordinate.
+        The string label of the single site may be referenced by extended
+        events passed to the simulation engine.
 
         For instance, to simulate a selective sweep,
 
         .. code-block:: python
 
-            contig.add_single_site_mutation_type(
+            contig.add_single_site(
                 id="sweep_variant",
-                selection_coef=0.1,
+                selection_coeff=0.1,
+                coordinate=mutation_coordinate,
             )
             extended_events = [
                 stdpopsim.ext.DrawMutation(
                     time=mutation_time,
-                    mutation_id="sweep_variant",
+                    single_site_id="sweep_variant",
                     population_id=0,
-                    coordinate=mutation_coordinate,
                     save=True,
                 ),
                 stdpopsim.ext.ConditionOnAlleleFrequency(
                     start_time=stdpopsim.ext.GenerationAfter(mutation_time),
                     end_time=0,
-                    mutation_id="sweep_variant",
+                    single_site_id="sweep_variant",
                     population_id=0,
                     op=">",
                     allele_frequency=0.0,
@@ -426,12 +431,23 @@ class Contig:
                 extended_events=extended_events,
             )
 
-        :param str id: A unique identifier for the DFE representing the mutation.
+        :param str id: A unique identifier for the single site.
+        :param int coordinate: The coordinate of the site on the contig.
         :param float selection_coeff: The selection coefficient of the mutation,
             see :class:`MutationType` for details.
         :param float dominance_coeff: The dominance coefficient of the mutation,
             see :class:`MutationType` for details.
+        :param str description: A short description of the single site mutation
+            model as it would be used in written text, e.g., "Strong selective
+            sweep".
+        :param str long_description: A concise, but detailed, summary of the
+            single site mutation model.
         """
+        if description is None:
+            description = "Single site mutation"
+        if long_description is None:
+            long_description = "Added by Contig.add_single_site"
+
         mut_type = stdpopsim.MutationType(
             distribution_type="f",
             dominance_coeff=dominance_coeff,
@@ -442,11 +458,11 @@ class Contig:
             id=id,
             mutation_types=[mut_type],
             proportions=[1.0],
-            description="Single site mutation",
-            long_description="Added by 'Contig.add_single_site_mutation_type'",
+            description=description,
+            long_description=long_description,
         )
         self.add_dfe(
-            intervals=np.empty((0, 2), dtype="int"),
+            intervals=np.array([[coordinate, coordinate + 1]], dtype="int"),
             DFE=dfe,
         )
 

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -386,7 +386,9 @@ class Contig:
         self.dfe_list.append(DFE)
         self.interval_list.append(intervals)
 
-    def add_single_site_mutation_type(self, id, selection_coeff=0.0, dominance_coeff=1.0):
+    def add_single_site_mutation_type(
+        self, id, selection_coeff=0.0, dominance_coeff=1.0
+    ):
         """
         Adds a DFE representing a mutation at a single site, contain a single
         :class:`MutationType` with the provided parameters. The string ID of
@@ -394,43 +396,47 @@ class Contig:
         simulation engine.
 
         For instance, to simulate a selective sweep,
-        ```
-        contig.add_single_site_mutation_type(
-            id = "sweep_variant", 
-            selection_coef=0.1,
-        )
-        extended_events = [
-    	    stdpopsim.ext.DrawMutation(
-    	        time=mutation_time,
-    	        mutation_id="sweep_variant",
-    	        population_id=0,
-    	        coordinate=mutation_coordinate,
-    	        save=True,
-    	    ),
-    	    stdpopsim.ext.ConditionOnAlleleFrequency(
-    	        start_time=stdpopsim.ext.GenerationAfter(mutation_time),
-    	        end_time=0,
-    	        mutation_id="sweep_variant",
-    	        population_id=0,
-    	        op=">",
-    	        allele_frequency=0.0,
-    	    )
-        ]
-        engine = stdpopsim.get_engine("slim")
-        ts_sweep = engine.simulate(...,
-            extended_events=extended_events,
-        )
-        ```
+
+        .. code-block:: python
+
+            contig.add_single_site_mutation_type(
+                id="sweep_variant",
+                selection_coef=0.1,
+            )
+            extended_events = [
+                stdpopsim.ext.DrawMutation(
+                    time=mutation_time,
+                    mutation_id="sweep_variant",
+                    population_id=0,
+                    coordinate=mutation_coordinate,
+                    save=True,
+                ),
+                stdpopsim.ext.ConditionOnAlleleFrequency(
+                    start_time=stdpopsim.ext.GenerationAfter(mutation_time),
+                    end_time=0,
+                    mutation_id="sweep_variant",
+                    population_id=0,
+                    op=">",
+                    allele_frequency=0.0,
+                ),
+            ]
+            engine = stdpopsim.get_engine("slim")
+            ts_sweep = engine.simulate(
+                ...,
+                extended_events=extended_events,
+            )
 
         :param str id: A unique identifier for the DFE representing the mutation.
-        :param float selection_coeff: The selection coefficient of the mutation, see :class:`MutationType`.
-        :param float dominance_coeff: The dominance coefficient of the mutation, see :class:`MutationType`.
+        :param float selection_coeff: The selection coefficient of the mutation,
+            see :class:`MutationType` for details.
+        :param float dominance_coeff: The dominance coefficient of the mutation,
+            see :class:`MutationType` for details.
         """
         mut_type = stdpopsim.MutationType(
-                distribution_type="f",
-                dominance_coeff=dominance_coeff,
-                distribution_args=[selection_coeff],
-                convert_to_substitution=False,
+            distribution_type="f",
+            dominance_coeff=dominance_coeff,
+            distribution_args=[selection_coeff],
+            convert_to_substitution=False,
         )
         dfe = stdpopsim.DFE(
             id=id,
@@ -440,7 +446,7 @@ class Contig:
             long_description="Added by 'Contig.add_single_site_mutation_type'",
         )
         self.add_dfe(
-            intervals=np.empty((0,2), dtype='int'), 
+            intervals=np.empty((0, 2), dtype="int"),
             DFE=dfe,
         )
 

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -405,21 +405,21 @@ class Contig:
         .. code-block:: python
 
             contig.add_single_site(
-                id="sweep_variant",
+                id="hard_sweep",
                 selection_coeff=0.1,
                 coordinate=mutation_coordinate,
             )
             extended_events = [
                 stdpopsim.ext.DrawMutation(
                     time=mutation_time,
-                    single_site_id="sweep_variant",
+                    single_site_id="hard_sweep",
                     population_id=0,
                     save=True,
                 ),
                 stdpopsim.ext.ConditionOnAlleleFrequency(
                     start_time=stdpopsim.ext.GenerationAfter(mutation_time),
                     end_time=0,
-                    single_site_id="sweep_variant",
+                    single_site_id="hard_sweep",
                     population_id=0,
                     op=">",
                     allele_frequency=0.0,
@@ -440,8 +440,7 @@ class Contig:
         :param str description: A short description of the single site mutation
             model as it would be used in written text, e.g., "Strong selective
             sweep".
-        :param str long_description: A concise, but detailed, summary of the
-            single site mutation model.
+        :param str long_description: If necessary, a more detailed summary.
         """
         if description is None:
             description = "Single site mutation"

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -950,19 +950,20 @@ def slim_makescript(
     slim_mutation_ids = []
     slim_mutation_dfe = []
     for i, x in _dfe_to_mtypes(contig).items():
-      slim_mutation_ids.extend([u[0] for u in x])
-      slim_mutation_dfe.extend([i for u in x])
+        slim_mutation_ids.extend([u[0] for u in x])
+        slim_mutation_dfe.extend([i for u in x])
     for ee in extended_events:
         if hasattr(ee, "mutation_id"):
             mut_id = getattr(ee, "mutation_id")
             cls_name = ee.__class__.__name__
             mtype_idx = [
-                j for j,i in enumerate(slim_mutation_dfe) 
+                j
+                for j, i in enumerate(slim_mutation_dfe)
                 if contig.dfe_list[i].id == mut_id
             ]
             n_mtypes = len(mtype_idx)
             # TODO: are these checks too restrictive? For example, these will
-            # prevent using DrawMutation with an arbitrary MutationType in an 
+            # prevent using DrawMutation with an arbitrary MutationType in an
             # arbitary DFE.
             if n_mtypes != 1:
                 raise ValueError(
@@ -983,7 +984,7 @@ def slim_makescript(
                     )
 
         if hasattr(ee, "mutation_type_id"):
-            # TODO: this is a bit redundant now that ee.mutation_type 
+            # TODO: this is a bit redundant now that ee.mutation_type
             # replaces ee.mutation_type_id in the API, but should
             # allow setattr(ee, "mutation_type_id", <int>) to work for
             # arbitrary DFEs, if ee.mutation_type is None.

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -318,6 +318,8 @@ _slim_main = """
                     g_start+" > g_end="+g_end);
             }
 
+            // Save the state conditional on the allele frequency.
+            // If the condition isn't met, we restore.
             if (save) {
                 // Save the state conditional on the allele frequency.
                 // If the condition isn't met, we restore.
@@ -947,116 +949,108 @@ def slim_makescript(
     fitness_callbacks = []
     condition_on_allele_frequency = []
     op_id = stdpopsim.ext.ConditionOnAlleleFrequency.op_id
-    slim_mutation_ids = []
-    slim_mutation_dfe = []
-    for i, x in _dfe_to_mtypes(contig).items():
-        slim_mutation_ids.extend([u[0] for u in x])
-        slim_mutation_dfe.extend([i for u in x])
+    slim_mutation_ids = _dfe_to_mtypes(contig)
+    drawn_single_site_ids = set()
+    referenced_single_site_ids = set()
     for ee in extended_events:
+        mutation_type_id = None
+        coordinate = None
         if hasattr(ee, "single_site_id"):
-            mut_id = getattr(ee, "single_site_id")
             cls_name = ee.__class__.__name__
-            mtype_idx = [
-                j
-                for j, i in enumerate(slim_mutation_dfe)
-                if contig.dfe_list[i].id == mut_id
+            dfe_index = [
+                i for i, x in enumerate(contig.dfe_list) if x.id == ee.single_site_id
             ]
-            n_mtypes = len(mtype_idx)
-            if n_mtypes != 1:
+            if len(dfe_index) != 1:
                 raise ValueError(
-                    f"The single site mutation type with id '{mut_id}' "
+                    f"The single site with id '{ee.single_site_id}' "
                     f"referenced by {cls_name} must exist and be uniquely "
-                    f"labelled, but there are {n_mtypes} other mutation types "
+                    f"labelled, but there are {len(dfe_index)} DFEs "
                     f"with this id on {contig}. "
                 )
-            mtype_idx = mtype_idx[0]
-            setattr(ee, "mutation_type_id", slim_mutation_ids[mtype_idx])
-            dfe_idx = slim_mutation_dfe[mtype_idx]
-            dfe_intervals = contig.interval_list[dfe_idx]
+            dfe_index = dfe_index[0]
+            if len(slim_mutation_ids[dfe_index]) != 1:
+                raise ValueError(
+                    f"The single site with id '{ee.single_site_id}' referenced "
+                    f"by {cls_name} must contain a single mutation type, but "
+                    f"has {len(slim_mutation_ids[dfe_index])} mutation "
+                    f"types."
+                )
+            dfe_intervals = contig.interval_list[dfe_index]
             if dfe_intervals.shape[0] == 0:
                 raise ValueError(
-                    f"The single site id '{mut_id}' referenced by {cls_name} "
-                    f"has no coordinate: it may have been removed by the addition "
-                    f"of an overlapping DFE or a single site with an "
-                    f"identical coordinate."
+                    f"The single site id '{ee.single_site_id}' referenced by "
+                    f"{cls_name} has no coordinate: it may have been removed "
+                    f"by the addition of an overlapping DFE after the single "
+                    f"site was added to the contig."
                 )
             if (
                 dfe_intervals.shape[0] > 1
                 or dfe_intervals[0, 1] - dfe_intervals[0, 0] != 1
             ):
                 raise ValueError(
-                    f"The id '{mut_id}' referenced by {cls_name} "
-                    f"refers to a DFE with intervals {dfe_intervals}, "
-                    f"not to a single site."
+                    f"The id '{ee.single_site_id}' referenced by {cls_name} "
+                    f"refers to a DFE with intervals {dfe_intervals}, not "
+                    f"to a single site."
                 )
-            setattr(ee, "coordinate", dfe_intervals[0, 0])
-            assert len(contig.dfe_list[dfe_idx].mutation_types) == 1
-            mt = contig.dfe_list[dfe_idx].mutation_types[0]
+            mt_id, mt = slim_mutation_ids[dfe_index][0]
             if not mt.distribution_type == "f":
                 raise ValueError(
-                    f"The single site id '{mut_id}' referenced by "
+                    f"The single site id '{ee.single_site_id}' referenced by "
                     f"{cls_name} has a mutation type with fitness "
-                    f"distribution '{mt.distribution_type}', instead "
-                    f"of a fixed fitness coefficient."
+                    f"distribution '{mt.distribution_type}', instead of a "
+                    f"fixed fitness coefficient."
                 )
-
+            coordinate = dfe_intervals[0, 0]
+            mutation_type_id = mt_id
         if hasattr(ee, "start_time") and hasattr(ee, "end_time"):
             # Now that GenerationAfter times have been accounted for, we can
             # properly catch invalid start/end times.
-            start_time = getattr(ee, "start_time")
-            end_time = getattr(ee, "end_time")
-            stdpopsim.ext.validate_time_range(start_time, end_time)
+            stdpopsim.ext.validate_time_range(ee.start_time, ee.end_time)
 
+        # Append attributes to lists per event type
         if isinstance(ee, stdpopsim.ext.DrawMutation):
-            # TODO: warning if mutation type id points to a neutral mut.
-            time = ee.time * demographic_model.generation_time
-            save = 1 if ee.save else 0
             drawn_mutations.append(
-                (time, ee.mutation_type_id, ee.population_id, ee.coordinate, save)
+                (
+                    ee.time * demographic_model.generation_time,
+                    mutation_type_id,
+                    ee.population_id,
+                    coordinate,
+                    int(ee.save),
+                )
             )
+            drawn_single_site_ids.add(ee.single_site_id)
         elif isinstance(ee, stdpopsim.ext.ChangeMutationFitness):
-            start_time = ee.start_time * demographic_model.generation_time
-            end_time = ee.end_time * demographic_model.generation_time
             fitness_callbacks.append(
                 (
-                    start_time,
-                    end_time,
-                    ee.mutation_type_id,
+                    ee.start_time * demographic_model.generation_time,
+                    ee.end_time * demographic_model.generation_time,
+                    mutation_type_id,
                     ee.population_id,
                     ee.selection_coeff,
                     ee.dominance_coeff,
                 )
             )
+            referenced_single_site_ids.add(ee.single_site_id)
         elif isinstance(ee, stdpopsim.ext.ConditionOnAlleleFrequency):
-            start_time = ee.start_time * demographic_model.generation_time
-            end_time = ee.end_time * demographic_model.generation_time
-            save = 1 if ee.save else 0
             condition_on_allele_frequency.append(
                 (
-                    start_time,
-                    end_time,
-                    ee.mutation_type_id,
+                    ee.start_time * demographic_model.generation_time,
+                    ee.end_time * demographic_model.generation_time,
+                    mutation_type_id,
                     ee.population_id,
                     op_id(ee.op),
                     ee.allele_frequency,
-                    save,
+                    int(ee.save),
                 )
             )
+            referenced_single_site_ids.add(ee.single_site_id)
         else:
             raise ValueError(f"Unknown extended event type {type(ee)}")
 
     # Check that drawn mutations exist for extended events that need them.
-    drawn_mut_type_ids = {mt_id for _, mt_id, _, _, _ in drawn_mutations}
-    for ee in extended_events:
-        if isinstance(ee, stdpopsim.ext.ChangeMutationFitness) or isinstance(
-            ee, stdpopsim.ext.ConditionOnAlleleFrequency
-        ):
-            if ee.mutation_type_id not in drawn_mut_type_ids:
-                cls_name = ee.__class__.__name__
-                raise ValueError(
-                    f"Invalid {cls_name} event. No drawn mutation for "
-                    f"mutation type id {ee.mutation_type_id}"
-                )
+    for single_site_id in referenced_single_site_ids:
+        if single_site_id not in drawn_single_site_ids:
+            raise ValueError(f"No drawn mutation for single site id {single_site_id}.")
 
     printsc = functools.partial(print, file=script_file)
 

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -975,29 +975,29 @@ def slim_makescript(
             dfe_intervals = contig.interval_list[dfe_idx]
             if dfe_intervals.shape[0] == 0:
                 raise ValueError(
-                    f"The single site id '{mut_id}' associated with the {cls_name} "
-                    f"event has no coordinate: it may have been removed by the addition "
-                    f"of an overlapping DFE or single site."
+                    f"The single site id '{mut_id}' referenced by {cls_name} "
+                    f"has no coordinate: it may have been removed by the addition "
+                    f"of an overlapping DFE or a single site with an "
+                    f"identical coordinate."
                 )
-            if dfe_intervals.shape[0] > 1:
+            if (
+                dfe_intervals.shape[0] > 1
+                or dfe_intervals[0, 1] - dfe_intervals[0, 0] != 1
+            ):
                 raise ValueError(
-                    f"The single site id '{mut_id}' associated with the {cls_name} "
-                    f"event refers to a DFE with multiple intervals, {dfe_intervals}."
+                    f"The id '{mut_id}' referenced by {cls_name} "
+                    f"refers to a DFE with intervals {dfe_intervals}, "
+                    f"not to a single site."
                 )
-            if dfe_intervals[0, 1] - dfe_intervals[0, 0] != 1:
-                raise ValueError(
-                    f"The single site id '{mut_id}' associated with the {cls_name} "
-                    f"event refers to a DFE that spans multiple sites, {dfe_intervals}."
-                )
-            setattr(ee, "coordinate", dfe_intervals[0, 1])
+            setattr(ee, "coordinate", dfe_intervals[0, 0])
             assert len(contig.dfe_list[dfe_idx].mutation_types) == 1
             mt = contig.dfe_list[dfe_idx].mutation_types[0]
             if not mt.distribution_type == "f":
                 raise ValueError(
-                    f"The single site id '{mut_id}' associated with the "
-                    f"{cls_name} event refers to a mutation type with fitness "
-                    f"distribution '{mt.distribution_type}', instead of a "
-                    f"fixed fitness coefficient ('f')."
+                    f"The single site id '{mut_id}' referenced by "
+                    f"{cls_name} has a mutation type with fitness "
+                    f"distribution '{mt.distribution_type}', instead "
+                    f"of a fixed fitness coefficient."
                 )
 
         if hasattr(ee, "start_time") and hasattr(ee, "end_time"):

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -964,9 +964,10 @@ def slim_makescript(
             n_mtypes = len(mtype_idx)
             if n_mtypes != 1:
                 raise ValueError(
-                    f"The single site mutation id '{mut_id}' associated with the "
-                    f"{cls_name} event must be unique, but there are {n_mtypes} "
-                    f"other mutation types with the same id on {contig}. "
+                    f"The single site mutation type with id '{mut_id}' "
+                    f"referenced by {cls_name} must exist and be uniquely "
+                    f"labelled, but there are {n_mtypes} other mutation types "
+                    f"with this id on {contig}. "
                 )
             mtype_idx = mtype_idx[0]
             setattr(ee, "mutation_type_id", slim_mutation_ids[mtype_idx])

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1383,13 +1383,13 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             dry_run=True,
         )
 
-    def test_invalid_mutation_id(self):
+    def test_invalid_single_site_id(self):
         engine = stdpopsim.get_engine("slim")
-        for mut_id in ["deleterious", "sweep"]:
+        for single_site_id in ["deleterious", "sweep"]:
             extended_events = [
                 stdpopsim.ext.DrawMutation(
                     time=self.T_mut,
-                    single_site_id=mut_id,
+                    single_site_id=single_site_id,
                     population_id=0,
                 ),
             ]
@@ -1414,7 +1414,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         contig.add_single_site(id=self.mut_id, coordinate=100)
         contig.dfe_list[1].mutation_types = []
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="must exist and be uniquely labelled"):
+        with pytest.raises(ValueError, match="must contain a single mutation type"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1450,7 +1450,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             DFE=dfe,
         )
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="must exist and be uniquely labelled"):
+        with pytest.raises(ValueError, match="must contain a single mutation type"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1887,7 +1887,7 @@ class TestAlleleFrequencyConditioning(PiecewiseConstantSizeMixin):
             ),
         ]
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="No drawn mutation"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=self.contig,
@@ -1974,7 +1974,7 @@ class TestChangeMutationFitness(PiecewiseConstantSizeMixin):
                 # Condition on AF > 0, to restore() immediately if the
                 # allele is lost.
                 stdpopsim.ext.ConditionOnAlleleFrequency(
-                    start_time=0,
+                    start_time=stdpopsim.ext.GenerationAfter(self.T_mut),
                     end_time=0,
                     single_site_id=self.mut_id,
                     population_id=0,
@@ -2016,7 +2016,7 @@ class TestChangeMutationFitness(PiecewiseConstantSizeMixin):
             ),
         ]
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="No drawn mutation"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=self.contig,

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1393,7 +1393,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
                     population_id=0,
                 ),
             ]
-            with pytest.raises(ValueError, match="must be unique"):
+            with pytest.raises(ValueError, match="must exist and be uniquely labelled"):
                 engine.simulate(
                     demographic_model=self.model,
                     contig=self.contig,
@@ -1414,7 +1414,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         contig.add_single_site(id=self.mut_id, coordinate=100)
         contig.dfe_list[1].mutation_types = []
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="must be unique"):
+        with pytest.raises(ValueError, match="must exist and be uniquely labelled"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1450,7 +1450,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             DFE=dfe,
         )
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="must be unique"):
+        with pytest.raises(ValueError, match="must exist and be uniquely labelled"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1477,7 +1477,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         )
         contig.dfe_list[1].mutation_types[0] = mt
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="fixed fitness coefficient"):
+        with pytest.raises(ValueError, match="instead of a fixed fitness coefficient"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1513,7 +1513,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             DFE=dfe,
         )
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="DFE with multiple intervals"):
+        with pytest.raises(ValueError, match="refers to a DFE with intervals"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1549,7 +1549,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             DFE=dfe,
         )
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="spans multiple sites"):
+        with pytest.raises(ValueError, match="refers to a DFE with intervals"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,
@@ -1570,7 +1570,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         contig.add_single_site(id="test", coordinate=100)
         contig.add_single_site(id="test", coordinate=110)
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError, match="must be unique"):
+        with pytest.raises(ValueError, match="must exist and be uniquely labelled"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1393,7 +1393,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
                     population_id=0,
                 ),
             ]
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="must be unique"):
                 engine.simulate(
                     demographic_model=self.model,
                     contig=self.contig,
@@ -1414,7 +1414,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         contig.add_single_site(id=self.mut_id, coordinate=100)
         contig.dfe_list[1].mutation_types = []
         engine = stdpopsim.get_engine("slim")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be unique"):
             engine.simulate(
                 demographic_model=self.model,
                 contig=contig,

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -800,7 +800,12 @@ class PiecewiseConstantSizeMixin(object):
     samples = model.get_samples(100)
     contig = get_test_contig()
     mut_id = "mut"
-    contig.add_single_site(id=mut_id, coordinate=100)
+    contig.add_single_site(
+        id=mut_id,
+        coordinate=100,
+        description="🧬",
+        long_description="👽",
+    )
 
     def allele_frequency(self, ts):
         """


### PR DESCRIPTION
Following the rationale/outline [here](https://github.com/popsim-consortium/stdpopsim/issues/1082#issuecomment-966730838):

- Replace `mutation_type_id` with string `mutation_id` in various extended events (`ext.DrawMutation`, etc)
- Add `Contig.add_single_site_mutation_type` to create a named, interval-less DFE representing a point mutation
- Modify `slim_makescript` to match `mutation_id` to `DFE.id`; check for uniqueness of name, lack of interval, etc when parsing extended events
- Update tests accordingly
