### PR TITLE
update ubuntu in tests (closes #1353)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-20.04, macos-10.15, windows-latest]
         python: [3.7, "3.10"]
     env:
       CONDA_ENV_NAME: stdpopsim


### PR DESCRIPTION
Let's see if this works. However, 18 is still supported [until next April](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes) so maybe I'm jumping the gun here.