### PR TITLE
Add API to get contig from region of named chromosome

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-20.04, macos-10.15, windows-latest]
         python: [3.7, "3.10"]
     env:
       CONDA_ENV_NAME: stdpopsim

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -337,8 +337,30 @@ To simulate, however, only a small chunk of contig with selection––as in a s
 
 The DFE defined by Gamma_K17 will be incorporated only in positions between 1000 and 100000.
 
+Finally, for the sake of efficiency it might be desirable to simulate a region
+of a chromosome rather than the entire chromosome. Regions are specified via
+``--left`` and ``--right``:
+
+.. code-block:: console
+
+    $ stdpopsim -e slim --slim-scaling-factor 10 HomSap \
+        -c chr22 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 \
+        --dfe-interval 200000,300000 --left 150000 --right 350000 2 4
+
+This will simulate a 200 Kb contig that uses the genetic map from coordinates
+150000 to 350000 along `chr22`; with a DFE applied between coordinates 200000
+and 300000. Note that the coordinate system used for ``--dfe-interval`` is that
+of the original chromosome: relative to the **start of the contig**, the DFE
+spans from coordinate 50000 to 150000.
+
 See also the python API to incorporate `selection <https://popsim-consortium.github.io/stdpopsim-docs/latest/tutorial.html#incorporating-selection>`__.
 
+.. warning::
+
+    Simulating a region under selection is **not** the same as simulating a
+    chromosome under selection and clipping to the region. This is because
+    selected mutations outside of the region can influence ancestry within
+    the region, due to linkage.
 
 Debugging output from SLiM
 ==========================
@@ -1177,6 +1199,26 @@ but nonetheless there is lower diversity in exons than outside of them:
     # and outside of exons it is 0.211 differences per Kb.
 
 
+For the sake of efficiency, we might want to simulate a particular region
+rather than the entire annotated chromosome. This can be done by supplying
+`left` and `right` to :meth:`Species.get_contig`. For example, to simulate the
+region of chromosome 20 spanning from 30 Mb to 40 Mb (containing roughly 300
+identified genes):
+
+.. code-block:: python
+
+    contig_region = species.get_contig("chr20", left=30e6, right=40e6)
+    contig_region.add_dfe(intervals=exon_intervals, DFE=dfe)
+
+The annotation (as well as any supplied masks) will be automatically clipped to
+the region of interest.
+
+.. warning::
+
+    Simulating a region under selection is **not** the same as simulating a
+    chromosome under selection and clipping to the region. This is because
+    selected mutations outside of the region can influence ancestry within
+    the region, due to linkage.
 
 .. _sec_tute_selective_sweep:
 

--- a/stdpopsim/genetic_maps.py
+++ b/stdpopsim/genetic_maps.py
@@ -122,8 +122,10 @@ class GeneticMap:
             rates = np.append(recomb_map.rate, 0)
             recomb_map = msprime.RateMap(position=positions, rate=rates)
         elif map_length > chrom.length:
+            # TODO: consider making this an error, and deprecating genetic maps
+            # that do not match the assembly.
             warnings.warn(
                 f"Recombination map has length {map_length}, which is longer than"
-                f" chromosome length {chrom.length}. The former will be used."
+                f" chromosome length {chrom.length}. The latter will be used."
             )
         return recomb_map

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -175,6 +175,8 @@ class Species:
         gene_conversion_length=None,
         inclusion_mask=None,
         exclusion_mask=None,
+        left=None,
+        right=None,
     ):
         """
         Returns a :class:`.Contig` instance describing a section of genome that
@@ -223,6 +225,12 @@ class Species:
             length of genome sequence for this contig. For a generic contig, mutation
             and recombination rates are equal to the genome-wide average across all
             autosomal chromosomes.
+        :param float left: The left coordinate (inclusive) of the region to
+            keep on the chromosome. Defaults to 0.  Genetic maps and masks are
+            clipped to this boundary.
+        :param float right: The right coordinate (exclusive) of the region to
+            keep on the chromosome. Defaults to the length of the chromosome.
+            Genetic maps and masks are clipped to this boundary.
         :rtype: :class:`.Contig`
         :return: A :class:`.Contig` describing the section of the genome.
         """
@@ -238,6 +246,8 @@ class Species:
             gene_conversion_length=gene_conversion_length,
             inclusion_mask=inclusion_mask,
             exclusion_mask=exclusion_mask,
+            left=left,
+            right=right,
         )
 
     def get_demographic_model(self, id):

--- a/stdpopsim/warning_categories.py
+++ b/stdpopsim/warning_categories.py
@@ -22,3 +22,7 @@ class SLiMOddSampleWarning(UserWarning):
 
 class UnspecifiedSLiMWarning(UserWarning):
     pass
+
+
+class EmptyIntervalsWarning(UserWarning):
+    pass

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -303,6 +303,7 @@ class TestGetContig:
         with pytest.raises(ValueError, match="without setting gene conversion rate"):
             # cannot specify custom gene conversion length without gene conversion rate
             self.species.get_contig("chr1", gene_conversion_length=1)
+        # TODO: invalid interval
 
     def test_use_species_gene_conversion(self):
         contig = self.species.get_contig("chr22", use_species_gene_conversion=True)
@@ -355,3 +356,4 @@ class TestGetContig:
         else:
             assert contig.gene_conversion_rate == np.average(gcs, weights=Ls)
             assert contig.gene_conversion_length == np.average(gcls, weights=Ls)
+        # TODO: origin


### PR DESCRIPTION
Mostly addresses #1346, #670, #401 (and supersedes #402) by adding a way to get a contig from an arbitrary interval of a named chromosome.

Thanks to `msprime.RateMap.slice` this was pretty straightforward, except for the handling of coordinates when DFEs are added. I opted to use the same coordinate system as the chromosome from which the contig is extracted, so for example the following adds a DFE in the middle of the contig:
```python
species = stdpopsim.get_species("HomSap")
contig = species.get_contig(chromosome="chr1", left=1e6, right=1.1e6)
contig.add_dfe(intervals=[[1.05e6, 1.06e6]], dfe=...)
```
IMO this is cleaner than requiring the user to manually shift the DFE coordinates (and is less confusing with DFE bed files, annotations, etc).

Previously, if an added DFE had an interval that fell outside the contig, a rather ambiguous SLiM error would get raised. Now, the added DFE intervals are silently clipped to the contig boundaries. If all the intervals fall outside of these boundaries, a warning is raised and a DFE with empty intervals is added.

The same goes for masks (previously an error would get thrown from tskit if a mask interval overlapped a contig boundary): these are now clipped, with a warning if all masked intervals fall outside of the contig boundaries. 