### PR TITLE
Rescale haploid population size in SLiM engine

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -575,6 +575,7 @@ with a brief discussion of possible courses of action to take when components ha
 
 4. The **effective population size** should represent the historical average effective population size,
    and should ideally produce simulated data that matches the average observed genetic diversity in that species.
+   Population size is defined as the number of individuals, regardless of ploidy.
    However, this will often not capture features of genetic variation that are caused by recent changes in population size and the presence of population structure.
    To capture those, one should also provide a demographic model (or multiple models) for the species
    (see `Adding a new demographic model`_).
@@ -1171,6 +1172,7 @@ The final three attributes
 describe the inferred demographic history that you wish to code.
 This history consists of ancestral population size changes,
 migration rates, split times, and admixture events.
+Note that population size is defined as the number of individuals, regardless of ploidy.
 These attributes should be coded using the standard format of ``msprime``.
 If this is your first time specifying a demographic model using ``msprime``,
 then we highly recommend that you take some time to read through its

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -1761,6 +1761,9 @@ class _SLiMEngine(stdpopsim.Engine):
             migration_matrix=recap_epoch.migration_matrix,
         )
 
+        # `recap_epoch` contains population sizes from the demographic model,
+        # that are the number of individuals regardless of ploidy. Thus,
+        # ploidy must be set here, as is done in `_MsprimeEngine.simulate`
         ts = msprime.sim_ancestry(
             initial_state=ts,
             demography=demography,

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -1842,26 +1842,7 @@ class _SLiMEngine(stdpopsim.Engine):
 
         # If haploid, rebuild individual table so each sample is an individual
         if contig.ploidy == 1:
-            tables = ts.dump_tables()
-            node_indiv = tables.nodes.individual
-            haploid_indiv = tskit.IndividualTable()
-            haploid_indiv.metadata_schema = tables.individuals.metadata_schema
-            for new_idx, node in enumerate(ts.samples()):
-                old_idx = node_indiv[node]
-                haploid_indiv.add_row(
-                    flags=tables.individuals[old_idx].flags,
-                    location=tables.individuals[old_idx].location,
-                    parents=tables.individuals[old_idx].parents,
-                    metadata=tables.individuals[old_idx].metadata,
-                )
-                assert (
-                    haploid_indiv[new_idx].metadata
-                    == tables.individuals[old_idx].metadata
-                )
-                node_indiv[node] = new_idx
-            tables.nodes.individual = node_indiv
-            tables.individuals.replace_with(haploid_indiv)
-            ts = tables.tree_sequence()
+            ts = stdpopsim.utils.haploidize_individuals(ts)
 
         return ts
 

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -1765,6 +1765,7 @@ class _SLiMEngine(stdpopsim.Engine):
             initial_state=ts,
             demography=demography,
             recombination_rate=contig.recombination_map,
+            ploidy=contig.ploidy,
             random_seed=s0,
         )
         ts = self._simplify_remembered(ts)

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -900,7 +900,9 @@ def slim_makescript(
     growth_rates = np.empty(shape=(dd.num_populations, len(epochs)), dtype=float)
     for j, epoch in enumerate(epochs):
         for i, pop in enumerate(epoch.populations):
-            N[i, j] = int(pop.end_size)
+            # SLiM simulates a diploid population, so rescale population size
+            # depending on contig ploidy.
+            N[i, j] = int(pop.end_size * contig.ploidy / 2)
             growth_rates[i, j] = pop.growth_rate
 
     admixture_pulses = []

--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -308,3 +308,22 @@ def parse_population_sample_pairs(pop_sample_pairs):
             "Sample specification must be in the form "
             "<population_name:number_of_samples>"
         )
+
+
+def haploidize_individuals(ts):
+    """
+    Rebuild IndividualsTable of tree sequence such that each individual is
+    referenced by only one sample, by duplicating individuals that are
+    referenced by multiple samples in the original tree sequence.
+    """
+    tables = ts.dump_tables()
+    old_inds = tables.individuals.copy()
+    tables.individuals.clear()
+    # Make sure we don't refer to any individuals that are not samples
+    node_indiv = np.zeros_like(ts.nodes_individual) - 1
+    for new_idx, node in enumerate(ts.samples()):
+        old_idx = ts.nodes_individual[node]
+        tables.individuals.append(old_inds[old_idx])
+        node_indiv[node] = new_idx
+    tables.nodes.individual = node_indiv
+    return tables.tree_sequence()

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -2972,3 +2972,18 @@ class TestPloidy:
             assert ts.num_samples == 2 * ploidy
             individual = ts.tables.nodes.individual
             assert len(np.unique(individual[: ts.num_samples])) == ts.num_individuals
+
+    @pytest.mark.filterwarnings("ignore::stdpopsim.SLiMScalingFactorWarning")
+    def test_haploidize_individuals(self):
+        N = 100
+        model = stdpopsim.PiecewiseConstantSize(N)
+        engine = stdpopsim.get_engine("slim")
+        contig = stdpopsim.Contig.basic_contig(length=1000, ploidy=2)
+        ts = engine.simulate(model, contig, samples={"pop_0": 3})
+        ts_hap = stdpopsim.utils.haploidize_individuals(ts)
+        assert ts_hap.num_individuals == ts.num_individuals * 2
+        for i, j in zip(ts.samples(), ts_hap.samples()):
+            assert i == j
+            ind_i = ts.nodes_individual[i]
+            ind_j = ts_hap.nodes_individual[j]
+            assert ts.tables.individuals[ind_i] == ts_hap.tables.individuals[ind_j]


### PR DESCRIPTION
Fixes #1406.

Should probably add a test for equivalence between msprime and SLiM engines when `contig.ploidy != 2`.