### PR TITLE
Add ploidy as attribute of species; rework samples specification

### DIFF
--- a/docs/examples.py
+++ b/docs/examples.py
@@ -13,7 +13,7 @@ def generic_models_example():
     species = stdpopsim.get_species("HomSap")
     contig = species.get_contig("chr22", length_multiplier=0.1)
     model = stdpopsim.PiecewiseConstantSize(species.population_size)
-    samples = model.get_samples(10)
+    samples = {"pop_0": 5}
     engine = stdpopsim.get_default_engine()
     ts = engine.simulate(model, contig, samples)
     print("num_trees =", ts.num_trees)

--- a/docs/selection_example.py
+++ b/docs/selection_example.py
@@ -21,9 +21,7 @@ def adaptive_introgression(seed):
     species = stdpopsim.get_species("HomSap")
     model = species.get_demographic_model("PapuansOutOfAfrica_10J19")
     contig = species.get_contig("chr1", length_multiplier=0.001)
-    samples = model.get_samples(
-        100, 0, 0, 100, 2, 2  # YRI, CEU, CHB, Papuan, DenA, NeaA
-    )
+    samples = {"YRI": 50, "Papuan": 50, "DenA": 1, "NeaA": 1}
 
     # We need some demographic model parameters to set bounds on the timing
     # of random variables and extended_events (below).

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -73,21 +73,23 @@ different output which shows options for performing the simulation itself and
 the species default parameters. This includes selecting the demographic model,
 chromosome, recombination map, and number of samples.
 
-The most basic simulation we can run is to simulate two (haploid) genomes
-- i.e., two samples -
+The most basic simulation we can run is to simulate a diploid genome
+- i.e., a single individual -
 using the species' defaults as seen in the species help (``stdpopsim HomSap --help``).
-These defaults include constant size population, a uniform recombination map based
+These defaults include constant size population named ``pop_0``, a uniform recombination map based
 on the average recombination rate (either genome-wide or within a chromosome, if
 specified), and the mutation rate shown above.
 To save time we will specify that the simulation use
 chromosome 22, using the ``-c`` option. We also specify that the resulting
 tree-sequence formatted output should be written to the file ``foo.ts`` with the
 ``-o`` option. For more information on how to use tree-sequence files see
-`tskit <https://tskit.dev/tskit/docs/stable/introduction.html>`__.
+`tskit <https://tskit.dev/tskit/docs/stable/introduction.html>`__. Finally, we
+specify that a single (diploid) sample should be simulated for population
+``pop_0`` using the syntax ``<population_name>:<number_of_samples>``.
 
 .. code-block:: console
 
-    $ stdpopsim HomSap -c chr22 -o foo.ts 2
+    $ stdpopsim HomSap -c chr22 -o foo.ts pop_0:1
 
 .. warning:: It's important to remember to either redirect the output of ``stdpopsim``
                 to file or to use the ``-o/--output`` option. If you do not, the
@@ -108,8 +110,8 @@ the two population out-of-Africa :ref:`model <sec_catalog_homsap_models_outofafr
 from `Tennesen et al. (2012) <https://doi.org/10.1126/science.1219240>`_ .
 By looking at the model help we find that the name for this model is
 ``OutOfAfrica_2T12`` and that we can specify it using
-the ``--demographic-model`` or ``-d`` option. We choose to draw two samples from the
-"African American" population and three samples from the "European American" population.
+the ``--demographic-model`` or ``-d`` option. We choose to draw two diploid sample from the
+``AFR`` ("African American") population and three diploids from the ``EUR`` ("European American") population.
 To increase simulation speed we can also choose to simulate a sequence that is
 a fraction of the length of the specified chromosome using the ``-l`` option
 (e.g. 5%). This is just specifying a sequence length, not actually selecting
@@ -118,14 +120,11 @@ other than a uniform recombination map. The command now looks like this:
 
 .. code-block:: console
 
-    $ stdpopsim HomSap -c chr22 -l 0.05 -o foo.ts -d OutOfAfrica_2T12 2 3
+    $ stdpopsim HomSap -c chr22 -l 0.05 -o foo.ts -d OutOfAfrica_2T12 AFR:2 EUR:3
 
-Note that the number of samples from each population are simply specified
-as two numbers at the end of the command. There must be *two* numbers because the
-model has two populations that we can sample from
-The order of those numbers is the same as the order
-specified in the model documentation. In this case, ``2 3`` means
-we are simulating two African American samples and three European American samples.
+Note that the number of samples from each population are simply specified as
+``<population_name>:<number_of_samples>`` at the end of the command. Omitted
+populations will have no samples in the resulting tree sequence.
 
 .. note::
     Many demographic models were inferred or calibrated using a mutation rate that
@@ -150,14 +149,14 @@ the ``-l`` option. (NOTE: this may a minute or so to run).
 
 .. code-block:: console
 
-    $ stdpopsim HomSap -g HapMapII_GRCh37 -c chr22 -o foo.ts -d OutOfAfrica_2T12 2 3
+    $ stdpopsim HomSap -g HapMapII_GRCh37 -c chr22 -o foo.ts -d OutOfAfrica_2T12 AFR:2 EUR:3
 
 For reproducibility we can also choose set the seed for the simulator using the
 ``-s`` flag.
 
 .. code-block:: console
 
-    $ stdpopsim HomSap -s 1046 -g HapMapII_GRCh37 -c chr22 -o foo.ts -d OutOfAfrica_2T12 2 3
+    $ stdpopsim HomSap -s 1046 -g HapMapII_GRCh37 -c chr22 -o foo.ts -d OutOfAfrica_2T12 AFR:2 EUR:3
 
 On running these commands, the CLI also outputs the relevant citations for both
 the simulator used and the resources used for simulation scenario.
@@ -180,15 +179,15 @@ with the ``tskit vcf`` command:
    $ tskit vcf foo.ts > foo.vcf
 
 For this small example (only five samples), the file sizes are similar,
-but the tree sequence is slightly larger
+but the tree sequence is slightly larger than the VCF
 (it does carry a good bit more information about the trees, after all).
-However, if we up the sample sizes to 2000 and 3000
+However, if we up the sample sizes to 1000 and 1500
 (the simulation is still pretty quick)
 the tree sequence is twenty-three times smaller:
 
 .. code-block:: console
 
-   $ stdpopsim HomSap -s 1046 -g HapMapII_GRCh37 -c chr22 -o foo.ts -d OutOfAfrica_2T12 2000 3000
+   $ stdpopsim HomSap -s 1046 -g HapMapII_GRCh37 -c chr22 -o foo.ts -d OutOfAfrica_2T12 AFR:1000 EUR:1500
    $ tskit vcf foo.ts > foo.vcf
    $ ls -lth foo.*
    -rw-r--r-- 1 peter peter 3139M Apr  3 10:40 foo.vcf
@@ -229,11 +228,8 @@ we would just run:
 
 .. code-block:: console
 
-    $ stdpopsim -e slim HomSap -c chr22 -l 0.05 -o foo.ts -d OutOfAfrica_2T12 2 4
+    $ stdpopsim -e slim HomSap -c chr22 -l 0.05 -o foo.ts -d OutOfAfrica_2T12 AFR:1 EUR:2
 
-Here we've changed the sample sizes to be even:
-SLiM simulates diploid individuals, but sample sizes are in numbers of chromosomes,
-so if you ask for an odd number, it will be rounded up to an even number.
 **But:** this simulation can take quite a while to run,
 so before you try that command out, **read on!**
 
@@ -255,7 +251,7 @@ Unlike the previous command, this one should run very fast:
 .. code-block:: console
 
     $ stdpopsim -e slim --slim-scaling-factor 10 HomSap \
-    $    -c chr22 -l 0.05 -o foo.ts -d OutOfAfrica_2T12 2 4
+    $    -c chr22 -l 0.05 -o foo.ts -d OutOfAfrica_2T12 AFR:1 EUR:2
 
 (Indeed, this example runs in less than a minute,
 but without setting the scaling factor, leaving at its default of 1.0,
@@ -292,7 +288,7 @@ To add it the example above we can type as follows:
 .. code-block:: console
 
     $ stdpopsim -e slim --slim-scaling-factor 10 HomSap \
-        -c chr22 -l 0.05 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 2 4
+        -c chr22 -l 0.05 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 AFR:1 EUR:2
 
 This example will simulate selection following the proportion of sites described in `Gamma_K17 <https://popsim-consortium.github.io/stdpopsim-docs/main/catalog.html#sec_catalog_homsap_dfes_gamma_k17>`_
 
@@ -303,7 +299,7 @@ and specifying a CDS annotation:
 
     $ stdpopsim -e slim --slim-scaling-factor 20 HomSap \
          -c chr22 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 \
-         --dfe-annotation ensembl_havana_104_CDS 2 4
+         --dfe-annotation ensembl_havana_104_CDS AFR:1 EUR:2
 
 
 If instead of an annotation file one has a bed file (ex.bed) like the one below:
@@ -321,7 +317,7 @@ then it is possible to simulate selection in all intervals provided by the bed f
 
     $ stdpopsim -e slim --slim-scaling-factor 10 HomSap \
          -c chr22 -l 0.05 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 \
-         --dfe-bed-file ex.bed 2 4
+         --dfe-bed-file ex.bed AFR:1 EUR:2
 
 The examples above (using the flags ``--dfe-annotation``, to use a named annotation, or ``--dfe-bed-file`` to include a bed file)
 incorporate selection on the specified segments of genome.
@@ -333,7 +329,7 @@ To simulate, however, only a small chunk of contig with selection––as in a s
 
     $ stdpopsim -e slim --slim-scaling-factor 10 HomSap \
         -c chr22 -l 0.05 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 \
-        --dfe-interval 1000,100000 2 4
+        --dfe-interval 1000,100000 AFR:1 EUR:2
 
 The DFE defined by Gamma_K17 will be incorporated only in positions between 1000 and 100000.
 
@@ -345,7 +341,7 @@ of a chromosome rather than the entire chromosome. Regions are specified via
 
     $ stdpopsim -e slim --slim-scaling-factor 10 HomSap \
         -c chr22 --dfe Gamma_K17 -o foo.ts -d OutOfAfrica_2T12 \
-        --dfe-interval 200000,300000 --left 150000 --right 350000 2 4
+        --dfe-interval 200000,300000 --left 150000 --right 350000 AFR:1 EUR:2
 
 This will simulate a 200 Kb contig that uses the genetic map from coordinates
 150000 to 350000 along `chr22`; with a DFE applied between coordinates 200000
@@ -380,7 +376,7 @@ using SLiM with a (very large!) scaling factor of 1000, we could run
 .. code-block:: console
 
    $ stdpopsim -e slim --slim-scaling-factor 1000 DroMel\
-   $     -c chr2L -l 0.05 -o foo.ts -d African3Epoch_1S16 100
+   $     -c chr2L -l 0.05 -o foo.ts -d African3Epoch_1S16 AFR:50
 
 The scaling factor of 1000 makes this model run very quickly,
 but should also make you *very* nervous.
@@ -396,7 +392,7 @@ which can be turned off with ``--quiet``:
 .. code-block:: console
 
    $ stdpopsim -v -e slim --slim-scaling-factor 1000 DroMel \
-   $     -c chr2L -l 0.05 -o foo.ts -d African3Epoch_1S16 100 --quiet
+   $     -c chr2L -l 0.05 -o foo.ts -d African3Epoch_1S16 AFR:50 --quiet
 
 Trimming down the output somewhat, we get:
 
@@ -416,8 +412,7 @@ This tells us that after rescaling by a factor of 1000,
 the population sizes in the three epochs are 652, 145, and 544 individuals,
 respectively.
 No wonder it runs so quickly!
-At the end, fifty (diploid) individuals are sampled,
-to get us our requested 100 genomes.
+At the end, fifty (diploid) individuals are sampled.
 These numbers are not obviously completely wrong,
 as would be for instance if we had population sizes of 1 or 2 individuals.
 However, extensive testing would need to be done to find out
@@ -538,19 +533,19 @@ Choose a sampling scheme and simulate
 
 The final ingredient we need before simulating
 is a specification of the number of samples from each population.
-We'll simulate 10 samples each from YRI and CHB, and zero from CEU,
+We'll simulate 5 diploids each from YRI and CHB, and zero from CEU,
 using ``msprime`` as the simulation engine:
 
 .. code-block:: python
 
-   samples = model.get_samples(10, 0, 10)
+   samples = {"YRI": 5, "CHB": 5, "CEU": 0}
    engine = stdpopsim.get_engine("msprime")
    ts = engine.simulate(model, contig, samples)
    print(ts.num_sites)
    # 88063
 
 And that's it! It's that easy! We now have a tree sequence
-describing the history and genotypes of 20 genomes,
+describing the history and genotypes of 20 haploid genomes,
 between which there are 88,063 variant sites.
 (We didn't set the random seed, though, so you'll get a somewhat
 different number.)
@@ -646,15 +641,15 @@ mutation rate, as no mutation rate was provided when defining the contig.
 Choose a sampling scheme, and simulate
 --------------------------------------
 
-Next, we set the number of samples and set the simulation engine.
-In this case we will simulate genomes of 10 samples
-using the simulation engine `msprime`.
-But, you can go crazy with the sample size!
-`msprime` is great at simulating large samples!
+Next, we set the number of samples and set the simulation engine.  In this case
+we will simulate genomes of 5 diploids using the simulation engine `msprime`
+(note that the generic `PiecewiseConstantSize` model has a single population
+named `pop_0`).  But, you can go crazy with the sample size!  `msprime` is
+great at simulating large samples!
 
 .. code-block:: python
 
-    samples = model.get_samples(10)
+    samples = {"pop_0": 5}
     engine = stdpopsim.get_engine("msprime")
 
 Finally, we simulate the model with the contig length and number of samples we
@@ -746,15 +741,13 @@ Here is a simple example.
 Choose the species, contig, and recombination map
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-First, let's set up a simulation of 10% of human chromosome 22
-with a flat recombination map,
-drawing 200 samples from the Tennesen et al (2012) model of African history,
-``Africa_1T12``.
-Since SLiM must simulate the entire population,
-sample size does not affect the run time of the simulation,
-only the size of the output tree sequence
-(and, since the tree sequence format scales well with sample size,
-it doesn't affect this very much either).
+First, let's set up a simulation of 10% of human chromosome 22 with a flat
+recombination map, drawing 100 diploids from the Tennesen et al (2012) model of
+African history, ``Africa_1T12`` (which has a single population named `AFR`).
+Since SLiM must simulate the entire population, sample size does not affect the
+run time of the simulation, only the size of the output tree sequence (and,
+since the tree sequence format scales well with sample size, it doesn't affect
+this very much either).
 
 
 .. code-block:: python
@@ -767,7 +760,7 @@ it doesn't affect this very much either).
        "chr22", length_multiplier=0.1, mutation_rate=model.mutation_rate
    )
    # default is a flat genetic map with average rate across chr22
-   samples = model.get_samples(200)
+   samples = {"AFR": 100}
 
 
 Choose the simulation engine
@@ -848,7 +841,7 @@ then we'd run the SLiM simulation starting at 5,920 + 731 = 6,651 generations ag
 and anything *longer ago* than that would be simulated
 with a msprime coalescent simulation.
 
-To simulate 200 samples of all of human chromosome 22 in this way,
+To simulate 100 diploid samples of all of human chromosome 22 in this way,
 with the ``HapMapII_GRCh37`` genetic map,
 we'd do the following
 (again setting ``slim_scaling_factor`` to keep this example reasonably-sized):
@@ -858,7 +851,7 @@ we'd do the following
    contig = species.get_contig(
        "chr22", genetic_map="HapMapII_GRCh37", mutation_rate=model.mutation_rate
    )
-   samples = model.get_samples(200)
+   samples = {"AFR": 100}
    engine = stdpopsim.get_engine("slim")
    ts = engine.simulate(model, contig, samples, slim_burn_in=0.1, slim_scaling_factor=10)
 
@@ -1019,7 +1012,7 @@ specifying which set of *intervals* it will apply to:
     contig.add_dfe(intervals=np.array([[0, int(contig.length)]]), DFE=dfe)
 
     model = species.get_demographic_model("OutOfAfrica_3G09")
-    samples = model.get_samples(100, 100, 100)  # YRI, CEU, CHB
+    samples = {"YRI": 50, "CEU": 50, "CHB": 50}
 
 Now, we can simulate as usual:
 
@@ -1076,7 +1069,7 @@ are removed from the intervals associated with previous DFEs.
     dfe = species.get_dfe("Gamma_K17")
     contig = species.get_contig(length=30000)
     model = species.get_demographic_model("OutOfAfrica_3G09")
-    samples = model.get_samples(100, 100, 100)  # YRI, CEU, CHB
+    samples = {"YRI": 50, "CEU": 50, "CHB": 50}
 
     gene_interval = np.array([[10000, 20000]])
     contig.add_dfe(intervals=gene_interval, DFE=dfe)
@@ -1159,7 +1152,7 @@ and use this in :meth:`.Contig.add_dfe`:
     dfe = species.get_dfe("Gamma_K17")
     contig = species.get_contig("chr20")
     model = species.get_demographic_model("OutOfAfrica_3G09")
-    samples = model.get_samples(100, 100, 100)  # YRI, CEU, CHB
+    samples = {"YRI": 50, "CEU": 50, "CHB": 50}
 
     exons = species.get_annotations("ensembl_havana_104_exons")
     exon_intervals = exons.get_chromosome_annotations("chr20").astype("int")
@@ -1245,7 +1238,7 @@ which we will insert later.
 
     species = stdpopsim.get_species("DroMel")
     model = stdpopsim.PiecewiseConstantSize(100000)
-    samples = model.get_samples(100)
+    samples = {"pop_0": 50}
     contig = species.get_contig("2L", length_multiplier=0.01)
 
 Next, we need to set things up to add a selected mutation to a randomly chosen
@@ -1588,11 +1581,13 @@ and that rates of migration since the split between the populations are both zer
         NA=5000, N1=4000, N2=1000, T=1000, M12=0, M21=0
     )
 
-We'll simulate 10 chromosomes from each of the populations using the ``msprime`` engine.
+We'll simulate 5 diploids from each of the populations using the
+``msprime`` engine (the populations in this generic model are named
+``pop1`` and ``pop2``).
 
 .. code-block:: python
 
-    samples = model.get_samples(10, 10)
+    samples = {"pop1": 5, "pop2": 5}
     engine = stdpopsim.get_engine("msprime")
 
 Finally, we'll run a simulation using the objects we've created and store the outputted

--- a/stdpopsim/catalog/AedAeg/species.py
+++ b/stdpopsim/catalog/AedAeg/species.py
@@ -5,6 +5,15 @@ from . import genome_data
 # These are in Table 1 of Juneja et al:
 _recombination_rate = {"1": 0.306e-8, "2": 0.249e-8, "3": 0.291e-8, "MT": 0}
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "MT": 1,
+}
+
 _JunejaEtAl = stdpopsim.Citation(
     doi="https://doi.org/10.1371/journal.pntd.0002652",
     year=2014,
@@ -56,6 +65,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         _NeneEtAl,
         _JunejaEtAl,
@@ -72,6 +82,7 @@ _species = stdpopsim.Species(
     common_name="Yellow fever mosquito",
     genome=_genome,
     generation_time=1 / 15,
+    ploidy=_species_ploidy,
     # the estimated population size today the modern Senegal forest population
     population_size=1e6,
     citations=[_CrawfordEtAl],

--- a/stdpopsim/catalog/AnaPla/species.py
+++ b/stdpopsim/catalog/AnaPla/species.py
@@ -148,6 +148,51 @@ _recombination_rate = {
     "40": _default_recombination_rate,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "22": _species_ploidy,
+    "23": _species_ploidy,
+    "24": _species_ploidy,
+    "25": _species_ploidy,
+    "26": _species_ploidy,
+    "27": _species_ploidy,
+    "28": _species_ploidy,
+    "29": _species_ploidy,
+    "30": _species_ploidy,
+    "Z": _species_ploidy,
+    "31": _species_ploidy,
+    "32": _species_ploidy,
+    "33": _species_ploidy,
+    "34": _species_ploidy,
+    "35": _species_ploidy,
+    "36": _species_ploidy,
+    "37": _species_ploidy,
+    "38": _species_ploidy,
+    "39": _species_ploidy,
+    "40": _species_ploidy,
+}
 
 # value used in Lavretsky et al 2020, as obtained for nuclear genes in other
 # ducks by Peters, Zhuravlev, Fefelov, Humphries, & Omland, 2008
@@ -203,6 +248,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         _LavretskyEtAl2019,
         _HuangEtAl2006,
@@ -237,6 +283,7 @@ _species = stdpopsim.Species(
     # choosing Ne based on theta = 4 Ne u from Guo et al 2021
     # theta = 0.003 (Figure 1), u as above (the paper uses a rate from chicken)
     population_size=156000,
+    ploidy=_species_ploidy,
     citations=[
         _LavretskyEtAl2020,
         _GuoEtAl2020,

--- a/stdpopsim/catalog/AnoCar/species.py
+++ b/stdpopsim/catalog/AnoCar/species.py
@@ -42,6 +42,25 @@ _recombination_rate = {
     "MT": 0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "LGa": _species_ploidy,
+    "LGb": _species_ploidy,
+    "LGc": _species_ploidy,
+    "LGd": _species_ploidy,
+    "LGf": _species_ploidy,
+    "LGg": _species_ploidy,
+    "LGh": _species_ploidy,
+    "MT": 1,
+}
+
 # Mutation rate
 _overall_rate = 2.1e-10
 
@@ -66,6 +85,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[_BourgeoisEtAl],
 )
 stdpopsim.utils.append_common_synonyms(_genome)
@@ -84,6 +104,7 @@ _species = stdpopsim.Species(
     # poulation size caculated from theta caculations
     # theta = 4Neu, theta from table 1
     # Ne averaged across the 5 populations from BourgeoisEtAl
+    ploidy=_species_ploidy,
     citations=[_LovernEtAl, _BourgeoisEtAl],
 )
 

--- a/stdpopsim/catalog/AnoGam/species.py
+++ b/stdpopsim/catalog/AnoGam/species.py
@@ -56,6 +56,16 @@ _recombination_rate = {
     "Mt": 0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "2L": _species_ploidy,
+    "2R": _species_ploidy,
+    "3L": _species_ploidy,
+    "3R": _species_ploidy,
+    "X": _species_ploidy,
+    "Mt": 1,
+}
 
 # the rate for DroMel as inferred by Keightley et al 2009,
 # which was used for the stairwayplot demographic inference
@@ -73,6 +83,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         _SharakhovaEtAl,
         _Ag1000G,
@@ -92,6 +103,7 @@ _species = stdpopsim.Species(
     generation_time=1 / 11,
     # based on theta = 4 Ne u in Gabon population, rounded
     population_size=1e6,
+    ploidy=_species_ploidy,
     citations=[_Ag1000G],
 )
 

--- a/stdpopsim/catalog/ApiMel/species.py
+++ b/stdpopsim/catalog/ApiMel/species.py
@@ -30,6 +30,30 @@ _recombination_rate = {
     "CM009947.2": 0,
 }
 
+# TODO: This species is haplodiploid, but machinery is not in place to simulate
+# haplodiploidy.
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "CM009931.2": _species_ploidy,
+    "CM009932.2": _species_ploidy,
+    "CM009933.2": _species_ploidy,
+    "CM009934.2": _species_ploidy,
+    "CM009935.2": _species_ploidy,
+    "CM009936.2": _species_ploidy,
+    "CM009937.2": _species_ploidy,
+    "CM009938.2": _species_ploidy,
+    "CM009939.2": _species_ploidy,
+    "CM009940.2": _species_ploidy,
+    "CM009941.2": _species_ploidy,
+    "CM009942.2": _species_ploidy,
+    "CM009943.2": _species_ploidy,
+    "CM009944.2": _species_ploidy,
+    "CM009945.2": _species_ploidy,
+    "CM009946.2": _species_ploidy,
+    "CM009947.2": 1,  # Mt
+}
+
 
 _YangEtAl = stdpopsim.Citation(
     doi="https://doi.org/10.1038/nature14649",
@@ -79,6 +103,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         _YangEtAl,
         _BeyeEtAl,
@@ -139,6 +164,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=2,
     population_size=2e05,
+    ploidy=_species_ploidy,
     citations=[
         _WallbergEtAl,
         _NelsonEtAl,

--- a/stdpopsim/catalog/AraTha/species.py
+++ b/stdpopsim/catalog/AraTha/species.py
@@ -8,6 +8,18 @@ _recombination_rate_data = {str(j): _mean_recombination_rate for j in range(1, 6
 _recombination_rate_data["Mt"] = 0
 _recombination_rate_data["Pt"] = 0  # JK Is this correct??
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "Mt": 1,
+    "Pt": 1,
+}
 
 # mutation rate from Ossowski 2010 Science
 # recombination value from Huber et al 2014 MBE
@@ -21,6 +33,7 @@ for name, data in genome_data.data["chromosomes"].items():
             synonyms=data["synonyms"],
             mutation_rate=7e-9,
             recombination_rate=_recombination_rate_data[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -59,6 +72,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=1.0,
     population_size=10**4,
+    ploidy=_species_ploidy,
     citations=[
         stdpopsim.Citation(
             doi="https://doi.org/10.1890/0012-9658(2002)083[1006:GTINSO]2.0.CO;2",

--- a/stdpopsim/catalog/BosTau/species.py
+++ b/stdpopsim/catalog/BosTau/species.py
@@ -64,6 +64,42 @@ _recombination_rate_data = collections.defaultdict(
 # Set some exceptions for non-recombining chrs.
 _recombination_rate_data["MT"] = 0
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "22": _species_ploidy,
+    "23": _species_ploidy,
+    "24": _species_ploidy,
+    "25": _species_ploidy,
+    "26": _species_ploidy,
+    "27": _species_ploidy,
+    "28": _species_ploidy,
+    "29": _species_ploidy,
+    "X": _species_ploidy,
+    "MT": 1,
+}
+
 _chromosomes = []
 for name, data in genome_data.data["chromosomes"].items():
     _chromosomes.append(
@@ -74,6 +110,7 @@ for name, data in genome_data.data["chromosomes"].items():
             # Harland et al. (2017), sex-averaged estimate per bp per generation.
             mutation_rate=1.2e-8,
             recombination_rate=_recombination_rate_data[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -96,6 +133,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=5,
     population_size=62000,  # ancestral Ne in _MacLeodEtAl
+    ploidy=_species_ploidy,
     citations=[_MacLeodEtAl],
 )
 

--- a/stdpopsim/catalog/CaeEle/species.py
+++ b/stdpopsim/catalog/CaeEle/species.py
@@ -94,6 +94,18 @@ _mutation_rate_data = {
     "MtDNA": 1.05e-7,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "V": _species_ploidy,
+    "X": _species_ploidy,
+    "MtDNA": 1,
+}
+
 _chromosomes = []
 for name, data in genome_data.data["chromosomes"].items():
     _chromosomes.append(
@@ -107,6 +119,7 @@ for name, data in genome_data.data["chromosomes"].items():
             # a mutation map.
             # mutation_rate=_mutation_rate_data[name],
             recombination_rate=_recombination_rate_data[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -135,6 +148,7 @@ _species = stdpopsim.Species(
     population_size=10000,  # Lots of estimates available,
     # they are all over the place. Settling on 10,000.
     #    selfing_rate,=0.999,
+    ploidy=_species_ploidy,
     citations=[
         _FrezalAndFelix2015.because(stdpopsim.CiteReason.GEN_TIME),
         _BarriereAndFelix2005.because(stdpopsim.CiteReason.POP_SIZE),

--- a/stdpopsim/catalog/CanFam/species.py
+++ b/stdpopsim/catalog/CanFam/species.py
@@ -48,6 +48,51 @@ _recombination_rate_data = {
     "MT": 0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "22": _species_ploidy,
+    "23": _species_ploidy,
+    "24": _species_ploidy,
+    "25": _species_ploidy,
+    "26": _species_ploidy,
+    "27": _species_ploidy,
+    "28": _species_ploidy,
+    "29": _species_ploidy,
+    "30": _species_ploidy,
+    "31": _species_ploidy,
+    "32": _species_ploidy,
+    "33": _species_ploidy,
+    "34": _species_ploidy,
+    "35": _species_ploidy,
+    "36": _species_ploidy,
+    "37": _species_ploidy,
+    "38": _species_ploidy,
+    "X": _species_ploidy,
+    "MT": 1,
+}
+
 _LindbladTohEtAl = stdpopsim.Citation(
     # Genome sequence, comparative analysis and haplotype structure of the
     # domestic dog.
@@ -88,6 +133,7 @@ for name, data in genome_data.data["chromosomes"].items():
             synonyms=data["synonyms"],
             mutation_rate=4e-9,  # based on non-CpG sites only
             recombination_rate=_recombination_rate_data[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -112,6 +158,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     population_size=13000,  # ancestral dog size
     generation_time=3,
+    ploidy=_species_ploidy,
     citations=[
         # Everyone uses 3 years for generation time because everyone else uses it.
         # It's likely higher, at least in wolves:

--- a/stdpopsim/catalog/ChlRei/species.py
+++ b/stdpopsim/catalog/ChlRei/species.py
@@ -30,6 +30,28 @@ _recombination_rate = {
     "17": 1.83e-10,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 1
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+}
+
 _mutation_rate = {
     "1": 9.74e-10,
     "2": 8.62e-10,
@@ -54,6 +76,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         stdpopsim.Citation(
             author="Merchant et al",
@@ -85,6 +108,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=1 / 876,
     population_size=1.4 * 1e-7,
+    ploidy=_species_ploidy,
     citations=[
         stdpopsim.Citation(
             author="Ness et al.",

--- a/stdpopsim/catalog/DroMel/species.py
+++ b/stdpopsim/catalog/DroMel/species.py
@@ -54,6 +54,18 @@ _recombination_rate = {
     "mitochondrion_genome": 0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "2L": _species_ploidy,
+    "2R": _species_ploidy,
+    "3L": _species_ploidy,
+    "3R": _species_ploidy,
+    "4": _species_ploidy,
+    "X": _species_ploidy,
+    "Y": 1,
+    "mitochondrion_genome": 1,
+}
 
 # Comeron et al:
 # - GC avg track length = 518bp
@@ -85,6 +97,7 @@ _mutation_rate = {c: 5.49e-9 for c in genome_data.data["chromosomes"]}
 #             synonyms=data["synonyms"],
 #             mutation_rate=5.49e-9,  # _SchriderEtAl de novo mutation rate
 #             recombination_rate=_recombination_rate_data[name],
+#             ploidy=_ploidy[name],
 #             gene_conversion_fraction=_gene_conversion_fraction_data[name],
 #             gene_conversion_length=_gene_conversion_length,
 #         )
@@ -94,6 +107,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     gene_conversion_fraction=_gene_conversion_fraction,
     gene_conversion_length=_gene_conversion_length,
     citations=[
@@ -116,6 +130,7 @@ _species = stdpopsim.Species(
     # Li and Stephan in a two-epoch model of African populations.
     # N_A0 is given as 8.603e6, and N_A1 (used here) is 5 times smaller.
     population_size=1720600,
+    ploidy=_species_ploidy,
     citations=[_LiAndStephan],
 )
 

--- a/stdpopsim/catalog/DroSec/species.py
+++ b/stdpopsim/catalog/DroSec/species.py
@@ -66,6 +66,17 @@ _mutation_rate = {
     "4": _overall_rate,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "2L": _species_ploidy,
+    "2R": _species_ploidy,
+    "3L": _species_ploidy,
+    "3R": _species_ploidy,
+    "X": _species_ploidy,
+    "4": _species_ploidy,
+}
+
 # We could not auto-pull the genome data from ensemble
 # so instead we used the most up-to-date assembly
 # currently available from NCBI.
@@ -73,6 +84,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[_ChakrabortyEtAl, _ComeronEtAl, _WallEtAl],
 )
 stdpopsim.utils.append_common_synonyms(_genome)
@@ -89,6 +101,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=0.05,
     population_size=100000,
+    ploidy=_species_ploidy,
     citations=[_LegrandEtAl],
 )
 

--- a/stdpopsim/catalog/EscCol/species.py
+++ b/stdpopsim/catalog/EscCol/species.py
@@ -28,6 +28,8 @@ _didelot_et_al = stdpopsim.Citation(
     doi="https://doi.org/10.1186/1471-2164-13-256",
 )
 
+_species_ploidy = 1
+
 _chromosomes = []
 for name, data in genome_data.data["chromosomes"].items():
     _chromosomes.append(
@@ -38,6 +40,7 @@ for name, data in genome_data.data["chromosomes"].items():
             # Wielgoss et al. (2011) calculated for strain REL606,
             # from synonymous substitutions over 40,000 generations.
             mutation_rate=8.9e-11,
+            ploidy=_species_ploidy,
             recombination_rate=8.9e-11,
             gene_conversion_length=542,
         )
@@ -72,6 +75,7 @@ _species = stdpopsim.Species(
     # Hartl et al. calculated Ne for "natural isolates of E. coli",
     # assuming mu=5e-10 (from Drake 1991).
     population_size=1.8e8,
+    ploidy=_species_ploidy,
     citations=[
         _sezonov_et_al.because(stdpopsim.CiteReason.GEN_TIME),
         _hartl_et_al.because(stdpopsim.CiteReason.POP_SIZE),

--- a/stdpopsim/catalog/GasAcu/species.py
+++ b/stdpopsim/catalog/GasAcu/species.py
@@ -30,6 +30,34 @@ _recombination_rate = {
     "MT": 0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "Y": 1,
+    "MT": 1,
+}
+
 # From the PSMC results.
 # Intermediate value between the from Materials and Methods.
 _overall_rate = 3.7e-8
@@ -63,6 +91,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         stdpopsim.Citation(
             author="Peichel et al.",
@@ -93,6 +122,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=2,  # PSMC description at the Materials and Methods.
     population_size=1e4,  # From PSMC results.
+    ploidy=_species_ploidy,
     citations=[
         stdpopsim.Citation(
             author="Liu et al.",

--- a/stdpopsim/catalog/HelAnn/species.py
+++ b/stdpopsim/catalog/HelAnn/species.py
@@ -27,6 +27,28 @@ _recombination_rate = {
     "17": _overall_rate,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+}
+
 # Average mutation rate reported by Andrew et al., 2013.
 _overall_rate = 6.1e-9
 _mutation_rate = {
@@ -54,6 +76,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         stdpopsim.Citation(
             doi="https://doi.org/10.1038/nature22380",
@@ -84,6 +107,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=1.0,
     population_size=673968,
+    ploidy=_species_ploidy,
     citations=[
         stdpopsim.Citation(
             doi="https://doi.org/10.1093/molbev/msq270",

--- a/stdpopsim/catalog/HelMel/species.py
+++ b/stdpopsim/catalog/HelMel/species.py
@@ -51,10 +51,37 @@ _mutation_rate = {
     "21": _overall_rate,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+}
+
 _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         stdpopsim.Citation(
             author="Davey et al",
@@ -81,6 +108,7 @@ _species = stdpopsim.Species(
     generation_time=35 / 365,  # 35 days
     # population size from the first of two datasets in Pardo-Diaz et al 2012
     population_size=2111109,
+    ploidy=_species_ploidy,
     citations=[
         stdpopsim.Citation(
             author="Pardo-Diaz et al",

--- a/stdpopsim/catalog/HomSap/species.py
+++ b/stdpopsim/catalog/HomSap/species.py
@@ -33,6 +33,36 @@ _recombination_rate_data = {
     "MT": 0.0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "22": _species_ploidy,
+    "X": _species_ploidy,
+    "Y": 1,
+    "MT": 1,
+}
+
 _genome2001 = stdpopsim.Citation(
     doi="http://dx.doi.org/10.1038/35057062",
     year=2001,
@@ -76,6 +106,7 @@ for name, data in genome_data.data["chromosomes"].items():
             synonyms=data["synonyms"],
             mutation_rate=1.29e-8,
             recombination_rate=_recombination_rate_data[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -99,6 +130,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=30,
     population_size=10**4,
+    ploidy=_species_ploidy,
     citations=[
         _tremblay2000.because(stdpopsim.CiteReason.GEN_TIME),
         _takahata1993.because(stdpopsim.CiteReason.POP_SIZE),

--- a/stdpopsim/catalog/PanTro/species.py
+++ b/stdpopsim/catalog/PanTro/species.py
@@ -30,6 +30,36 @@ _langergraber2012 = stdpopsim.Citation(
     reasons={stdpopsim.CiteReason.GEN_TIME},
 )
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2A": _species_ploidy,
+    "2B": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "22": _species_ploidy,
+    "X": _species_ploidy,
+    "Y": 1,
+}
+
 _chromosomes = []
 for name, data in genome_data.data["chromosomes"].items():
     _chromosomes.append(
@@ -39,6 +69,7 @@ for name, data in genome_data.data["chromosomes"].items():
             synonyms=data["synonyms"],
             mutation_rate=1.6e-8,
             recombination_rate=1.2e-8,
+            ploidy=_ploidy[name],
         )
     )
 
@@ -62,6 +93,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=24.6,
     population_size=16781,
+    ploidy=_species_ploidy,
     citations=[
         _langergraber2012.because(stdpopsim.CiteReason.GEN_TIME),
         _stevison2015.because(stdpopsim.CiteReason.POP_SIZE),

--- a/stdpopsim/catalog/PapAnu/species.py
+++ b/stdpopsim/catalog/PapAnu/species.py
@@ -33,6 +33,32 @@ _recombination_rate = {
     "Y": 0.0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "X": _species_ploidy,
+    "Y": 1,
+}
 
 _batra2020 = stdpopsim.Citation(
     author="Batra et. al.",
@@ -66,6 +92,7 @@ for name, data in genome_data.data["chromosomes"].items():
             synonyms=data["synonyms"],
             mutation_rate=5.7e-9,
             recombination_rate=_recombination_rate[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -90,6 +117,7 @@ _species = stdpopsim.Species(
     # "Inferring split times of humans and baboons"
     population_size=335505,  # Most recent from Wall et al demographic model
     # included in demographic_models.py in this directory
+    ploidy=_species_ploidy,
     citations=[
         _wall2022.because(stdpopsim.CiteReason.POP_SIZE),
         _wu2020.because(stdpopsim.CiteReason.GEN_TIME),

--- a/stdpopsim/catalog/PonAbe/species.py
+++ b/stdpopsim/catalog/PonAbe/species.py
@@ -35,6 +35,36 @@ _recombination_rate_data = {
     "MT": 0,
 }
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2A": _species_ploidy,
+    "2B": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "9": _species_ploidy,
+    "10": _species_ploidy,
+    "11": _species_ploidy,
+    "12": _species_ploidy,
+    "13": _species_ploidy,
+    "14": _species_ploidy,
+    "15": _species_ploidy,
+    "16": _species_ploidy,
+    "17": _species_ploidy,
+    "18": _species_ploidy,
+    "19": _species_ploidy,
+    "20": _species_ploidy,
+    "21": _species_ploidy,
+    "22": _species_ploidy,
+    "X": _species_ploidy,
+    "MT": 1,
+}
+
 # High-resolution comparative analysis of great ape genomes
 _kronenberg2018 = stdpopsim.Citation(
     author="Kronenberg et al.",
@@ -80,6 +110,7 @@ for name, data in genome_data.data["chromosomes"].items():
             # assumption that it's similar to humans and chimps.
             mutation_rate=1.5e-8,
             recombination_rate=_recombination_rate_data[name],
+            ploidy=_ploidy[name],
         )
     )
 
@@ -101,6 +132,7 @@ _species = stdpopsim.Species(
     generation_time=25,
     # Locke et al. inferred ancestral Ne
     population_size=1.79e4,
+    ploidy=_species_ploidy,
     citations=[_locke2011, _wich2008],
 )
 

--- a/stdpopsim/catalog/StrAga/species.py
+++ b/stdpopsim/catalog/StrAga/species.py
@@ -16,6 +16,10 @@ _DaCunha_et_al = stdpopsim.Citation(
 # mu =  0.56/(1e6*365)
 _mutation_rate = {"1": 1.53e-9}
 
+# Generic and chromosome-specific ploidy
+_species_ploidy = 1
+_ploidy = {"1": _species_ploidy}
+
 # gene conversion rate (HGT rate):
 # hard to estimate precisely. What is often estimated is the r/m or rho/theta ratio.
 # in Oliveira et. al, PNAS, 2016, they estimate those rates on coregenome
@@ -50,6 +54,7 @@ _genome = stdpopsim.Genome.from_data(
     genome_data.data,
     recombination_rate=_recombination_rate,
     mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
     citations=[
         _DaCunha_et_al.because(stdpopsim.CiteReason.ASSEMBLY),
         _DaCunha_et_al.because(stdpopsim.CiteReason.MUT_RATE),
@@ -94,6 +99,7 @@ _species = stdpopsim.Species(
     genome=_genome,
     generation_time=1 / 365,  # year / generations
     population_size=140000,
+    ploidy=_species_ploidy,
     citations=[
         _DaCunha_et_al.because(stdpopsim.CiteReason.POP_SIZE),
         stdpopsim.Citation(

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -6,10 +6,7 @@ import textwrap
 
 import msprime
 import warnings
-
-# DeprecationWarning is filtered by default. The following ensures that these
-# warnings are visible to the user.
-warnings.simplefilter("always", DeprecationWarning)
+import stdpopsim
 
 
 class Population:
@@ -249,12 +246,13 @@ class DemographicModel:
         """
 
         warnings.warn(
-            "The use of `DemographicModel.get_samples` (Python API) and "
-            "positional sample counts (CLI) is deprecated. Instead, supply a "
-            "{population_name:num_samples} dict to "
-            "`Engine.simulate(samples=...)` (Python API); or use the syntax "
-            "`stdpopsim SpeciesName population_name:num_samples` (CLI).",
-            DeprecationWarning,
+            stdpopsim.DeprecatedFeatureWarning(
+                "The use of `DemographicModel.get_samples` (Python API) and "
+                "positional sample counts (CLI) is deprecated. Instead, supply a "
+                "{population_name:num_samples} dict to "
+                "`Engine.simulate(samples=...)` (Python API); or use the syntax "
+                "`stdpopsim SpeciesName population_name:num_samples` (CLI)."
+            )
         )
 
         samples = []

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -125,6 +125,8 @@ class Species:
         model uses the generation time that was used in the original
         publication(s).
     :vartype generation_time: float
+    :ivar ploidy: The ploidy of the organism.
+    :vartype ploidy: int
     :ivar population_size: The current best estimate for the population
         size of this species. Note that individual demographic
         models in the catalog may or may not use this estimate: each
@@ -151,6 +153,7 @@ class Species:
     common_name = attr.ib(type=str, kw_only=True)
     genome = attr.ib(type=int, kw_only=True)
     generation_time = attr.ib(default=0, kw_only=True)
+    ploidy = attr.ib(default=2, type=int, kw_only=True)
     population_size = attr.ib(default=0, kw_only=True)
     demographic_models = attr.ib(factory=list, kw_only=True)
     dfes = attr.ib(factory=list, kw_only=True)

--- a/stdpopsim/warning_categories.py
+++ b/stdpopsim/warning_categories.py
@@ -26,3 +26,7 @@ class UnspecifiedSLiMWarning(UserWarning):
 
 class EmptyIntervalsWarning(UserWarning):
     pass
+
+
+class DeprecatedFeatureWarning(UserWarning):
+    pass

--- a/tests/test_AedAeg.py
+++ b/tests/test_AedAeg.py
@@ -42,3 +42,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_AnaPla.py
+++ b/tests/test_AnaPla.py
@@ -166,3 +166,7 @@ class TestGenomeData(test_species.GenomeTestBase):
 
     def test_bacterial_recombination(self):
         assert self.genome.bacterial_recombination is False
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 2

--- a/tests/test_AnoCar.py
+++ b/tests/test_AnoCar.py
@@ -77,3 +77,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_AnoGam.py
+++ b/tests/test_AnoGam.py
@@ -66,3 +66,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["Mt"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_ApiMel.py
+++ b/tests/test_ApiMel.py
@@ -79,3 +79,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["CM009947.2"]:  # Mt
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_AraTha.py
+++ b/tests/test_AraTha.py
@@ -1,4 +1,5 @@
 import stdpopsim
+import pytest
 from tests import test_species
 
 
@@ -20,3 +21,10 @@ class TestGenome(test_species.GenomeTestBase):
     def test_basic_attributes(self):
         # 5 autosomes + Mt + Pt
         assert len(self.genome.chromosomes) == 7
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["Mt", "Pt"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_BosTau.py
+++ b/tests/test_BosTau.py
@@ -158,3 +158,10 @@ class TestGenome(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_CaeEle.py
+++ b/tests/test_CaeEle.py
@@ -100,3 +100,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MtDNA"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_CanFam.py
+++ b/tests/test_CanFam.py
@@ -151,3 +151,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_ChlRei.py
+++ b/tests/test_ChlRei.py
@@ -79,3 +79,7 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 1

--- a/tests/test_DroMel.py
+++ b/tests/test_DroMel.py
@@ -36,3 +36,10 @@ class TestGenome(test_species.GenomeTestBase):
         chrom = self.genome.get_chromosome(chr_id)
         assert chrom.recombination_rate > 0
         assert chrom.gene_conversion_fraction > 0
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["mitochondrion_genome", "Y"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_DroSec.py
+++ b/tests/test_DroSec.py
@@ -57,3 +57,7 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 2

--- a/tests/test_EscCol.py
+++ b/tests/test_EscCol.py
@@ -2,6 +2,7 @@
 Tests for the EscCol data definitions.
 """
 import stdpopsim
+import pytest
 from tests import test_species
 
 
@@ -38,3 +39,7 @@ class TestGenome(test_species.GenomeTestBase):
 
     def test_bacterial_recombination(self):
         assert self.genome.bacterial_recombination is True
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 1

--- a/tests/test_GasAcu.py
+++ b/tests/test_GasAcu.py
@@ -91,3 +91,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT", "Y"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_HelAnn.py
+++ b/tests/test_HelAnn.py
@@ -79,3 +79,8 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    @pytest.mark.filterwarnings("ignore::stdpopsim.NonAutosomalWarning")
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 2

--- a/tests/test_HelMel.py
+++ b/tests/test_HelMel.py
@@ -87,3 +87,7 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 2

--- a/tests/test_HomSap.py
+++ b/tests/test_HomSap.py
@@ -40,3 +40,10 @@ class TestGenome(test_species.GenomeTestBase):
 
     def test_bacterial_recombination(self):
         assert self.genome.bacterial_recombination is False
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT", "Y"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_PanTro.py
+++ b/tests/test_PanTro.py
@@ -41,3 +41,10 @@ class TestGenome(test_species.GenomeTestBase):
     @pytest.mark.parametrize("chr_id", [chrom.id for chrom in genome.chromosomes])
     def test_mutation_rate(self, chr_id, rate=1.6e-8):
         assert rate == pytest.approx(self.genome.get_chromosome(chr_id).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["Y"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_PapAnu.py
+++ b/tests/test_PapAnu.py
@@ -89,3 +89,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["Y"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_PonAbe.py
+++ b/tests/test_PonAbe.py
@@ -111,3 +111,10 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        if chrom.id in ["MT"]:
+            assert chrom.ploidy == 1
+        else:
+            assert chrom.ploidy == 2

--- a/tests/test_StrAga.py
+++ b/tests/test_StrAga.py
@@ -45,3 +45,7 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize("chrom", [chrom for chrom in genome.chromosomes])
+    def test_chromosome_ploidy(self, chrom):
+        assert chrom.ploidy == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,48 +140,48 @@ class TestHomoSapiensArgumentParser:
     def test_defaults(self):
         parser = cli.stdpopsim_cli_parser()
         cmd = "HomSap"
-        args = parser.parse_args([cmd, "2"])
+        args = parser.parse_args([cmd, "pop_0:2"])
         assert args.output is None
         assert args.seed is None
-        assert args.samples == [2]
+        assert args.samples == ["pop_0:2"]
 
     def test_output(self):
         parser = cli.stdpopsim_cli_parser()
         cmd = "HomSap"
         output = "/stuff/tmp.trees"
 
-        args = parser.parse_args([cmd, "2", "-o", output])
+        args = parser.parse_args([cmd, "pop_0:2", "-o", output])
         assert args.output == output
-        assert args.samples == [2]
+        assert args.samples == ["pop_0:2"]
 
-        args = parser.parse_args([cmd, "-o", output, "2"])
+        args = parser.parse_args([cmd, "-o", output, "pop_0:2"])
         assert args.output == output
-        assert args.samples == [2]
+        assert args.samples == ["pop_0:2"]
 
-        args = parser.parse_args([cmd, "--output", output, "2"])
+        args = parser.parse_args([cmd, "--output", output, "pop_0:2"])
         assert args.output == output
-        assert args.samples == [2]
+        assert args.samples == ["pop_0:2"]
 
     def test_seed(self):
         parser = cli.stdpopsim_cli_parser()
         cmd = "HomSap"
-        args = parser.parse_args([cmd, "2", "-s", "1234"])
-        assert args.samples == [2]
+        args = parser.parse_args([cmd, "pop_0:2", "-s", "1234"])
+        assert args.samples == ["pop_0:2"]
         assert args.seed == 1234
 
-        args = parser.parse_args([cmd, "2", "--seed", "14"])
-        assert args.samples == [2]
+        args = parser.parse_args([cmd, "pop_0:2", "--seed", "14"])
+        assert args.samples == ["pop_0:2"]
         assert args.seed == 14
 
     def test_cache_dir(self):
         parser = cli.stdpopsim_cli_parser()
         cmd = "HomSap"
-        args = parser.parse_args(["-c", "cache_dir", cmd, "2"])
-        assert args.samples == [2]
+        args = parser.parse_args(["-c", "cache_dir", cmd, "pop_0:2"])
+        assert args.samples == ["pop_0:2"]
         assert args.cache_dir == "cache_dir"
 
-        args = parser.parse_args(["--cache-dir", "/some/cache_dir", cmd, "2"])
-        assert args.samples == [2]
+        args = parser.parse_args(["--cache-dir", "/some/cache_dir", cmd, "pop_0:2"])
+        assert args.samples == ["pop_0:2"]
         assert args.cache_dir == "/some/cache_dir"
 
     def test_bibtex(self):
@@ -191,9 +191,9 @@ class TestHomoSapiensArgumentParser:
         bib = "tmp.bib"
 
         with mock.patch.object(argparse.FileType, "__call__", autospec=True) as call:
-            args = parser.parse_args([cmd, "-b", bib, "-o", output, "2"])
+            args = parser.parse_args([cmd, "-b", bib, "-o", output, "pop_0:2"])
             assert args.output == output
-            assert args.samples == [2]
+            assert args.samples == ["pop_0:2"]
             call.assert_called_with(mock.ANY, bib)
 
 
@@ -214,47 +214,47 @@ class TestEndToEnd:
         assert ts.num_samples == num_samples
 
     def test_homsap_seed(self):
-        cmd = "HomSap -c chr20 -l0.1 -s 1234 20"
+        cmd = "HomSap -c chr20 -l0.1 -s 1234 pop_0:10"
         self.verify(cmd, num_samples=20, seed=1234)
 
     def test_homsap_constant(self):
-        cmd = "HomSap -c chr20 -l0.1 20"
-        self.verify(cmd, num_samples=20)
+        cmd = "HomSap -c chr20 -l0.1 pop_0:5"
+        self.verify(cmd, num_samples=10)
 
     def test_tennessen_two_pop_ooa(self):
-        cmd = "HomSap -c chr20 -l0.1 -d OutOfAfrica_2T12 2 3"
-        self.verify(cmd, num_samples=5)
+        cmd = "HomSap -c chr20 -l0.1 -d OutOfAfrica_2T12 AFR:2 EUR:3"
+        self.verify(cmd, num_samples=10)
 
     def test_gutenkunst_three_pop_ooa(self):
-        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 10"
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 YRI:5"
         self.verify(cmd, num_samples=10)
 
     def test_browning_america(self):
-        cmd = "HomSap -c chr1 -l0.01 -d AmericanAdmixture_4B11 10"
+        cmd = "HomSap -c chr1 -l0.01 -d AmericanAdmixture_4B11 AFR:5"
         self.verify(cmd, num_samples=10)
 
     def test_ragsdale_archaic(self):
-        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfricaArchaicAdmixture_5R19 10"
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfricaArchaicAdmixture_5R19 YRI:5"
         self.verify(cmd, num_samples=10)
 
     def test_dromel_constant(self):
-        cmd = "DroMel -c 2L -l0.001 4"
+        cmd = "DroMel -c 2L -l0.001 pop_0:2"
         self.verify(cmd, num_samples=4)
 
     def test_li_stephan_two_population(self):
-        cmd = "DroMel -c 2L -l0.001 -d OutOfAfrica_2L06 3"
-        self.verify(cmd, num_samples=3)
+        cmd = "DroMel -c 2L -l0.001 -d OutOfAfrica_2L06 AFR:3"
+        self.verify(cmd, num_samples=6)
 
     def test_aratha_constant(self):
-        cmd = "AraTha -L 100 8"
+        cmd = "AraTha -L 100 pop_0:4"
         self.verify(cmd, num_samples=8)
 
     def test_durvusula_2017_msmc(self):
-        cmd = "AraTha -L 100 -d SouthMiddleAtlas_1D17 7"
-        self.verify(cmd, num_samples=7)
+        cmd = "AraTha -L 100 -d SouthMiddleAtlas_1D17 SouthMiddleAtlas:7"
+        self.verify(cmd, num_samples=14)
 
     def test_lapierre_constant(self):
-        cmd = "EscCol -L 1000 2"
+        cmd = "EscCol -L 1000 pop_0:2"
         self.verify(cmd, num_samples=2)
 
 
@@ -288,7 +288,7 @@ class TestWriteOutput:
     def test_stdout(self):
         ts = msprime.simulate(10, random_seed=2)
         parser = cli.stdpopsim_cli_parser()
-        args = parser.parse_args(["AraTha", "2"])
+        args = parser.parse_args(["AraTha", "pop_0:2"])
         with mock.patch("shutil.copyfileobj", autospec=True) as mocked_copy:
             with mock.patch("sys.stdout", autospec=True) as stdout:
                 stdout.buffer = open(os.devnull, "wb")
@@ -299,7 +299,7 @@ class TestWriteOutput:
         ts = msprime.simulate(10, random_seed=2)
         parser = cli.stdpopsim_cli_parser()
         output_file = "mocked.trees"
-        args = parser.parse_args(["HomSap", "2", "-o", output_file])
+        args = parser.parse_args(["HomSap", "pop_0:2", "-o", output_file])
         with mock.patch("tskit.TreeSequence.dump", autospec=True) as mocked_dump:
             cli.write_output(ts, args)
             mocked_dump.assert_called_once_with(mock.ANY, output_file)
@@ -351,11 +351,11 @@ class TestRedirection:
             self.verify_files(filename1, filename2)
 
     def test_quiet(self):
-        cmd = "-q HomSap -s 2 10 -c chr20 -l 0.001"
+        cmd = "-q HomSap pop_0:5 -s 2 -c chr20 -l 0.001"
         self.verify(cmd)
 
     def test_no_quiet(self):
-        cmd = "HomSap -s 3 10 -c chr20 -l 0.001"
+        cmd = "HomSap pop_0:5 -s 3 -c chr20 -l 0.001"
         self.verify(cmd)
 
 
@@ -364,7 +364,7 @@ class TestArgumentParsing:
     Tests that basic argument parsing works as expected.
     """
 
-    basic_cmd = ["HomSap", "10"]
+    basic_cmd = ["HomSap", "pop_0:10"]
 
     def test_quiet_verbose(self):
         parser = cli.stdpopsim_cli_parser()
@@ -391,7 +391,7 @@ class TestLogging:
     Tests that logging has the desired effect.
     """
 
-    basic_cmd = ["HomSap", "10"]
+    basic_cmd = ["HomSap", "pop_0:10"]
 
     def test_quiet(self):
         parser = cli.stdpopsim_cli_parser()
@@ -608,14 +608,14 @@ class TestWriteBibtex:
     Test that citations are able to be converted to bibtex
     and written to file."""
 
-    def test_whole_bibex(self):
+    def test_whole_bibtex(self):
         # Test end to end
         seed = 1
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = pathlib.Path(tmpdir) / "output.trees"
             bibfile = pathlib.Path(tmpdir) / "bib.bib"
             full_cmd = (
-                f"HomSap -c chr20 -l0.1 20 "
+                f"HomSap -c chr20 -l0.1 YRI:10 "
                 f"-o {filename} -d OutOfAfrica_3G09 --seed={seed} "
                 f"--bibtex={bibfile}"
             )
@@ -632,7 +632,7 @@ class TestWriteBibtex:
     def test_number_of_calls(self):
         # Test that genetic map citations are converted.
         species = stdpopsim.get_species("HomSap")
-        genetic_map = species.get_genetic_map("HapMapII_GRCh37")
+        genetic_map = species.get_genetic_map("HapMapII_GRCh38")
         contig = species.get_contig("chr20", genetic_map=genetic_map.id)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
         engine = stdpopsim.get_default_engine()
@@ -759,12 +759,12 @@ class TestCacheDir:
 
     def test_homsap_simulation(self):
         cache_dir = "/some/cache/dir"
-        cmd = f"-c {cache_dir} HomSap 2 -o tmp.trees"
+        cmd = f"-c {cache_dir} HomSap pop_0:2 -o tmp.trees"
         self.check_cache_dir_set(cmd, cache_dir)
 
     def test_dromel_simulation(self):
         cache_dir = "cache_dir"
-        cmd = f"--cache-dir {cache_dir} DroMel 2 -o tmp.trees"
+        cmd = f"--cache-dir {cache_dir} DroMel pop_0:2 -o tmp.trees"
         self.check_cache_dir_set(cmd, cache_dir)
 
     def test_download_genetic_maps(self):
@@ -868,7 +868,10 @@ class TestDryRun:
             path = pathlib.Path(tmpdir)
             with open(path / "stderr", "w+") as stderr:
                 filename = path / "output.trees"
-                cmd = f"{sys.executable} -m stdpopsim HomSap -D -L 1000 -o {filename} 2"
+                cmd = (
+                    f"{sys.executable} -m stdpopsim HomSap -D -L 1000 -o "
+                    f"{filename} pop_0:1"
+                )
                 subprocess.run(cmd, stderr=stderr, shell=True, check=True)
                 assert stderr.tell() > 0
             assert not os.path.isfile(filename)
@@ -880,7 +883,7 @@ class TestDryRun:
                 filename = path / "output.trees"
                 cmd = (
                     f"{sys.executable} -m stdpopsim -q HomSap -D -L 1000 "
-                    f"-o {filename} 2"
+                    f"-o {filename} pop_0:1"
                 )
                 subprocess.run(cmd, stderr=stderr, shell=True, check=True)
                 assert stderr.tell() == 0
@@ -891,7 +894,7 @@ class TestMsprimeEngine:
     def docmd(self, _cmd):
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = pathlib.Path(tmpdir) / "output.trees"
-            cmd = f"-q -e msprime {_cmd} AraTha -L 100 --seed 1 -o {filename} 10"
+            cmd = f"-q -e msprime {_cmd} AraTha -L 100 --seed 1 -o {filename} pop_0:5"
             return capture_output(stdpopsim.cli.stdpopsim_main, cmd.split())
 
     def test_simulate(self):
@@ -926,7 +929,7 @@ class TestMsprimeEngine:
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr20")
         model = species.get_demographic_model("OutOfAfrica_2T12")
-        samples = model.get_samples(10)
+        samples = {"AFR": 5}
         with pytest.raises(ValueError):
             engine.simulate(model, contig, samples, msprime_model="notamodel")
         with pytest.raises(ValueError):
@@ -944,7 +947,7 @@ class TestNonAutosomal:
     # TODO: This test should be removed when #383 is fixed.
     # https://github.com/popsim-consortium/stdpopsim/issues/383
     def test_chrX_gives_a_warning(self):
-        cmd = "HomSap -D -c chrX -o /dev/null 10".split()
+        cmd = "HomSap -D -c chrX -o /dev/null pop_0:10".split()
         # setup_logging() interferes with pytest.warns().
         with mock.patch("stdpopsim.cli.setup_logging", autospec=True):
             with pytest.warns(stdpopsim.NonAutosomalWarning):
@@ -985,10 +988,10 @@ class TestNoQCWarning:
                 capture_output(stdpopsim.cli.stdpopsim_main, cmd.split())
 
     def test_noQC_warning(self):
-        self.verify_noQC_warning("EscCol -d FakeModel -D 10 -L 1000")
+        self.verify_noQC_warning("EscCol -d FakeModel -D -L 1000 Omicronians:10")
 
     def test_noQC_warning_quiet(self):
-        self.verify_noQC_warning("-q EscCol -d FakeModel -D 10 -L 1000")
+        self.verify_noQC_warning("-q EscCol -d FakeModel -D -L 1000 Omicronians:10")
 
     def verify_noQC_citations_not_written(self, cmd, caplog):
         # Non-QCed models shouldn't be used in publications, so citations
@@ -1011,14 +1014,14 @@ class TestNoQCWarning:
     @pytest.mark.usefixtures("caplog")
     def test_noQC_citations_not_written(self, caplog):
         self.verify_noQC_citations_not_written(
-            "EscCol -d FakeModel -D 10 -L 1000", caplog
+            "EscCol -d FakeModel -D -L 1000 Omicronians:10", caplog
         )
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.QCMissingWarning")
     @pytest.mark.usefixtures("caplog")
     def test_noQC_citations_not_written_verbose(self, caplog):
         self.verify_noQC_citations_not_written(
-            "-vv EscCol -d FakeModel -D 10 -L 1000", caplog
+            "-vv EscCol -d FakeModel -D -L 1000 Omicronians:10", caplog
         )
 
 
@@ -1033,8 +1036,56 @@ def test_species_simulation(species_id):
     for chrom in species.genome.chromosomes:
         if chrom.gene_conversion_length is not None:
             L = max(L, chrom.gene_conversion_length + 100)
-    cmd = f"-q {species_id} -L {L} --seed 1234 10"
+    cmd = f"-q {species_id} -L {L} --seed 1234 pop_0:10"
     # Just check to see if the simulation runs
     with mock.patch("sys.stdout", autospec=True) as stdout:
         stdout.buffer = open(os.devnull, "wb")
         stdpopsim.cli.stdpopsim_main(cmd.split())
+
+
+class TestSampleCountParser:
+    def verify(self, cmd, num_samples, seed=1):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = pathlib.Path(tmpdir) / "output.trees"
+            full_cmd = f" -q {cmd} -o {filename} --seed={seed}"
+            with mock.patch("stdpopsim.cli.setup_logging", autospec=True):
+                stdout, stderr = capture_output(cli.stdpopsim_main, full_cmd.split())
+            assert len(stderr) == 0
+            assert len(stdout) == 0
+            ts = tskit.load(str(filename))
+        for i in range(len(num_samples)):
+            assert len(ts.samples(population=i)) == num_samples[i]
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_deprecated_positional_samples(self):
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 5"
+        self.verify(cmd, num_samples=[5, 0, 0])
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 5 10"
+        self.verify(cmd, num_samples=[5, 10, 0])
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 5 0 10"
+        self.verify(cmd, num_samples=[5, 0, 10])
+
+    def test_population_sample_pairs(self):
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 YRI:5"
+        self.verify(cmd, num_samples=[10, 0, 0])
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 CHB:5 YRI:10"
+        self.verify(cmd, num_samples=[20, 0, 10])
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 CHB:5 YRI:10 CEU:0"
+        self.verify(cmd, num_samples=[20, 0, 10])
+
+    def test_bad_sample_specification(self):
+        for cmd in [
+            "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 5 bad",
+            "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 5 CEU:5",
+            "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 YRI:5 very:bad",
+            "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 YRI=5",
+        ]:
+            with pytest.raises(
+                ValueError, match="Sample specification must be in the form"
+            ):
+                self.verify(cmd, num_samples=[5, 0, 0])
+
+    def test_duplicate_sample_specification(self):
+        cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 YRI:5 YRI:5"
+        with pytest.raises(ValueError, match="specified more than once"):
+            self.verify(cmd, num_samples=[20, 0, 0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1056,7 +1056,7 @@ class TestSampleCountParser:
         for i in range(len(num_samples)):
             assert len(ts.samples(population=i)) == num_samples[i]
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::stdpopsim.DeprecatedFeatureWarning")
     def test_deprecated_positional_samples(self):
         cmd = "HomSap -c chr1 -l0.01 -d OutOfAfrica_3G09 5"
         self.verify(cmd, num_samples=[5, 0, 0])

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -573,13 +573,14 @@ class TestCreateDFE:
         contig = stdpopsim.Contig.basic_contig(
             length=10000,
             mutation_rate=1e-6,
+            ploidy=2,
         )
         contig.add_dfe(
             intervals=np.array([[0, contig.length / 2]], dtype="int"),
             DFE=d,
         )
         model = stdpopsim.PiecewiseConstantSize(1000)
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
         engine = stdpopsim.get_engine("msprime")
         with pytest.raises(ValueError, match="but you are using .* msprime"):
             _ = engine.simulate(
@@ -657,6 +658,7 @@ class DFETestMixin:
         contig = stdpopsim.Contig.basic_contig(
             length=1_000_000,
             mutation_rate=1e-8,  # Ne=1e3 and length=1e6 so theta=40
+            ploidy=2,
         )
         contig.clear_dfes()
         contig.add_dfe(
@@ -665,7 +667,7 @@ class DFETestMixin:
         )
 
         model = stdpopsim.PiecewiseConstantSize(1000)
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             model, contig, samples, slim_scaling_factor=10, slim_burn_in=10, seed=42

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -366,6 +366,10 @@ class TestContig(object):
                     right=interval[1],
                 )
 
+    def test_basic_contig_is_diploid(self):
+        contig = stdpopsim.Contig.basic_contig(length=1000)
+        assert contig.ploidy == 2
+
 
 class TestGeneConversion(object):
     def test_mean_gene_conversion(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -327,7 +327,7 @@ class TestPopulationSampling:
         sample_populations = [i.population for i in test_samples]
         assert sample_populations == [0, 1]
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::stdpopsim.DeprecatedFeatureWarning")
     def test_deprecated_get_samples(self):
         base_mod = self.make_model()
         test_samples = base_mod.get_samples(2, 1)
@@ -335,7 +335,7 @@ class TestPopulationSampling:
         assert sum([ss.num_samples for ss in test_samples]) == 3
 
         # Check that deprecation warning is raised
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
             base_mod.get_samples(2, 1)
         # Check for error when prohibited sampling asked for
         with pytest.raises(ValueError):

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -198,7 +198,7 @@ class TestAPI:
             assert all(tree.num_roots == 1 for tree in ts.trees())
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::stdpopsim.DeprecatedFeatureWarning")
     @pytest.mark.filterwarnings(
         "ignore:.*model has mutation rate.*but this simulation used.*"
     )

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -40,7 +40,7 @@ class TestAPI:
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr1")
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
 
         for scaling_factor in (0, -1, -1e-6):
             with pytest.raises(ValueError):
@@ -62,6 +62,41 @@ class TestAPI:
                     dry_run=True,
                 )
 
+    def test_bad_samples(self):
+        engine = stdpopsim.get_engine("slim")
+        species = stdpopsim.get_species("HomSap")
+        contig = species.get_contig("chr1")
+        model = stdpopsim.PiecewiseConstantSize(species.population_size)
+        samples = [1, 2, ["foo"]]
+        with pytest.raises(ValueError, match="Samples must be a dict"):
+            engine.simulate(
+                demographic_model=model,
+                contig=contig,
+                samples=samples,
+                dry_run=True,
+            )
+        with pytest.raises(ValueError, match="Samples must be a dict"):
+            engine.recap_and_rescale(
+                ts=None,
+                demographic_model=model,
+                contig=contig,
+                samples=samples,
+            )
+        samples = [
+            msprime.SampleSet(
+                num_samples=2,
+                population=0,
+                ploidy=3,
+            )
+        ]
+        with pytest.raises(ValueError, match="Sample ploidy other than 1 or 2"):
+            engine.simulate(
+                demographic_model=model,
+                contig=contig,
+                samples=samples,
+                dry_run=True,
+            )
+
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     @pytest.mark.filterwarnings(
         "ignore:.*model has mutation rate.*but this simulation used.*"
@@ -72,7 +107,7 @@ class TestAPI:
         contig = species.get_contig("chr1")
 
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
         out, _ = capture_output(
             engine.simulate,
             demographic_model=model,
@@ -83,7 +118,15 @@ class TestAPI:
         assert "community.registerLateEvent" in out
 
         model = species.get_demographic_model("AncientEurasia_9K19")
-        samples = model.get_samples(10, 20, 30, 40, 50, 60, 70)
+        samples = {
+            "Mbuti": 5,
+            "LBK": 10,
+            "Sardinian": 15,
+            "Loschbour": 20,
+            "MA1": 25,
+            "Han": 30,
+            "UstIshim": 35,
+        }
         out, _ = capture_output(
             engine.simulate,
             demographic_model=model,
@@ -94,7 +137,7 @@ class TestAPI:
         assert "community.registerLateEvent" in out
 
         model = species.get_demographic_model("AmericanAdmixture_4B11")
-        samples = model.get_samples(10, 10, 10)
+        samples = {"AFR": 10, "EUR": 10, "ASIA": 10}
         out, _ = capture_output(
             engine.simulate,
             demographic_model=model,
@@ -110,7 +153,7 @@ class TestAPI:
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr1", genetic_map="HapMapII_GRCh37")
         model = stdpopsim.PiecewiseConstantSize(100)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
         engine.simulate(
             demographic_model=model,
             contig=contig,
@@ -124,7 +167,7 @@ class TestAPI:
         species = stdpopsim.get_species("AraTha")
         contig = species.get_contig("5", length_multiplier=0.001)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
         ts = engine.simulate(
             demographic_model=model,
             contig=contig,
@@ -141,7 +184,7 @@ class TestAPI:
         species = stdpopsim.get_species("AraTha")
         contig = species.get_contig("5", length_multiplier=0.001)
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
         for v in [0, 1, 2, 3]:
             ts = engine.simulate(
                 demographic_model=model,
@@ -155,6 +198,7 @@ class TestAPI:
             assert all(tree.num_roots == 1 for tree in ts.trees())
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.filterwarnings(
         "ignore:.*model has mutation rate.*but this simulation used.*"
     )
@@ -162,63 +206,65 @@ class TestAPI:
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")
         model = species.get_demographic_model("OutOfAfrica_3G09")
-        samples = model.get_samples(10, 10, 10)
-        for proportion, seed in zip((0, 1), (1234, 2345)):
-            contig = species.get_contig("chr22", length_multiplier=0.001)
-            # need selected mutations so that SLiM produces some
-            contig.add_dfe(
-                intervals=np.array([[0, contig.length / 2]], dtype="int"),
-                DFE=stdpopsim.DFE(
-                    id="test",
-                    description="test",
-                    long_description="test",
-                    mutation_types=[
-                        stdpopsim.MutationType(
-                            distribution_type="n",
-                            distribution_args=[0, 0.01],
-                        )
-                    ],
-                ),
-            )
-            if proportion:
-                extended_events = None
-            else:
-                extended_events = []
-            ts1 = engine.simulate(
-                demographic_model=model,
-                contig=contig,
-                samples=samples,
-                extended_events=extended_events,
-                slim_scaling_factor=10,
-                slim_burn_in=0,
-                seed=seed,
-            )
-            ts2_headless = engine.simulate(
-                demographic_model=model,
-                contig=contig,
-                samples=samples,
-                extended_events=extended_events,
-                slim_scaling_factor=10,
-                slim_burn_in=0,
-                seed=seed,
-                _recap_and_rescale=False,
-            )
-            ts2 = engine.recap_and_rescale(
-                ts2_headless,
-                demographic_model=model,
-                contig=contig,
-                samples=samples,
-                extended_events=extended_events,
-                slim_scaling_factor=10,
-                seed=seed,
-            )
+        samples_deprecated = model.get_samples(10, 10, 10)
+        samples_dict = {"YRI": 5, "CEU": 5, "CHB": 5}
+        for samples in [samples_deprecated, samples_dict]:
+            for proportion, seed in zip((0, 1), (1234, 2345)):
+                contig = species.get_contig("chr22", length_multiplier=0.001)
+                # need selected mutations so that SLiM produces some
+                contig.add_dfe(
+                    intervals=np.array([[0, contig.length / 2]], dtype="int"),
+                    DFE=stdpopsim.DFE(
+                        id="test",
+                        description="test",
+                        long_description="test",
+                        mutation_types=[
+                            stdpopsim.MutationType(
+                                distribution_type="n",
+                                distribution_args=[0, 0.01],
+                            )
+                        ],
+                    ),
+                )
+                if proportion:
+                    extended_events = None
+                else:
+                    extended_events = []
+                ts1 = engine.simulate(
+                    demographic_model=model,
+                    contig=contig,
+                    samples=samples,
+                    extended_events=extended_events,
+                    slim_scaling_factor=10,
+                    slim_burn_in=0,
+                    seed=seed,
+                )
+                ts2_headless = engine.simulate(
+                    demographic_model=model,
+                    contig=contig,
+                    samples=samples,
+                    extended_events=extended_events,
+                    slim_scaling_factor=10,
+                    slim_burn_in=0,
+                    seed=seed,
+                    _recap_and_rescale=False,
+                )
+                ts2 = engine.recap_and_rescale(
+                    ts2_headless,
+                    demographic_model=model,
+                    contig=contig,
+                    samples=samples,
+                    extended_events=extended_events,
+                    slim_scaling_factor=10,
+                    seed=seed,
+                )
 
-            tables1 = ts1.dump_tables()
-            tables2 = ts2.dump_tables()
+                tables1 = ts1.dump_tables()
+                tables2 = ts2.dump_tables()
 
-            assert tables1.nodes == tables2.nodes
-            assert tables1.edges == tables2.edges
-            assert tables1.mutations == tables2.mutations
+                assert tables1.nodes == tables2.nodes
+                assert tables1.edges == tables2.edges
+                assert tables1.mutations == tables2.mutations
 
     def test_assert_min_version(self):
         engine = stdpopsim.get_engine("slim")
@@ -239,21 +285,19 @@ class TestAPI:
 @pytest.mark.skipif(IS_WINDOWS, reason="SLiM not available on windows")
 class TestCLI:
     def docmd(self, _cmd):
-        cmd = (
-            f"-q -e slim --slim-burn-in 0 {_cmd} -l 0.001 -c chr1 -s 1234 10"
-        ).split()
+        cmd = (f"-q -e slim --slim-burn-in 0 {_cmd} -l 0.001 -c chr1 -s 1234").split()
         return capture_output(stdpopsim.cli.stdpopsim_main, cmd)
 
     def test_script_generation(self):
-        out, _ = self.docmd("--slim-script HomSap")
+        out, _ = self.docmd("--slim-script HomSap pop_0:5")
         assert "community.registerLateEvent" in out
 
         # msprime.MassMigration demographic events, with proportion<1.0
         # low level migration
-        out, _ = self.docmd("--slim-script HomSap -d AncientEurasia_9K19")
+        out, _ = self.docmd("--slim-script HomSap -d AncientEurasia_9K19 Mbuti:5")
         assert "community.registerLateEvent" in out
         # simultaneous mass migrations, with proportions summing to 1.0
-        out, _ = self.docmd("--slim-script HomSap -d AmericanAdmixture_4B11")
+        out, _ = self.docmd("--slim-script HomSap -d AmericanAdmixture_4B11 AFR:5")
         assert "community.registerLateEvent" in out
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
@@ -263,7 +307,8 @@ class TestCLI:
         slim_path = os.environ.get("SLIM", "slim")
         with tempfile.NamedTemporaryFile(mode="w") as f:
             self.docmd(
-                f"--slim-scaling-factor 20 --slim-path {slim_path} HomSap -o {f.name}"
+                f"--slim-scaling-factor 20 --slim-path {slim_path} HomSap "
+                f"pop_0:5 -o {f.name}"
             )
             ts = tskit.load(f.name)
         assert ts.num_samples == 10
@@ -275,7 +320,7 @@ class TestCLI:
             os.environ["SLIM"] = saved_slim_env
 
         with tempfile.NamedTemporaryFile(mode="w") as f:
-            self.docmd(f"--slim-scaling-factor 20 HomSap -o {f.name}")
+            self.docmd(f"--slim-scaling-factor 20 HomSap pop_0:5 -o {f.name}")
             ts = tskit.load(f.name)
         assert ts.num_samples == 10
 
@@ -284,7 +329,7 @@ class TestCLI:
             cmd = (
                 "-q -e slim --slim-scaling-factor 20 --slim-burn-in 0 "
                 f"HomSap -o {f.name} -l 0.001 -c chr1 -s 1234 "
-                "-d OutOfAfrica_3G09 0 0 8"
+                "-d OutOfAfrica_3G09 YRI:0 CEU:0 CHB:4"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -307,7 +352,8 @@ class TestCLI:
         with tempfile.NamedTemporaryFile(mode="w") as f:
             cmd = (
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
-                f"HomSap -c chr22 -l 0.02 -o {f.name} --dfe Gamma_K17 -s 24 10"
+                f"HomSap -c chr22 -l 0.02 -o {f.name} --dfe Gamma_K17 -s 24 "
+                f"pop_0:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -319,7 +365,7 @@ class TestCLI:
             cmd = (
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
                 f"HomSap -c chr22 -l 0.01 -o {f.name} --dfe Gamma_K17 -s 984 "
-                f"--dfe-interval 1000,100000 10"
+                f"--dfe-interval 1000,100000 pop_0:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -333,7 +379,7 @@ class TestCLI:
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
                 f"HomSap -c chr22 -l 0.01 -o {f.name} "
                 "-d OutOfAfrica_3G09 --dfe Gamma_K17 -s 148 "
-                "--dfe-interval 1000,100000 10"
+                "--dfe-interval 1000,100000 YRI:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -345,7 +391,7 @@ class TestCLI:
             cmd = (
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
                 f"HomSap -c chr22 -o {f.name} --dfe Gamma_K17 -s 913 "
-                "--dfe-annotation ensembl_havana_104_CDS 10"
+                "--dfe-annotation ensembl_havana_104_CDS pop_0:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -366,7 +412,7 @@ class TestCLI:
         cmd = (
             f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
             f"HomSap -c chr22 -s 1234 -l 0.01 -o {fname} --dfe Gamma_K17 -s 183 "
-            f"--dfe-bed-file {tmp_path / 'ex.bed'} 10"
+            f"--dfe-bed-file {tmp_path / 'ex.bed'} pop_0:5"
         ).split()
         capture_output(stdpopsim.cli.stdpopsim_main, cmd)
         ts = tskit.load(fname)
@@ -380,7 +426,7 @@ class TestCLI:
             cmd = (
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
                 f"HomSap -c chr22 --left {left} --right {right} -o {f.name} "
-                f"--dfe Gamma_K17 -s 24 10"
+                f"--dfe Gamma_K17 -s 24 pop_0:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -397,7 +443,8 @@ class TestCLI:
             cmd = (
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
                 f"HomSap -c chr22 --left {left} --right {right} -o {f.name} "
-                f"--dfe Gamma_K17 -s 984 --dfe-interval {dfe_left},{dfe_right} 10"
+                f"--dfe Gamma_K17 -s 984 --dfe-interval {dfe_left},{dfe_right} "
+                f"pop_0:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -420,7 +467,8 @@ class TestCLI:
         cmd = (
             f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
             f"HomSap -c chr22 -s 1234 --left {left} --right {right} -o {fname} "
-            f"--dfe Gamma_K17 -s 183 --dfe-bed-file {tmp_path / 'ex.bed'} 10"
+            f"--dfe Gamma_K17 -s 183 --dfe-bed-file {tmp_path / 'ex.bed'} "
+            f"pop_0:5"
         ).split()
         capture_output(stdpopsim.cli.stdpopsim_main, cmd)
         ts = tskit.load(fname)
@@ -435,7 +483,8 @@ class TestCLI:
             cmd = (
                 f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
                 f"HomSap -c chr22 --left {left} --right {right} -o {f.name} "
-                f"--dfe Gamma_K17 -s 913 --dfe-annotation ensembl_havana_104_CDS 10"
+                f"--dfe Gamma_K17 -s 913 --dfe-annotation ensembl_havana_104_CDS "
+                f"pop_0:5"
             ).split()
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
             ts = tskit.load(f.name)
@@ -457,25 +506,25 @@ class TestCLI:
         base_cmd = (
             f"-q -e slim --slim-scaling-factor 20 --slim-path {slim_path} "
             f"HomSap -c chr22 -s 1234 -l 0.01 -o {fname} "
-            "-d OutOfAfrica_3G09 "
+            f"-d OutOfAfrica_3G09 YRI:5 "
         )
 
         # Intervals but no DFE
-        cmd = (base_cmd + "--dfe-interval 1000,100000 10").split()
+        cmd = (base_cmd + "--dfe-interval 1000,100000").split()
         with pytest.raises(
             SystemExit, match="interval has been assigned " "without a DFE"
         ):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
 
         # Annotation but no DFE
-        cmd = (base_cmd + "--dfe-annotation ensembl_havana_104_exons 10").split()
+        cmd = (base_cmd + "--dfe-annotation ensembl_havana_104_exons").split()
         with pytest.raises(
             SystemExit, match="A DFE annotation has been assigned without a DFE."
         ):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
 
         # bed file but no DFE
-        cmd = (base_cmd + f"--dfe-bed-file {tmp_path / 'ex.bed'} 10").split()
+        cmd = (base_cmd + f"--dfe-bed-file {tmp_path / 'ex.bed'}").split()
         with pytest.raises(
             SystemExit, match="A DFE bed file has been assigned without a DFE."
         ):
@@ -485,7 +534,7 @@ class TestCLI:
         cmd = (
             base_cmd + "--dfe Gamma_K17 "
             "--dfe-interval 999,1000 "
-            "--dfe-annotation ensembl_havana_104_exons 10"
+            "--dfe-annotation ensembl_havana_104_exons"
         ).split()
         with pytest.raises(
             SystemExit, match="A DFE annotation and a DFE interval have been"
@@ -496,7 +545,7 @@ class TestCLI:
         cmd = (
             base_cmd + "--dfe Gamma_K17 "
             "--dfe-interval 999,1000 "
-            f"--dfe-bed-file {tmp_path / 'ex.bed'} 10"
+            f"--dfe-bed-file {tmp_path / 'ex.bed'}"
         ).split()
         with pytest.raises(
             SystemExit, match="A DFE bed file and a DFE interval have been"
@@ -507,7 +556,7 @@ class TestCLI:
         cmd = (
             base_cmd + "--dfe Gamma_K17 "
             f"--dfe-bed-file {tmp_path / 'ex.bed'} "
-            "--dfe-annotation ensembl_havana_104_exons 10"
+            "--dfe-annotation ensembl_havana_104_exons"
         ).split()
         with pytest.raises(SystemExit, match="A DFE bed file and a DFE annotation"):
             capture_output(stdpopsim.cli.stdpopsim_main, cmd)
@@ -523,12 +572,12 @@ class TestCLI:
             proc.stdout = io.StringIO()
             proc.stderr = io.StringIO()
             with tempfile.NamedTemporaryFile(mode="w") as f:
-                self.docmd(f"HomSap --dry-run -o {f.name}")
+                self.docmd(f"HomSap pop_0:5 --dry-run -o {f.name}")
         mocked_popen.assert_called_once()
         slim_path = os.environ.get("SLIM", "slim")
         assert slim_path in mocked_popen.call_args[0][0]
         with tempfile.NamedTemporaryFile(mode="w") as f:
-            self.docmd(f"HomSap --dry-run -o {f.name}")
+            self.docmd(f"HomSap pop_0:5 --dry-run -o {f.name}")
             assert os.stat(f.name).st_size == 0
 
     def test_bad_slim_environ_var(self):
@@ -536,7 +585,7 @@ class TestCLI:
 
         os.environ["SLIM"] = "nonexistent"
         with pytest.raises(FileNotFoundError):
-            self.docmd("HomSap")
+            self.docmd("HomSap pop_0:5")
 
         if saved_slim_env is None:
             del os.environ["SLIM"]
@@ -547,7 +596,7 @@ class TestCLI:
         saved_slim_env = os.environ.get("SLIM")
 
         with pytest.raises(FileNotFoundError):
-            self.docmd("--slim-path nonexistent HomSap")
+            self.docmd("--slim-path nonexistent HomSap pop_0:5")
 
         if saved_slim_env is None:
             del os.environ["SLIM"]
@@ -561,10 +610,16 @@ class TestWarningsAndErrors:
     Checks that warning messages are printed when appropriate.
     """
 
-    def triplet(self):
+    def triplet_diploid(self):
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr22", length_multiplier=0.001)
+        return engine, species, contig
+
+    def triplet_haploid(self):
+        engine = stdpopsim.get_engine("slim")
+        species = stdpopsim.get_species("EscCol")
+        contig = species.get_contig("Chromosome", length_multiplier=0.001)
         return engine, species, contig
 
     @pytest.mark.filterwarnings("error::stdpopsim.SLiMOddSampleWarning")
@@ -572,9 +627,9 @@ class TestWarningsAndErrors:
         "ignore:.*model has mutation rate.*but this simulation used.*"
     )
     def test_no_odd_sample_warning_for_even_samples(self):
-        engine, species, contig = self.triplet()
-        model = species.get_demographic_model("OutOfAfrica_2T12")
-        samples = model.get_samples(4, 6)
+        engine, species, contig = self.triplet_haploid()
+        model = stdpopsim.PiecewiseConstantSize(100)
+        samples = {"pop_0": 4}
         engine.simulate(
             demographic_model=model,
             contig=contig,
@@ -583,9 +638,9 @@ class TestWarningsAndErrors:
         )
 
     def test_odd_sample_warning(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_haploid()
         model = stdpopsim.PiecewiseConstantSize(100)
-        samples = model.get_samples(5)
+        samples = {"pop_0": 5}
         with pytest.warns(stdpopsim.SLiMOddSampleWarning):
             engine.simulate(
                 demographic_model=model,
@@ -594,8 +649,8 @@ class TestWarningsAndErrors:
                 dry_run=True,
             )
 
-        model = species.get_demographic_model("OutOfAfrica_2T12")
-        samples = model.get_samples(2, 5)
+        model = stdpopsim.IsolationWithMigration(100, 100, 100, 100, 0.1, 0.1)
+        samples = {"pop1": 2, "pop2": 5}
         with pytest.warns(stdpopsim.SLiMOddSampleWarning):
             engine.simulate(
                 demographic_model=model,
@@ -606,9 +661,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     def test_bad_population_size_addSubPop_warning(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(100)
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
 
         with pytest.warns(
             stdpopsim.UnspecifiedSLiMWarning, match="has only.*individuals alive"
@@ -623,9 +678,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     def test_no_populations_in_generation1_error(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(100)
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
 
         with pytest.raises(stdpopsim.SLiMException):
             engine.simulate(
@@ -638,11 +693,11 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     def test_bad_population_size_addSubpopSplit_warning(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.IsolationWithMigration(
             NA=1000, N1=100, N2=1000, T=1000, M12=0, M21=0
         )
-        samples = model.get_samples(2)
+        samples = {"pop1": 1}
         with pytest.warns(
             stdpopsim.UnspecifiedSLiMWarning, match="has only.*individuals alive"
         ):
@@ -657,11 +712,11 @@ class TestWarningsAndErrors:
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     @pytest.mark.filterwarnings("ignore:.*has only.*individuals alive")
     def test_bad_population_size_addSubpopSplit_error(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.IsolationWithMigration(
             NA=1000, N1=100, N2=1000, T=1000, M12=0, M21=0
         )
-        samples = model.get_samples(2)
+        samples = {"pop1": 1}
         with pytest.raises(stdpopsim.SLiMException):
             engine.simulate(
                 demographic_model=model,
@@ -673,9 +728,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     def test_bad_population_size_setSubpopulationSize_warning(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(100, (1000, 1000))
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
         with pytest.warns(
             stdpopsim.UnspecifiedSLiMWarning, match="has only.*individuals alive"
         ):
@@ -690,9 +745,9 @@ class TestWarningsAndErrors:
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     @pytest.mark.filterwarnings("ignore:.*has only.*individuals alive")
     def test_bad_population_size_setSubpopulationSize_error(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(100, (1000, 1000))
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
         with pytest.raises(stdpopsim.SLiMException):
             engine.simulate(
                 demographic_model=model,
@@ -704,9 +759,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     def test_sample_size_too_big_error(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(1000)
-        samples = model.get_samples(300)
+        samples = {"pop_0": 150}
 
         with pytest.raises(stdpopsim.SLiMException):
             engine.simulate(
@@ -723,18 +778,18 @@ class TestWarningsAndErrors:
         Used for testing that growth rates are handled appropriately.
         """
         r = math.log(N0 / N1) / T
-        pop0 = stdpopsim.models.Population(id="pop0", description="")
+        pop_0 = stdpopsim.models.Population(id="pop_0", description="")
         return stdpopsim.DemographicModel(
             id="exp_decline",
             description="exp_decline",
             long_description="exp_decline",
-            populations=[pop0],
+            populations=[pop_0],
             generation_time=1,
             population_configurations=[
                 msprime.PopulationConfiguration(
                     initial_size=N0,
                     growth_rate=r,
-                    metadata=pop0.asdict(),
+                    metadata=pop_0.asdict(),
                 )
             ],
             demographic_events=[
@@ -746,9 +801,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     def test_bad_population_size_exp_decline_warning(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = self.exp_decline()
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
         with pytest.warns(
             stdpopsim.UnspecifiedSLiMWarning, match="has only.*individuals alive"
         ):
@@ -763,9 +818,9 @@ class TestWarningsAndErrors:
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     @pytest.mark.filterwarnings("ignore:.*has only.*individuals alive")
     def test_bad_population_size_exp_decline_error(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = self.exp_decline()
-        samples = model.get_samples(2)
+        samples = {"pop_0": 1}
         with pytest.raises(stdpopsim.SLiMException):
             engine.simulate(
                 demographic_model=model,
@@ -778,9 +833,9 @@ class TestWarningsAndErrors:
     @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
     @pytest.mark.filterwarnings("ignore:.*has only.*individuals alive")
     def test_sample_size_too_big_exp_decline_error(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = self.exp_decline()
-        samples = model.get_samples(30)
+        samples = {"pop_0": 15}
 
         with pytest.raises(stdpopsim.SLiMException):
             engine.simulate(
@@ -793,9 +848,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.filterwarnings("error::stdpopsim.SLiMScalingFactorWarning")
     def test_no_warning_when_not_scaling(self):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(10000)
-        samples = model.get_samples(100)
+        samples = {"pop_0": 50}
         engine.simulate(
             demographic_model=model,
             contig=contig,
@@ -821,9 +876,9 @@ class TestWarningsAndErrors:
 
     @pytest.mark.parametrize("scaling_factor", [2, 4.3])
     def test_warning_when_scaling(self, scaling_factor):
-        engine, species, contig = self.triplet()
+        engine, species, contig = self.triplet_diploid()
         model = stdpopsim.PiecewiseConstantSize(10000)
-        samples = model.get_samples(100)
+        samples = {"pop_0": 50}
         with pytest.warns(stdpopsim.SLiMScalingFactorWarning):
             engine.simulate(
                 demographic_model=model,
@@ -872,7 +927,7 @@ class PiecewiseConstantSizeMixin(object):
     T_mut = 300  # introduce a mutation at this generation
     model = stdpopsim.PiecewiseConstantSize(N0, (T, N1))
     model.generation_time = 1
-    samples = model.get_samples(100)
+    samples = {"pop_0": 50}
     contig = get_test_contig()
     mut_id = "mut"
     contig.add_single_site(
@@ -928,7 +983,7 @@ class TestRecombinationMap(PiecewiseConstantSizeMixin):
         species = stdpopsim.get_species("HomSap")
         contig = species.get_contig("chr1", genetic_map="HapMapII_GRCh38")
         model = stdpopsim.PiecewiseConstantSize(100)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
         ts = engine.simulate(
             demographic_model=model,
             contig=contig,
@@ -950,7 +1005,7 @@ class TestRecombinationMap(PiecewiseConstantSizeMixin):
             rate=np.array([0.0, 0.1, 0.0]),
         )
         model = stdpopsim.PiecewiseConstantSize(100)
-        samples = model.get_samples(10)
+        samples = {"pop_0": 5}
         ts = engine.simulate(
             demographic_model=model,
             contig=contig,
@@ -2188,10 +2243,10 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
     @staticmethod
     def _get_island_model(Ne=1000, migration_rate=0.01):
         model = msprime.Demography()
-        model.add_population(initial_size=Ne, name="pop0")
-        model.add_population(initial_size=Ne, name="pop1")
-        model.set_migration_rate(source="pop0", dest="pop1", rate=migration_rate)
-        model.set_migration_rate(source="pop1", dest="pop0", rate=migration_rate)
+        model.add_population(initial_size=Ne, name="pop_0")
+        model.add_population(initial_size=Ne, name="pop_1")
+        model.set_migration_rate(source="pop_0", dest="pop_1", rate=migration_rate)
+        model.set_migration_rate(source="pop_1", dest="pop_0", rate=migration_rate)
         return stdpopsim.DemographicModel(
             id="🏝️",
             description="island model",
@@ -2432,7 +2487,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
         )
         extended_events = stdpopsim.ext.selective_sweep(
             single_site_id=locus_id,
-            population="pop1",
+            population="pop_1",
             mutation_generation_ago=mutation_generation_ago,
             start_generation_ago=start_generation_ago,
             end_generation_ago=end_generation_ago,
@@ -2487,7 +2542,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
         )
         extended_events = stdpopsim.ext.selective_sweep(
             single_site_id=locus_id,
-            population="pop1",
+            population="pop_1",
             mutation_generation_ago=mutation_generation_ago,
             start_generation_ago=start_generation_ago,
             end_generation_ago=end_generation_ago,
@@ -2531,7 +2586,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
         coords = [100, contig.length - 100]
         start_generation_agos = [mutation_generation_ago, mutation_generation_ago // 2]
         end_generation_agos = [0, 0]
-        pop_ids = ["pop0", "pop1"]
+        pop_ids = ["pop_0", "pop_1"]
         extended_events = []
         for locus_id, coord, start_generation_ago, end_generation_ago, pop in zip(
             ids, coords, start_generation_agos, end_generation_agos, pop_ids
@@ -2596,7 +2651,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
         )
         extended_events = stdpopsim.ext.selective_sweep(
             single_site_id=locus_id,
-            population="pop1",
+            population="pop_1",
             mutation_generation_ago=mutation_generation_ago,
             selection_coeff=100.0,
             globally_adaptive=False,

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -150,6 +150,7 @@ class SpeciesTestBase:
     def test_population_size_defined(self):
         assert self.species.population_size > 0
 
+    @pytest.mark.filterwarnings("ignore::stdpopsim.NonAutosomalWarning")
     def test_default_gc(self):
         for chrom in self.species.genome.chromosomes:
             contig = self.species.get_contig(chrom.id)
@@ -174,6 +175,14 @@ class SpeciesTestBase:
                     contig = self.species.get_contig(
                         chrom.id, use_species_gene_conversion=True
                     )
+
+    @pytest.mark.filterwarnings("ignore::stdpopsim.NonAutosomalWarning")
+    def test_default_ploidy(self):
+        for chrom in self.species.genome.chromosomes:
+            contig = self.species.get_contig(chrom.id)
+            assert contig.ploidy is not None
+        contig = self.species.get_contig(length=1000)
+        assert contig.ploidy == self.species.ploidy
 
 
 class GenomeTestBase:


### PR DESCRIPTION
- `engine.simulate(samples=...)` now takes a dict of the form `{population : num_individuals}`. `engine.simulate` uses a new function `DemographicModel.get_sample_sets` (that isn't part of the public API) to combine species ploidy with the demographic model.

- The corresponding number of haploid samples (`tree_sequence.num_samples`) is `num_individuals * species.ploidy`

- The CLI for sample specification is now `population_name:num_samples`, like `HomSap -c chr1 -d OutOfAfrica_3G09 YRI:10 CEU:2` (same as for msprime)

- The old way of specifying samples still works (via `DemographicModel.get_samples` in python API, and via positional arguments in the CLI), but throws a `DeprecationWarning`. I opted not to rename the `samples=...` argument to `Engine.simulate` to keep the API less cluttered -- so it now takes either a dict (new behavior) or a list of `msprime.SampleSet` (old behavior).

- Fixes #1282. 

- Fixes #1111 (by adding ploidy as an attribute of species) but doesn't alter the SLiM engine to do anything different for haploids (e.g. it still uses diploid recombination model, gives warning if odd number of samples is requested, etc).