### PR TITLE
add uniform DFE (closes #1481)

### DIFF
--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -23,6 +23,7 @@ class MutationType(object):
     - ``g``: gamma, two parameters (mean, shape)
     - ``n``: normal, two parameters (mean, SD)
     - ``w``: Weibull, two parameters (scale, shape)
+    - ``u``: Uniform, two parameters (min, max)
     - ``lp``: positive logNormal, two parameters (mean and sd on log scale; see rlnorm)
     - ``ln``: negative logNormal, two parameters (mean and sd on log scale; see rlnorm)
 
@@ -142,6 +143,19 @@ class MutationType(object):
             self.distribution_args = [
                 f"return {sign}rlnorm(1, {logmean} + log(Q), {logsd});"
             ]
+            self.distribution_type = "s"
+        elif self.distribution_type == "u":
+            # Uniform
+            if (
+                len(self.distribution_args) != 2
+                or self.distribution_args[0] > self.distribution_args[1]
+            ):
+                raise ValueError(
+                    "Uniformly-distributed sel. coefs. (distribution_type='u') "
+                    "use a (min, max) parameterisation, with min <= max."
+                )
+            umin, umax = self.distribution_args
+            self.distribution_args = [f"return runif(1, Q * {umin}, Q * {umax});"]
             self.distribution_type = "s"
         else:
             raise ValueError(

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -32,9 +32,9 @@ class TestCreateMutationType:
             "n": ([0.5, 1], [0, 1]),
             "ln": ([0.5, 1], []),
             "lp": ([0.5, 1], []),
+            "u": ([-0.5, 1], []),
         }
         for t in mut_params:
-            print(f"{t}\t{mut_params[t]}")
             if t == "f":
                 mt = dfe.MutationType(
                     distribution_type=t,
@@ -157,6 +157,14 @@ class TestCreateMutationType:
                 distribution_args=[1, -2],
             )
 
+        # Uniformly-distributed selection coefficients
+        for bad_args in ([0], [1, 2, 3], [3, -2]):
+            with pytest.raises(ValueError, match="use a .min, max"):
+                dfe.MutationType(
+                    distribution_type="u",
+                    distribution_args=bad_args,
+                )
+
         # Lognormally-distributed selection coefficients
         for dt in ["lp", "ln"]:
             with pytest.raises(
@@ -204,13 +212,14 @@ class TestCreateMutationType:
             "e": ([0.1], [10], [5000], [0]),
             "n": ([-0.1, 0.2], [0.1, 0.1], [50, 50]),
             "w": ([0.1, 0.2], [0.1, 0.1], [50, 50]),
+            "u": ([0.1, 0.2], [0.1, 0.1], [-5, 50]),
             "lp": ([-0.1, 0.2], [0.1, 0.1], [50, 50]),
             "ln": ([-0.1, 0.2], [0.1, 0.1], [50, 50]),
         }
         for t in mut_params:
             for p in mut_params[t]:
                 mt = dfe.MutationType(distribution_type=t, distribution_args=p)
-                if t in ("lp", "ln"):
+                if t in ("lp", "ln", "u"):
                     assert mt.distribution_type == "s"
                 else:
                     assert mt.distribution_type == t
@@ -225,6 +234,7 @@ class TestCreateMutationType:
             "e": ([], [0, 1], [0.1, 0.4, 0.5], [np.inf]),
             "n": ([], [0.1, -1], [0.1, 0.4, 0.5], [0.1], [0.3, np.inf]),
             "w": ([], [-0.1, 1], [0.1, -1], [0.1, 0.4, 0.5], [0.1], [np.inf, 2.3]),
+            "u": ([], [-0.1, -0.5], [0.1, 0.4, 0.5], [0.1], [2.3, np.inf]),
             "lp": ([], [0.1, -1], [0.1, 0.4, 0.5], [0.1], [0.1, np.inf]),
             "ln": ([], [0.1, -1], [0.1, 0.4, 0.5], [0.1], [0.1, np.inf]),
         }


### PR DESCRIPTION
This just adds the Uniform DFE class. In #1481 it was raised whether we also need "log uniform", that we'd do with something like
```
exp(runif(1, logmin, logmax))
```
... but we have no use cases for it, I think, so I'm not adding that.