### PR TITLE
add PanTro to the catalogue

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -74,6 +74,8 @@ Then, if you feel ready, make an issue on our
 
 .. speciescatalog:: HomSap
 
+.. speciescatalog:: PanTro
+
 .. speciescatalog:: PapAnu
 
 .. speciescatalog:: PonAbe


### PR DESCRIPTION
I noticed that PanTro has been reviewed (see `tests/test_PanTro.py`), so it can be added to the catalogue (i.e., made visible in the docs). Note that it's demographic model hasn't yet been (waiting on #1227), but that's OK.