### PR TITLE
Add API for selective sweeps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-20.04, macos-10.15, windows-latest]
         python: [3.7, "3.10"]
     env:
       CONDA_ENV_NAME: stdpopsim

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1189,7 +1189,7 @@ but nonetheless there is lower diversity in exons than outside of them:
     is preliminary, and subject to change!
 
 You may be interested in simulating and tracking a single mutation. To illustrate
-this scenario, let's simulate a selective sweep until it reaches an abitrary
+this scenario, let's simulate a selective sweep until it reaches an arbitrary
 allele frequency.
 
 First, let's define a contig and a demographic model; here, we are simulating a
@@ -1212,34 +1212,21 @@ We must also decide the time the mutation will be added, when selection will
 start and at what frequency we want our selected mutation to be at the end of
 the simulation.
 
-Let's assume the mutation appeared 1000 generations ago, it has a positive
-effect on fitness (s=0.5). Also, we want the mutation to have reached a frequency
-of at least 0.8 by the end. Next, we'll walk through the steps required to do this:
-
-.. note::
-
-    Note that because we are doing a forward-in-time simulation, you should be
-    careful with your conditioning. For example, even a strongly selected mutation
-    would not be able to reach 80% frequency in just a few generations. Since
-    this conditioning works by re-running the simulation until the condition is
-    achieved, a nearly impossible condition will result in very long run times.
-
-To set things up, we need to first add the site at which the selected mutation
-will occur.  This is like adding a DFE, except to a single site -- we're saying
-that there is a potential mutation at a particular site with defined fitness
-consequences. So that we can refer to the single site later, we give it a
-unique string ID. Here, we'll add the site in the middle of the contig, with ID
-"hard sweep".
+First, we need to add the site at which the selected mutation will occur.  This
+is like adding a DFE, except to a single site -- we're saying that there is a
+potential mutation at a particular site with defined fitness consequences. So
+that we can refer to the single site later, we give it a unique string ID.
+Here, we'll add the site in the middle of the contig with ID "hard sweep",
+so named because we will imagine this beneficial mutation originates at
+frequency :math:`1 / 2N`.
 
 .. code-block:: python
 
-    mut_id = "hard sweep"
+    locus_id = "hard sweep"
     coordinate = round(contig.recombination_map.sequence_length / 2)
     contig.add_single_site(
-        id=mut_id,
+        id=locus_id,
         coordinate=coordinate,
-        fitness_coeff=0.1,
-        dominance_coeff=0.5,
     )
 
 .. note::
@@ -1251,62 +1238,34 @@ unique string ID. Here, we'll add the site in the middle of the contig, with ID
     "overwritten" and an error will be raised in simulation.
 
 Next, we will set up the "extended events" which will modify the demography.
-The first extended event is the origination of the selected mutation, which
-will occur in a random individual from the first population (id 0), 1000
-generations ago.
+This is done through :func:`stdpopsim.ext.selective_sweep`, which represents a
+general model for a mutation that is beneficial within a single population.  We
+specify that the mutation should originate 1000 generations ago in a random
+individual from the first population (named "pop_0" by default); that the
+selection coefficient for the mutation should be 0.5; and that the frequency of
+the mutation in the present day (e.g. at the end of the sweep) should be
+greater than 0.8.
 
 .. code-block:: python
 
-    T_mut = 1000
-    extended_events = [
-        stdpopsim.ext.DrawMutation(
-            time=T_mut,
-            single_site_id=mut_id,
-            population_id=0,
-        )
-    ]
-
-Next, we condition on the mutation not being lost.  Since in the next step we
-condition on the mutation being at 80% frequency at the end, this is redundant,
-but it allows the simulation to immediately restart from any generation in
-which the mutation is lost, rather than waiting until the end.  Note that this
-conditioning must start one generation after the mutation is placed, for which
-we use ``stdpopsim.ext.GenerationAfter(T_mut)``.  We cannot simply specify
-``T_mut - 1`` if rescaling is present, otherwise the conditioning would start
-at the same generation when the mutation is placed.
-
-.. code-block:: python
-
-    extended_events.append(
-        stdpopsim.ext.ConditionOnAlleleFrequency(
-            start_time=stdpopsim.ext.GenerationAfter(T_mut),
-            end_time=0,
-            single_site_id=mut_id,
-            population_id=0,
-            op=">",
-            allele_frequency=0.0,
-        )
+    extended_events = stdpopsim.ext.selective_sweep(
+        single_site_id=locus_id,
+        population="pop_0",
+        selection_coeff=0.5,
+        mutation_generation_ago=1000,
+        min_freq_at_end=0.8,
     )
 
-Finally, we condition on the mutation being above 80% at the end of the simulation.
-(The "end" is at time 0, since "time" is in generations before the end of the simulation.)
+.. note::
 
-.. code-block:: python
+    Note that because we are doing a forward-in-time simulation, you should be
+    careful with your conditioning. For example, even a strongly selected mutation
+    would not be able to reach 80% frequency in just a few generations. Since
+    this conditioning works by re-running the simulation until the condition is
+    achieved, a nearly impossible condition will result in very long run times.
 
-    extended_events.append(
-        stdpopsim.ext.ConditionOnAlleleFrequency(
-            start_time=0,
-            end_time=0,
-            single_site_id=mut_id,
-            population_id=0,
-            op=">=",
-            allele_frequency=0.8,
-        )
-    )
-
-Now we can simulate, using SLiM of course.
-For comparison, we will run the same simulation
-without selection - i.e., without the "extended events":
+Now we can simulate, using SLiM of course.  For comparison, we will run the
+same simulation without selection - i.e., without the "extended events":
 
 .. code-block:: python
 

--- a/stdpopsim/ext/selection.py
+++ b/stdpopsim/ext/selection.py
@@ -48,8 +48,9 @@ def validate_time_range(start_time, end_time):
 class ExtendedEvent(object):
     """
     ExtendedEvent is analogous to msprime.DemographicEvent, but is used here
-    for SLiM things that msprime doesn't support. Times are all in units of
-    generations before the present, just like for msprime.DemographicEvent.
+    for explicitly manipulating mutations. Currently, these are only used by
+    the SLiM engine. Times are all in units of generations before the present,
+    just like for msprime.DemographicEvent.
     """
 
     pass
@@ -58,23 +59,25 @@ class ExtendedEvent(object):
 @attr.s(kw_only=True)
 class DrawMutation(ExtendedEvent):
     """
-    TODO: docstring.
+    Introduce a new mutation with the given mutation type in the given
+    population at a given single site. The mutation will be added to one
+    randomly chosen chromosome in the given population. Only one mutation
+    may be drawn per single site.
 
-    Draw a new mutation with the given mutation type in the given population
-    at the given genomic coordinate. The mutation will be added to one randomly
-    chosen chromosome in the given population.
-
-    FIXME: Drawing multiple mutations using the same mutation type causes
-           erroneous allele frequency calculation in the SLiM code!
-           Multiple drawn mutations should be disallowed, or the allele frequency
-           calculation should somehow be tied to specific drawn mutations.
-
-    See SLiM documentation for addNewDrawnMutation().
+    :ivar time: The number of generations in the past at which to introduce the
+        mutation.
+    :vartype start_time: float
+    :ivar single_site_id: The string ID of the single site at which to
+        introduce the mutation, see :meth:`Contig.add_single_site`.
+    :vartype single_site_id: str
+    :ivar population: The name of the population in which to introduce
+        the mutation.
+    :vartype population: str
     """
 
     time = attr.ib(type=float)
     single_site_id = attr.ib(type=str)
-    population_id = attr.ib(type=int)
+    population = attr.ib(type=str)
 
     def __attrs_post_init__(self):
         validate_time(self.time)
@@ -83,20 +86,38 @@ class DrawMutation(ExtendedEvent):
 @attr.s(kw_only=True)
 class ChangeMutationFitness(ExtendedEvent):
     """
-    TODO: docstring.
-
     Change the selection and/or dominance coefficients for the given mutation
     type in the given population. The mutation this applies to need not exist
     in the population for all generations between start_time and end_time.
     E.g. if the mutation could be transferred to the population via migration.
+    This requires that a `DrawMutation` event with the same `single_site_id` is
+    also supplied to the simulation engine.
 
     See SLiM documentation for registerFitnessCallback().
+
+    :ivar start_time: The number of generations in the past at which the change
+        in mutation fitness begins.
+    :vartype start_time: float
+    :ivar end_time: The number of generations in the past at which the change
+        in mutation fitness ends.
+    :vartype end_time: float
+    :ivar single_site_id: The string ID of the single site at which to change
+        the mutation fitness, see :meth:`Contig.add_single_site`.
+    :vartype single_site_id: str
+    :ivar population: The name of the population in which to change
+        the mutation fitness. If `None` (the default), then all populations are
+        affected.
+    :vartype population: str
+    :ivar selection_coeff: The new selection coefficient of the mutation.
+    :vartype selection_coeff: float
+    :ivar dominance_coeff: The new dominance coefficient of the mutation.
+    :vartype dominance_coeff: float
     """
 
     start_time = attr.ib(type=float)
     end_time = attr.ib(type=float)
     single_site_id = attr.ib(type=str)
-    population_id = attr.ib(type=int)
+    population = attr.ib(type=str, default=None)
     selection_coeff = attr.ib(type=float)
     dominance_coeff = attr.ib(type=float)
 
@@ -107,21 +128,35 @@ class ChangeMutationFitness(ExtendedEvent):
 @attr.s(kw_only=True)
 class ConditionOnAlleleFrequency(ExtendedEvent):
     """
-    TODO: docstring.
-
     Condition on the allele frequency of a drawn mutation with the given
     mutation type in the given population. The mutation need not have been
-    drawn in the population being conditioned upon.
+    drawn in the population being conditioned upon.  This requires that a
+    `DrawMutation` event for the same single site is also supplied to the
+    simulation engine.
 
-    This uses a save/restore mechanism in the SLiM code to do rejection
-    sampling on a simulation (when the condition is not met) without throwing
-    away the entire simulation.
+    :ivar start_time: The number of generations in the past at which to start
+        checking the allele frequency condition.
+    :vartype start_time: float
+    :ivar end_time: The number of generations in the past at which to stop
+        checking the allele frequency condition.
+    :vartype end_time: float
+    :ivar single_site_id: The string ID of the single site at which to check
+        the allele frequency condition, see :meth:`Contig.add_single_site`.
+    :vartype single_site_id: str
+    :ivar population: The name of the population in which to check
+        the allele frequency condition.
+    :vartype population: str
+    :ivar op: The comparison operator used for the allele frequency condition,
+        one of `(">", ">=", "<", "<=")`.
+    :vartype op: str
+    :ivar allele_frequency: The allele frequency to compare against.
+    :vartype op: float
     """
 
     start_time = attr.ib(type=float)
     end_time = attr.ib(type=float)
     single_site_id = attr.ib(type=str)
-    population_id = attr.ib(type=int)
+    population = attr.ib(type=str, default=None)
     op = attr.ib(type=str, default=None)
     allele_frequency = attr.ib(type=float, default=None)
 
@@ -151,3 +186,171 @@ class ConditionOnAlleleFrequency(ExtendedEvent):
     @classmethod
     def op_id(cls, op):
         return cls.op_types.index(op)
+
+
+def selective_sweep(
+    single_site_id,
+    population,
+    mutation_generation_ago,
+    selection_coeff,
+    dominance_coeff=0.5,
+    start_generation_ago=None,
+    end_generation_ago=None,
+    min_freq_at_start=None,
+    min_freq_at_end=None,
+    globally_adaptive=True,
+):
+    """
+    Creates a list of extended events corresponding to a selective sweep at a
+    single site (see :meth:`Contig.add_single_site`) that may subsequently be
+    passed to the simulation engine. The sequence of events is:
+
+        (1) In generation `mutation_generation_ago`, a **neutral** mutation is
+            introduced into `population`.
+
+        (2) In generation `start_generation_ago`, the mutation becomes
+            beneficial (whether globally or locally is controlled by the
+            `globally_adaptive` option). If the frequency of the mutation in
+            `population` is below `min_freq_at_start` in this generation, the
+            simulation will restart from `mutation_generation_ago`.
+
+        (3) In the generation after `end_generation_ago`, the mutation reverts to
+            neutrality in `population`. If the frequency of the mutation in
+            `population` is below `min_freq_at_end` in this generation, the
+            simulation will restart from `mutation_generation_ago`.
+
+    During the sweep, the fitnesses of individuals that are homozygous or
+    heterozygous for the beneficial mutation are `1 + selection_coeff` and  `1
+    + selection_coeff * dominance_coeff`, respectively. If `globally_adaptive`
+    is `True` (the default), then all individuals carrying the mutation are
+    impacted regardless of the population they belong to. Otherwise, the
+    mutation only influences fitness within `population`.
+
+    If the mutation is lost in `population` at any point between
+    `mutation_generation_ago` and `end_generation_ago`, then the simulation
+    will restart from `mutation_generation_ago`. The effect of "restarting"
+    (aka "rejection sampling") is that the resulting simulations are
+    conditioned on the mutation being extant after time
+    `mutation_generation_ago` with frequency above `min_freq_at_start` at
+    `start_generation_ago` and `min_freq_at_end` at `end_generation_ago`.
+
+    Because the simulation will restart until the allele frequency conditions
+    are satisfied, care must be taken to ensure that these are reasonable. For
+    example, if `start_generation_ago` is very close to
+    `mutation_generation_ago` and `min_freq_at_start` is substantially greater
+    than zero, the vast majority of proposed allele frequency trajectories will
+    be rejected and the simulation may take an infeasibly long time to
+    complete.
+
+    :param str single_site_id: The string ID of the single site at which to introduce
+        the mutation, see :meth:`Contig.add_single_site`.
+    :param int population: The name of the population in which the mutation is
+        introduced and the sweep occurs.
+    :param float mutation_generation_ago: The number of generations in the past at which
+        to introduce the mutation.
+    :param float selection_coeff: The selection coefficient of the beneficial
+        mutation during the sweep.  Must be greater than or equal to zero.
+    :param float dominance_coeff: The dominance coefficient of the beneficial
+        mutation during the sweep.  Defaults to `0.5`.
+    :param float start_generation_ago: The number of generations in the past at which the
+        sweep starts and the mutation switches from neutral to beneficial. Defaults to
+        `mutation_generation_ago` (i.e. a "hard" sweep).
+    :param float end_generation_ago: The number of generations in the past at which the
+        sweep ends and the mutation switches from beneficial to neutral. Defaults to
+        `0` (i.e. the end of the simulation).
+    :param float min_freq_at_start: The minimum allowed frequency for the
+        mutation in `population` at the start of the sweep (optional).
+    :param float min_freq_at_end: The minimum allowed frequency for the
+        mutation in `population` at the end of the sweep (optional).
+    :param bool globally_adaptive: If `True` (default), the mutation is beneficial in all
+        populations. If `False`, the mutation is beneficial only in the population of
+        origin.
+    """
+
+    if start_generation_ago is None:
+        start_generation_ago = mutation_generation_ago
+    if end_generation_ago is None:
+        end_generation_ago = 0
+
+    validate_time_range(mutation_generation_ago, start_generation_ago)
+    validate_time_range(start_generation_ago, end_generation_ago)
+    if selection_coeff < 0.0:
+        raise ValueError("Selection coefficient must be non-negative.")
+
+    extended_events = [
+        DrawMutation(
+            single_site_id=single_site_id,
+            time=mutation_generation_ago,
+            population=population,
+        ),
+        ConditionOnAlleleFrequency(
+            single_site_id=single_site_id,
+            start_time=GenerationAfter(mutation_generation_ago),
+            end_time=end_generation_ago,
+            population=population,
+            allele_frequency=0.0,
+            op=">",
+        ),
+    ]
+
+    # Sweep period is [start_generation_ago, end_generation_ago] (endpoints inclusive).
+    sweep_restricted_to = None if globally_adaptive else population
+    extended_events.extend(
+        [
+            ChangeMutationFitness(
+                single_site_id=single_site_id,
+                start_time=start_generation_ago,
+                end_time=end_generation_ago,
+                population=sweep_restricted_to,
+                selection_coeff=selection_coeff,
+                dominance_coeff=dominance_coeff,
+            ),
+        ]
+    )
+
+    # Only check sweep AF conditions in start/end generations, so that allele
+    # trajectories are otherwise unconstrained.
+    if min_freq_at_start is not None:
+        if not 0 < min_freq_at_start <= 1:
+            raise ValueError(
+                "If specified, the minimum allele frequency at the start of the sweep "
+                "must be in (0, 1]."
+            )
+        if start_generation_ago == mutation_generation_ago:
+            raise ValueError(
+                "If the start time of the sweep coincides with the introduction "
+                "of the mutation, then `min_freq_at_start` cannot be set."
+            )
+        extended_events.extend(
+            [
+                ConditionOnAlleleFrequency(
+                    single_site_id=single_site_id,
+                    start_time=start_generation_ago,
+                    end_time=start_generation_ago,
+                    population=population,
+                    allele_frequency=min_freq_at_start,
+                    op=">=",
+                ),
+            ]
+        )
+
+    if min_freq_at_end is not None:
+        if not 0 < min_freq_at_end <= 1:
+            raise ValueError(
+                "If specified, the minimum allele frequency at the end of the sweep "
+                "must be in (0, 1]."
+            )
+        extended_events.extend(
+            [
+                ConditionOnAlleleFrequency(
+                    single_site_id=single_site_id,
+                    start_time=end_generation_ago,
+                    end_time=end_generation_ago,
+                    population=population,
+                    allele_frequency=min_freq_at_end,
+                    op=">=",
+                ),
+            ]
+        )
+
+    return extended_events

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -484,52 +484,38 @@ class Contig:
         self,
         id,
         coordinate,
-        selection_coeff=0.0,
-        dominance_coeff=0.5,
         description=None,
         long_description=None,
     ):
         """
-        Adds a model of a single site mutation at the provided coordinate.
+        Adds a single site mutation class at the provided coordinate.
         The string label of the single site may be referenced by extended
         events passed to the simulation engine.
 
-        For instance, to simulate a selective sweep,
+        For instance, to simulate a selective sweep in population `pop_0`
+        starting at 1000 generations in the past:
 
         .. code-block:: python
 
             contig.add_single_site(
                 id="hard_sweep",
-                selection_coeff=0.1,
                 coordinate=mutation_coordinate,
             )
-            extended_events = [
-                stdpopsim.ext.DrawMutation(
-                    time=mutation_time,
-                    single_site_id="hard_sweep",
-                    population_id=0,
-                ),
-                stdpopsim.ext.ConditionOnAlleleFrequency(
-                    start_time=stdpopsim.ext.GenerationAfter(mutation_time),
-                    end_time=0,
-                    single_site_id="hard_sweep",
-                    population_id=0,
-                    op=">",
-                    allele_frequency=0.0,
-                ),
-            ]
+            extended_events = ext.selective_sweep(
+                mutation_generation_ago=1000,
+                selection_coeff=0.1,
+                population="pop_0",
+            )
             engine = stdpopsim.get_engine("slim")
             ts_sweep = engine.simulate(
                 ...,
                 extended_events=extended_events,
             )
 
+        See :func:`ext.selective_sweep` for more details on the sweep model.
+
         :param str id: A unique identifier for the single site.
         :param int coordinate: The coordinate of the site on the contig.
-        :param float selection_coeff: The selection coefficient of the mutation,
-            see :class:`MutationType` for details.
-        :param float dominance_coeff: The dominance coefficient of the mutation,
-            see :class:`MutationType` for details.
         :param str description: A short description of the single site mutation
             model as it would be used in written text, e.g., "Strong selective
             sweep".
@@ -542,10 +528,11 @@ class Contig:
 
         mut_type = stdpopsim.MutationType(
             distribution_type="f",
-            dominance_coeff=dominance_coeff,
-            distribution_args=[selection_coeff],
+            dominance_coeff=0.5,
+            distribution_args=[0.0],
             convert_to_substitution=False,
         )
+
         dfe = stdpopsim.DFE(
             id=id,
             mutation_types=[mut_type],


### PR DESCRIPTION
- Fixes #1329 and #1082.
- Fixes a bug in the SLiM engine at https://github.com/popsim-consortium/stdpopsim/blob/ec4fedd9859dc23b7b12013d69172d851a5d43d2/stdpopsim/slim_engine.py#L217 that caused fitness calculations to be disabled for one generation after a restore. This probably had very little impact on simulation correctness, but did reduce efficiency of the rejection sampler.
- Fixes a bug where fitness logging would be disabled if the logging interval was set to every generation.
- Removes `selection_coeff` and `dominance_coeff` as arguments from `Contig.add_single_site`, as these are now specified in `ext.selective_sweep`. For the lower-level API this means that these parameters have to be set by a `ChangeMutationFitness` event.
- Fixes #1336.
- Fixes #1337 and #608.
- "Fixes" #656. As these classes may ultimately also be used for sweep specification in msprime, we'll keep calling them "extended events".