### PR TITLE
Bump codecov to 2.1.13

### DIFF
--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -1,4 +1,4 @@
-codecov==2.1.12
+codecov==2.1.13
 coverage==6.3.3
 flake8==5.0.4
 pytest==7.2.1


### PR DESCRIPTION
codecov is [back](https://about.codecov.io/blog/message-regarding-the-pypi-package/) on pypi -- though I'm not clear if it even needs to be in requirements.txt at all.