### PR TITLE
revision to gene conversion API

### DIFF
--- a/docs/_ext/speciescatalog.py
+++ b/docs/_ext/speciescatalog.py
@@ -572,6 +572,31 @@ class SpeciesCatalogDirective(SphinxDirective):
         # genomes:
         genome_section = nodes.section(ids=[f"sec_catalog_{species.id}_genome"])
         genome_section += nodes.title(text="Genome")
+        if species.genome.bacterial_recombination is True:
+            genome_section += self.make_field_list(
+                [
+                    (
+                        "Bacterial recombination with tract length range",
+                        species.genome.range_gene_conversion_lengths,
+                        None,
+                    )
+                ]
+            )
+        elif species.genome.mean_gene_conversion_fraction > 0:
+            genome_section += self.make_field_list(
+                [
+                    (
+                        "Mean gene conversion fraction",
+                        species.genome.mean_gene_conversion_fraction,
+                        None,
+                    ),
+                    (
+                        "Range gene conversion lengths",
+                        species.genome.range_gene_conversion_lengths,
+                        None,
+                    ),
+                ]
+            )
         genome_section += self.chromosomes_table(species)
         genome_section += nodes.paragraph(
             text="Mutation and recombination rates "

--- a/stdpopsim/catalog/DroMel/species.py
+++ b/stdpopsim/catalog/DroMel/species.py
@@ -33,6 +33,7 @@ _ComeronEtAl = stdpopsim.Citation(
     author="Comeron et al",
     doi="https://doi.org/10.1371/journal.pgen.1002905",
     year=2012,
+    reasons={stdpopsim.CiteReason.REC_RATE, stdpopsim.CiteReason.GENE_CONVERSION},
 )
 
 # Mean chromosomal rates, calculated by taking the
@@ -42,7 +43,7 @@ _ComeronEtAl = stdpopsim.Citation(
 # Chromosome 4 isn't in this map, so the average of
 # 2L, 2R, 3L and 3R weighted by their respective
 # chromosome lengths was used instead.
-_recombination_rate_data = {
+_recombination_rate = {
     "2L": 2.40462600791e-08,
     "2R": 2.23458641776e-08,
     "3L": 1.79660308862e-08,
@@ -54,27 +55,52 @@ _recombination_rate_data = {
 }
 
 
-_chromosomes = []
-for name, data in genome_data.data["chromosomes"].items():
-    _chromosomes.append(
-        stdpopsim.Chromosome(
-            id=name,
-            length=data["length"],
-            synonyms=data["synonyms"],
-            mutation_rate=5.49e-9,  # _SchriderEtAl de novo mutation rate
-            recombination_rate=_recombination_rate_data[name],
-        )
-    )
+# Comeron et al:
+# - GC avg track length = 518bp
+# - 83% of DSBs are resolved as Gene Conversions
+# - avg rate of GC is 1.25E-07 / bp / female meiosis
+# (not sure if the latter estimate agrees)
 
-_genome = stdpopsim.Genome(
-    chromosomes=_chromosomes,
-    assembly_name=genome_data.data["assembly_name"],
-    assembly_accession=genome_data.data["assembly_accession"],
+_gene_conversion_fraction = {
+    "2L": 0.83,
+    "2R": 0.83,
+    "3L": 0.83,
+    "3R": 0.83,
+    "4": 0,
+    "X": 0.83,
+    "Y": 0,
+    "mitochondrion_genome": 0,
+}
+
+_gene_conversion_length = {c: 518 for c in genome_data.data["chromosomes"]}
+
+_mutation_rate = {c: 5.49e-9 for c in genome_data.data["chromosomes"]}
+
+# _chromosomes = []
+# for name, data in genome_data.data["chromosomes"].items():
+#     _chromosomes.append(
+#         stdpopsim.Chromosome(
+#             id=name,
+#             length=data["length"],
+#             synonyms=data["synonyms"],
+#             mutation_rate=5.49e-9,  # _SchriderEtAl de novo mutation rate
+#             recombination_rate=_recombination_rate_data[name],
+#             gene_conversion_fraction=_gene_conversion_fraction_data[name],
+#             gene_conversion_length=_gene_conversion_length,
+#         )
+#     )
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    gene_conversion_fraction=_gene_conversion_fraction,
+    gene_conversion_length=_gene_conversion_length,
     citations=[
         _SchriderEtAl.because(stdpopsim.CiteReason.MUT_RATE),
         _DosSantosEtAl,
         _HoskinsEtAl,
-        _ComeronEtAl.because(stdpopsim.CiteReason.REC_RATE),
+        _ComeronEtAl,
     ],
 )
 stdpopsim.utils.append_common_synonyms(_genome)

--- a/stdpopsim/catalog/EscCol/species.py
+++ b/stdpopsim/catalog/EscCol/species.py
@@ -32,8 +32,7 @@ for name, data in genome_data.data["chromosomes"].items():
             # Wielgoss et al. (2011) calculated for strain REL606,
             # from synonymous substitutions over 40,000 generations.
             mutation_rate=8.9e-11,
-            recombination_rate=0.0,
-            gene_conversion_rate=8.9e-11,
+            recombination_rate=8.9e-11,
             gene_conversion_length=345,
         )
     )
@@ -43,6 +42,7 @@ for name, data in genome_data.data["chromosomes"].items():
 
 _genome = stdpopsim.Genome(
     chromosomes=_chromosomes,
+    bacterial_recombination=True,
     assembly_name=genome_data.data["assembly_name"],
     assembly_accession=genome_data.data["assembly_accession"],
     citations=[

--- a/stdpopsim/catalog/EscCol/species.py
+++ b/stdpopsim/catalog/EscCol/species.py
@@ -22,6 +22,12 @@ _blattner_et_al = stdpopsim.Citation(
     doi="https://doi.org/10.1126/science.277.5331.1453",
 )
 
+_didelot_et_al = stdpopsim.Citation(
+    author="Didelot et al.",
+    year=2012,
+    doi="https://doi.org/10.1186/1471-2164-13-256",
+)
+
 _chromosomes = []
 for name, data in genome_data.data["chromosomes"].items():
     _chromosomes.append(
@@ -33,12 +39,9 @@ for name, data in genome_data.data["chromosomes"].items():
             # from synonymous substitutions over 40,000 generations.
             mutation_rate=8.9e-11,
             recombination_rate=8.9e-11,
-            gene_conversion_length=345,
+            gene_conversion_length=542,
         )
     )
-
-# mean_conversion_rate=8.9e-11 # not implemented yet!
-# mean_conversion_length=542 # not implemented yet!
 
 _genome = stdpopsim.Genome(
     chromosomes=_chromosomes,
@@ -46,8 +49,11 @@ _genome = stdpopsim.Genome(
     assembly_name=genome_data.data["assembly_name"],
     assembly_accession=genome_data.data["assembly_accession"],
     citations=[
-        _wielgoss_et_al.because(stdpopsim.CiteReason.MUT_RATE),
+        _wielgoss_et_al.because(
+            {stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.GENE_CONVERSION}
+        ),
         _blattner_et_al.because(stdpopsim.CiteReason.ASSEMBLY),
+        _didelot_et_al.because(stdpopsim.CiteReason.GENE_CONVERSION),
     ],
 )
 stdpopsim.utils.append_common_synonyms(_genome)

--- a/stdpopsim/catalog/StrAga/species.py
+++ b/stdpopsim/catalog/StrAga/species.py
@@ -16,9 +16,6 @@ _DaCunha_et_al = stdpopsim.Citation(
 # mu =  0.56/(1e6*365)
 _mutation_rate = {"1": 1.53e-9}
 
-# no cross-over recombination in bacteria
-_recombination_rate = {"1": 0}
-
 # gene conversion rate (HGT rate):
 # hard to estimate precisely. What is often estimated is the r/m or rho/theta ratio.
 # in Oliveira et. al, PNAS, 2016, they estimate those rates on coregenome
@@ -35,7 +32,7 @@ _recombination_rate = {"1": 0}
 # that is already not recombining a lot.
 # Overall, as most of the estimation might be conservatives one can use a relative
 # rate rho/theta = 10%.
-# _gene_conversion_rate = {"1": _mutation_rate/10}
+_recombination_rate = {c: _mutation_rate[c] / 10 for c in _mutation_rate}
 
 # Mean gene conversion  tract length
 # In Brochet et al., 2008, PNAS, they estimate the size of transferred DNA experimentally
@@ -46,7 +43,7 @@ _recombination_rate = {"1": 0}
 # discussed in more detail in response to a reviewer, that can be seen there :
 # https://evolbiol.peercommunityin.org/articles/rec?id=356
 #      > Revision round #3 > Author's reply (pdf).
-# _mean_gene_conversion_tract_length = 120000
+_gene_conversion_length = {"1": 120000}
 
 
 _genome = stdpopsim.Genome.from_data(
@@ -57,6 +54,8 @@ _genome = stdpopsim.Genome.from_data(
         _DaCunha_et_al.because(stdpopsim.CiteReason.ASSEMBLY),
         _DaCunha_et_al.because(stdpopsim.CiteReason.MUT_RATE),
     ],
+    bacterial_recombination=True,
+    gene_conversion_length=_gene_conversion_length,
 )
 stdpopsim.utils.append_common_synonyms(_genome)
 

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -20,6 +20,7 @@ class CiteReason:
     GEN_TIME = "generation time"
     MUT_RATE = "mutation rate"
     REC_RATE = "recombination rate"
+    GENE_CONVERSION = "gene conversion parameters"
     ASSEMBLY = "genome assembly"
     ANNOTATION = "genome annotation"
     DFE = "distribution of fitness effects"

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -248,13 +248,22 @@ def get_species_help(species_id):
     species_text += (
         f"Recombination rate: {species.genome.mean_recombination_rate:.4g}\n"
     )
-    species_text += (
-        f"Gene conversion rate: {species.genome.mean_gene_conversion_rate:.4g}\n"
-    )
-    species_text += (
-        f"Gene conversion tract length: "
-        f"{species.genome.range_gene_conversion_lengths}\n"
-    )
+    if species.genome.bacterial_recombination is True:
+        species_text += (
+            f"Bacterial recombination with tract length: "
+            f"{species.genome.range_gene_conversion_lengths}\n"
+        )
+    # TODO: there is no way to enable GC on the CLI
+    # elif ((species.genome.mean_gene_conversion_fraction is not None) and
+    #     (species.genome.mean_gene_conversion_fraction > 0.0)):
+    #     species_text += (
+    #         f"Gene conversion fraction: "
+    #         f"{species.genome.mean_gene_conversion_fraction:.4g}\n"
+    #     )
+    #     species_text += (
+    #         f"Gene conversion tract length: "
+    #         f"{species.genome.range_gene_conversion_lengths}\n"
+    #     )
 
     return species_text
 
@@ -883,6 +892,11 @@ def write_simulation_summary(
     dry_run_text += f"{indent}Mean recombination rate: {mean_recomb_rate}\n"
     dry_run_text += f"{indent}Mean mutation rate: {mut_rate}\n"
     dry_run_text += f"{indent}Genetic map: {gmap}\n"
+    if contig.bacterial_recombination is True:
+        dry_run_text += (
+            f"{indent}Bacterial recombination "
+            f"with tract length {contig.gene_conversion_length}\n"
+        )
     if dfe is not None:
         dry_run_text += f"{indent}DFE: {dfe}\n"
         dry_run_text += f"{indent}DFE applied to: {dfe_interval}\n"

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -171,8 +171,6 @@ class Species:
         length=None,
         mutation_rate=None,
         use_species_gene_conversion=False,
-        gene_conversion_rate=None,
-        gene_conversion_length=None,
         inclusion_mask=None,
         exclusion_mask=None,
         left=None,
@@ -202,17 +200,8 @@ class Species:
             the mutation rate defaults to the rate specified by species chromosomes.
         :param bool use_species_gene_conversion: If set to True the parameters for gene
             conversion of the species chromosome are used if available. For "generic"
-            contigs the gene conversion rate is given by the (mean) rate specified by
-            species chromosomes and the gene conversion length defaults to the mean
-            length specified by species chromosomes.
-        :param float gene_conversion_rate: The per-base gene conversion rate. Can only
-            be set together with gene_conversion_length and if
-            use_species_gene_conversion is False; If none is given, and
-            use_species_gene_conversion is True the gene conversion rate specified by
-            species chromosomes is used. If none and use_species_gene_conversion is
-            False gene conversion is disabled.
-        :param float gene_conversion_length: The mean gene conversion length.
-            May only be provided if gene_conversion_rate is also specified.
+            contigs the gene conversion fraction and length are given by the mean
+            values across all chromosomes.
         :param inclusion_mask: If specified, simulated genomes are subset to only
             inlude regions given by the mask. The mask can be specified by the
             path and file name of a bed file or as a list or array of intervals
@@ -242,8 +231,6 @@ class Species:
             length=length,
             mutation_rate=mutation_rate,
             use_species_gene_conversion=use_species_gene_conversion,
-            gene_conversion_rate=gene_conversion_rate,
-            gene_conversion_length=gene_conversion_length,
             inclusion_mask=inclusion_mask,
             exclusion_mask=exclusion_mask,
             left=left,

--- a/tests/test_AnaPla.py
+++ b/tests/test_AnaPla.py
@@ -163,3 +163,6 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    def test_bacterial_recombination(self):
+        assert self.genome.bacterial_recombination is False

--- a/tests/test_DroMel.py
+++ b/tests/test_DroMel.py
@@ -29,8 +29,10 @@ class TestGenome(test_species.GenomeTestBase):
     def test_non_recombining_chrs(self, chr_id):
         chrom = self.genome.get_chromosome(chr_id)
         assert chrom.recombination_rate == 0
+        assert chrom.gene_conversion_fraction == 0
 
     @pytest.mark.parametrize("chr_id", ["2L", "2R", "3L", "3R", "X"])
     def test_recombining_chrs(self, chr_id):
         chrom = self.genome.get_chromosome(chr_id)
         assert chrom.recombination_rate > 0
+        assert chrom.gene_conversion_fraction > 0

--- a/tests/test_EscCol.py
+++ b/tests/test_EscCol.py
@@ -1,5 +1,5 @@
 """
-Tests for the e. coli data definitions.
+Tests for the EscCol data definitions.
 """
 import stdpopsim
 from tests import test_species
@@ -19,7 +19,7 @@ class TestSpecies(test_species.SpeciesTestBase):
 
 class TestGenome(test_species.GenomeTestBase):
     """
-    Tests for the e_coli genome.
+    Tests for the EscCol genome.
     """
 
     genome = stdpopsim.get_species("EscCol").genome
@@ -30,8 +30,11 @@ class TestGenome(test_species.GenomeTestBase):
     def test_mutation_rate(self):
         assert self.genome.get_chromosome("Chromosome").mutation_rate == 8.9e-11
 
-    def test_gene_conversion_rate(self):
-        assert self.genome.get_chromosome("Chromosome").gene_conversion_rate == 8.9e-11
+    def test_recombination_rate(self):
+        assert self.genome.get_chromosome("Chromosome").recombination_rate == 8.9e-11
 
     def test_gene_conversion_length(self):
         assert self.genome.get_chromosome("Chromosome").gene_conversion_length == 345
+
+    def test_bacterial_recombination(self):
+        assert self.genome.bacterial_recombination is True

--- a/tests/test_EscCol.py
+++ b/tests/test_EscCol.py
@@ -34,7 +34,7 @@ class TestGenome(test_species.GenomeTestBase):
         assert self.genome.get_chromosome("Chromosome").recombination_rate == 8.9e-11
 
     def test_gene_conversion_length(self):
-        assert self.genome.get_chromosome("Chromosome").gene_conversion_length == 345
+        assert self.genome.get_chromosome("Chromosome").gene_conversion_length == 542
 
     def test_bacterial_recombination(self):
         assert self.genome.bacterial_recombination is True

--- a/tests/test_HomSap.py
+++ b/tests/test_HomSap.py
@@ -37,3 +37,6 @@ class TestGenome(test_species.GenomeTestBase):
         assert chrom.recombination_rate == pytest.approx(
             contig.recombination_map.mean_rate, rel=1e-6
         )
+
+    def test_bacterial_recombination(self):
+        assert self.genome.bacterial_recombination is False

--- a/tests/test_StrAga.py
+++ b/tests/test_StrAga.py
@@ -31,7 +31,7 @@ class TestGenomeData(test_species.GenomeTestBase):
     @pytest.mark.parametrize(
         ["name", "rate"],
         {
-            "1": 0,
+            "1": 1.53e-10,
         }.items(),
     )
     def test_recombination_rate(self, name, rate):

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -143,3 +143,13 @@ class TestBehaviour:
         contig.add_dfe(intervals=np.array([[0, 50]]), DFE=dfes[0])
         engine = stdpopsim.get_engine("msprime")
         engine.simulate(model, contig, samples, seed=1)
+
+    def test_gene_conversion(self):
+        species = stdpopsim.get_species("DroMel")
+        model = species.get_demographic_model("African3Epoch_1S16")
+        samples = model.get_samples(10)
+        contig = species.get_contig(length=1000, use_species_gene_conversion=True)
+        assert contig.gene_conversion_fraction > 0
+        assert contig.gene_conversion_length > 0
+        engine = stdpopsim.get_engine("msprime")
+        engine.simulate(model, contig, samples, seed=1)

--- a/validation.py
+++ b/validation.py
@@ -42,7 +42,8 @@ def irradiate(contig, x=20):
     """
     return stdpopsim.Contig(
         recombination_map=contig.recombination_map,
-        gene_conversion_rate=contig.gene_conversion_rate,
+        bacterial_recombination=contig.bacterial_recombination,
+        gene_conversion_fraction=contig.gene_conversion_fraction,
         gene_conversion_length=contig.gene_conversion_length,
         mutation_rate=x * contig.mutation_rate,
         genetic_map=contig.genetic_map,


### PR DESCRIPTION
Closes #1332; see there for discussion. Summary:

- `bacterial_recombination` is a property of a Genome and of a Contig; if this is True then recombination is all GC, so
  * `gene_conversion_fraction` must *not* be set
  * `gene_conversion_length` *must* be set
  * the recombination rate is converted at simulate( )-time to a gene conversion rate
- otherwise (ie for 'crossover' recombination), "recombination rate" is crossover rate, so:
  * if total rate of crossover + gene conversion is `total_rate` then `recomb_rate = total_rate * (1 - gc_frac)`
  * so for msprime, we set gene conversion rate to `gc_frac * total_rate = recomb_rate * gc_frac / (1 - gc_frac)`, where `recomb_rate` is the *mean* rate for the recombination map (since this must be constant)
  * and for SLiM we set the recombination rate (which here means the total rate!) to `recomb_rate / (1 - gc_frac)` and the gene conversion fraction to `gc_frac`