### PR TITLE
h-s relationship (closes #1488)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: find conda
         id: find-conda
         run: |
-          echo "::set-output name=CONDA::$CONDA"
+          echo "name=CONDA::$CONDA" >> $GITHUB_OUTPUT
 
       - name: fix conda permissions
         if: runner.os == 'macOS'
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increase this to reset the cache if the key hasn't changed.
-          CACHE_NUM: 2
+          CACHE_NUM: 3
         with:
           path: |
             ${{ steps.find-conda.outputs.CONDA }}/envs/${{ env.CONDA_ENV_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increase this to reset the cache if the key hasn't changed.
-          CACHE_NUM: 3
+          CACHE_NUM: 4
         with:
           path: |
             ${{ steps.find-conda.outputs.CONDA }}/envs/${{ env.CONDA_ENV_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-latest]
-        python: [3.7, "3.10"]
+        python: [3.8, "3.10"]
     env:
       CONDA_ENV_NAME: stdpopsim
       OS: ${{ matrix.os }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 [0.2.1] - 2023-XX-XX
 --------------------
 
+**Breaking changes**:
+
+- To add the possibility for a relationship between dominance and selection
+    coefficient, now each stdpopsim MutationType might have more than one
+    underlying SLiM mutation type; so, where this is recorded in top-level
+    metadata (under `ts.metadata["stdpopsim"]["DFEs"]`) is now a list
+    instead of a single value. This will not affect anyone who is not
+    parsing the metadata related to DFEs.
+
+**New features**:
+
+- *Relationship between dominance and selection coefficient:*
+    Added the `dominance_coeff_list` argument to `MutationType`, allowing
+    for DFEs with a discretized relationship between h and s.
+    (:user:`petrelharp`, :pr:`1498`)
+
 **New species**:
 
 - Mus musculus (:user:`peterdfields`, :pr:`1437`).

--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -1,10 +1,10 @@
 coverage==6.3.3
 flake8==5.0.4
-pytest==7.2.1
-pytest-cov==4.0.0
-pytest-xdist==3.2.0
+pytest==7.3.2
+pytest-cov==4.1.0
+pytest-xdist==3.3.1
 setuptools-scm==7.1.0
-sphinx==4.3.2
+sphinx==5.0.2
 sphinx-argparse==0.4.0
 sphinx-issues==3.0.1
 sphinx_rtd_theme==1.2.0
@@ -18,7 +18,7 @@ numpy==1.21.5; python_version=='3.7'
 numpy==1.22.3; python_version>='3.8'
 scipy; python_version=='3.7'
 scipy==1.10.1; python_version>='3.8'
-scikit-allel==1.3.5
+scikit-allel==1.3.6
 biopython==1.80
 demes==0.2.2
 demesdraw==0.3.1

--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -14,10 +14,8 @@ attrs==21.4.0
 appdirs==1.4.4
 humanize==4.6.0
 pyslim==1.0.1
-numpy==1.21.5; python_version=='3.7'
-numpy==1.22.3; python_version>='3.8'
-scipy; python_version=='3.7'
-scipy==1.10.1; python_version>='3.8'
+numpy==1.22.3
+scipy==1.10.1
 scikit-allel==1.3.6
 biopython==1.80
 demes==0.2.2

--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -37,16 +37,18 @@ class MutationType(object):
     exponential and gamma, a negative mean can be provided, obtaining always
     negative values.
 
-    Instead of a single dominance coefficient, a discretized relationship
-    between dominance and selection coefficient can be implemented:
-    if dominance_coeff_list is provided, then there is a mutations with selection
-    coefficient s with dominance_coeff_breaks[k-1] <= s <= dominance_coeff_breaks[k] will
-    have dominance coefficient dominance_coeff[k]. In other words, the first entry of
-    dominance_coeff_list applies to any mutations with selection coefficient below the
-    first entry of dominance_coeff_breaks; the second entry of dominance_coeff_list
-    applies to mutations with selection coefficient between the first and second entries
-    of dominance_coeff_breaks, and so forth. The list of breaks must therefore be of
-    length one less than the list of dominance coefficients.
+    Instead of a single dominance coefficient (which would be specified with
+    `dominance_coeff`), a discretized relationship between dominance and
+    selection coefficient can be implemented: if dominance_coeff_list is
+    provided, mutations with selection coefficient s for which
+    dominance_coeff_breaks[k-1] <= s <= dominance_coeff_breaks[k] will have
+    dominance coefficient dominance_coeff[k]. In other words, the first entry
+    of dominance_coeff_list applies to any mutations with selection coefficient
+    below the first entry of dominance_coeff_breaks; the second entry of
+    dominance_coeff_list applies to mutations with selection coefficient
+    between the first and second entries of dominance_coeff_breaks, and so
+    forth. The list of breaks must therefore be of length one less than the
+    list of dominance coefficients.
 
     :ivar distribution_type: A one-letter abbreviation for the distribution of
         fitness effects that each new mutation of this type draws from (see below).

--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -40,7 +40,7 @@ class MutationType(object):
     Instead of a single dominance coefficient, a discretized relationship
     between dominance and selection coefficient can be implemented:
     if dominance_coeff_list is provided, then there is a mutations with selection
-    coefficient s with dominance_coeff_breaks[k-] <= s <= dominance_coeff_breaks[k] will
+    coefficient s with dominance_coeff_breaks[k-1] <= s <= dominance_coeff_breaks[k] will
     have dominance coefficient dominance_coeff[k]. In other words, the first entry of
     dominance_coeff_list applies to any mutations with selection coefficient below the
     first entry of dominance_coeff_breaks; the second entry of dominance_coeff_list

--- a/stdpopsim/dfe.py
+++ b/stdpopsim/dfe.py
@@ -42,11 +42,11 @@ class MutationType(object):
     if dominance_coeff_list is provided, then there is a mutations with selection
     coefficient s with dominance_coeff_breaks[k-] <= s <= dominance_coeff_breaks[k] will
     have dominance coefficient dominance_coeff[k]. In other words, the first entry of
-    dominance_coeff_list applies to any mutations with selection coefficient below the first
-    entry of dominance_coeff_breaks; the second entry of dominance_coeff_list applies to
-    mutations with selection coefficient between the first and second entries of
-    dominance_coeff_breaks, and so forth. The list of breaks must therefore be of length
-    one less than the list of dominance coefficients.
+    dominance_coeff_list applies to any mutations with selection coefficient below the
+    first entry of dominance_coeff_breaks; the second entry of dominance_coeff_list
+    applies to mutations with selection coefficient between the first and second entries
+    of dominance_coeff_breaks, and so forth. The list of breaks must therefore be of
+    length one less than the list of dominance coefficients.
 
     :ivar distribution_type: A one-letter abbreviation for the distribution of
         fitness effects that each new mutation of this type draws from (see below).
@@ -65,16 +65,18 @@ class MutationType(object):
         a list of dominance coefficients, to apply to different selection coefficients
         (see details). Cannot be specified along with dominance_coeff.
     :vartype dominance_coeff_list: list of floats
-    :ivar dominance_coeff_breaks: Either None (the default) or a list of floats describing
-        the intervals of selection coefficient over which each of the entries of
-        dominance_coeff_list applies (see details). Must be of length one shorter than
+    :ivar dominance_coeff_breaks: Either None (the default) or a list of floats
+        describing the intervals of selection coefficient over which each of the entries
+        of dominance_coeff_list applies (see details). Must be of length one shorter than
         dominance_coeff_list.
     :vartype dominance_coeff_breaks: list of floats
     """
 
     dominance_coeff = attr.ib(default=None, type=float)
     distribution_type = attr.ib(default="f", type=str)
-    distribution_args = attr.ib(factory=lambda: [0], type=list, converter=_copy_converter)
+    distribution_args = attr.ib(
+        factory=lambda: [0], type=list, converter=_copy_converter
+    )
     convert_to_substitution = attr.ib(default=True, type=bool)
     dominance_coeff_list = attr.ib(default=None, type=list, converter=_copy_converter)
     dominance_coeff_breaks = attr.ib(default=None, type=list, converter=_copy_converter)
@@ -84,12 +86,18 @@ class MutationType(object):
             self.dominance_coeff = 0.5
 
         if self.dominance_coeff is not None:
-            if (self.dominance_coeff_list is not None) or (self.dominance_coeff_breaks is not None):
-                raise ValueError("Cannot specify both dominance_coeff and dominance_coeff_list.")
+            if (self.dominance_coeff_list is not None) or (
+                self.dominance_coeff_breaks is not None
+            ):
+                raise ValueError(
+                    "Cannot specify both dominance_coeff and dominance_coeff_list."
+                )
             if not isinstance(self.dominance_coeff, (float, int)):
                 raise ValueError("dominance_coeff must be a number.")
             if not np.isfinite(self.dominance_coeff):
-                raise ValueError(f"Invalid dominance coefficient {self.dominance_coeff}.")
+                raise ValueError(
+                    f"Invalid dominance coefficient {self.dominance_coeff}."
+                )
 
         if self.dominance_coeff_list is not None:
             # disallow the inefficient and annoying length-one case
@@ -101,18 +109,24 @@ class MutationType(object):
                 if not np.isfinite(h):
                     raise ValueError(f"Invalid dominance coefficient {h}.")
             if self.dominance_coeff_breaks is None:
-                raise ValueError(f"A list of dominance coefficients provided but no breaks.")
+                raise ValueError(
+                    "A list of dominance coefficients provided but no breaks."
+                )
             if len(self.dominance_coeff_list) != len(self.dominance_coeff_breaks) + 1:
-                raise ValueError("len(dominance_coeff_list) must be equal "
-                                 "to len(dominance_coeff_breaks) + 1") 
+                raise ValueError(
+                    "len(dominance_coeff_list) must be equal "
+                    "to len(dominance_coeff_breaks) + 1"
+                )
             lb = -1 * np.inf
             for b in self.dominance_coeff_breaks:
                 if not isinstance(b, (float, int)):
-                    raise ValueError("dominance_coeff_breaks must be a list of numbers.")
+                    raise ValueError(
+                        "dominance_coeff_breaks must be a list of numbers."
+                    )
                 if not np.isfinite(b):
                     raise ValueError(f"Invalid dominance coefficient break {b}.")
                 if b < lb:
-                    raise ValueError(f"dominance_coeff_breaks must be nondecreasing.")
+                    raise ValueError("dominance_coeff_breaks must be nondecreasing.")
                 lb = b
 
         if not isinstance(self.distribution_type, str):

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -686,7 +686,9 @@ _raw_stdpopsim_top_level_schema = {
                                 "properties": {
                                     "dominance_coeff": {"type": ["number", "null"]},
                                     "dominance_coeff_list": {"type": ["array", "null"]},
-                                    "dominance_coeff_breaks": {"type": ["array", "null"]},
+                                    "dominance_coeff_breaks": {
+                                        "type": ["array", "null"]
+                                    },
                                     "distribution_type": {"type": "string"},
                                     "distribution_args": {
                                         "type": "array",
@@ -1229,12 +1231,12 @@ def slim_makescript(
             if mt.dominance_coeff_list is None:
                 h_list = [mt.dominance_coeff]
             else:
-                h_list = [0.5] # this value will not matter
+                h_list = [0.5]  # this value will not matter
                 h_list.extend(mt.dominance_coeff_list)
                 # record here what we'll need to set up the callbacks in script
                 mutation_callbacks[mid_list[0]] = {
-                    "dominance_coeff_breaks" : mt.dominance_coeff_breaks,
-                    "mutation_types" : mid_list[1:],
+                    "dominance_coeff_breaks": mt.dominance_coeff_breaks,
+                    "mutation_types": mid_list[1:],
                 }
             assert len(mid_list) == len(h_list)
             first_mt = True
@@ -1401,25 +1403,27 @@ def slim_makescript(
     printsc()
 
     # Mutation callbacks.
-    printsc("    // Mutations callbacks for h-s relationships, "
-            "one variable for each callback.")
+    printsc(
+        "    // Mutations callbacks for h-s relationships, "
+        "one variable for each callback."
+    )
     mut_types_with_callbacks = list(mutation_callbacks.keys())
     printsc(
-        f'    defineConstant("mut_types_with_callbacks", c('
+        '    defineConstant("mut_types_with_callbacks", c('
         + ", ".join(map(str, mut_types_with_callbacks))
-        + '));'
+        + "));"
     )
     for mt in mut_types_with_callbacks:
         printsc(
             f'    defineConstant("dominance_coeff_types_{mt}", c('
-            + ", ".join(map(str, mutation_callbacks[mt]['mutation_types']))
-            + '));'
+            + ", ".join(map(str, mutation_callbacks[mt]["mutation_types"]))
+            + "));"
         )
 
         printsc(
             f'    defineConstant("dominance_coeff_breaks_{mt}", c(-INF, '
-            + ", ".join(map(str, mutation_callbacks[mt]['dominance_coeff_breaks']))
-            + ', INF));'
+            + ", ".join(map(str, mutation_callbacks[mt]["dominance_coeff_breaks"]))
+            + ", INF));"
         )
 
     # Allele frequency conditioning
@@ -1805,7 +1809,9 @@ class _SLiMEngine(stdpopsim.Engine):
                     "distribution_args": [0],
                     "convert_to_substitution": False,
                     "Q_scaled_index": [0],
-                    "slim_mutation_type_id": [max_id + 1,],
+                    "slim_mutation_type_id": [
+                        max_id + 1,
+                    ],
                     "is_neutral": True,
                 }
             ],

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -786,13 +786,14 @@ def _dfe_to_mtypes(contig):
     This is necessary so that we use the same numeric ids to the mutation types
     in the _add_dfes_to_metadata and slim_makescript steps.
 
-    The assigned mutation type ids is a tuple, that is only of length greater
-    than one if the mutation type is of a sort that is implemented using more than
-    one SLiM mutation type; currently, these are only mutation types with a
-    discretized h-s relationship, and (a) only the first of these mutation types
-    are actually assigned a positive mutation rate in SLiM, but (b) all such
-    mutations are transformed to the other mutation types in the list, and hence
-    never end up in the final tree sequence. (See Recipe 10.6 in the SLiM manual.)
+    The assigned mutation type ids is stored as a tuple, that is only of length
+    greater than one if the mutation type is of a sort that is implemented
+    using more than one SLiM mutation type; currently, these are only mutation
+    types with a discretized h-s relationship, and (a) only the first of these
+    mutation types are actually assigned a positive mutation rate in SLiM, but
+    (b) all mutations of the first type are transformed to the other mutation
+    types in the list, and hence never end up in the final tree sequence. (See
+    Recipe 10.6 in the SLiM manual.)
     """
     mid = 0
     dfe_to_mtypes = {}
@@ -1231,7 +1232,9 @@ def slim_makescript(
             if mt.dominance_coeff_list is None:
                 h_list = [mt.dominance_coeff]
             else:
-                h_list = [0.5]  # this value will not matter
+                # this first value will apply only to mutations that are never kept,
+                # and so has no effect
+                h_list = [0.5]
                 h_list.extend(mt.dominance_coeff_list)
                 # record here what we'll need to set up the callbacks in script
                 mutation_callbacks[mid_list[0]] = {

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -503,6 +503,22 @@ _slim_main = """
         }
     }
 
+    // Setup mutation callbacks.
+    // For each stdpopsim mutation type with an h-s relationship
+    // we have a sequence of assigned SLiM mutation types;
+    // the first is the one that gets produced by mutation,
+    // and the remainder are assigned by a mutation callback.
+    for (i in seqAlong(mut_types_with_callbacks)) {
+        mt = mut_types_with_callbacks[i];
+        sim.registerMutationCallback(NULL,
+            "{s = mut.selectionCoeff; "
+            + "k = findInterval(s, dominance_coeff_breaks_" + mt + "); "
+            + "mut.setMutationType(dominance_coeff_types_" + mt + "[k]); "
+            + "return T;}",
+            mt
+        );
+    }
+
     // Sample individuals.
     for (i in 0:(ncol(sampling_episodes)-1)) {
         pop = drop(sampling_episodes[0,i]);
@@ -538,7 +554,6 @@ _slim_main = """
 }
 
 """
-
 
 _slim_logfile = """
 // Optional logfile output:
@@ -669,7 +684,9 @@ _raw_stdpopsim_top_level_schema = {
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "dominance_coeff": {"type": "number"},
+                                    "dominance_coeff": {"type": ["number", "null"]},
+                                    "dominance_coeff_list": {"type": ["array", "null"]},
+                                    "dominance_coeff_breaks": {"type": ["array", "null"]},
                                     "distribution_type": {"type": "string"},
                                     "distribution_args": {
                                         "type": "array",
@@ -680,7 +697,7 @@ _raw_stdpopsim_top_level_schema = {
                                         "type": "array",
                                         "items": {"type": "number"},
                                     },
-                                    "slim_mutation_type_id": {"type": "integer"},
+                                    "slim_mutation_type_id": {"type": "array"},
                                     "is_neutral": {"type": "boolean"},
                                 },
                             },
@@ -759,21 +776,36 @@ def _enum_dfe_and_intervals(contig):
 
 def _dfe_to_mtypes(contig):
     """
-    Assigns a mutation type id to each of the mutation types contained in this
+    Assigns mutation type ids to each of the mutation types contained in this
     `Contig`. This function will return a dictionary with `len(contig.dfe_list)`
     elements, in which the position of the DFE in `contig.dfe_list` is the key.
-    For each DFE, the dictionary holds a list of tuples that contain the an
-    assigned mutation type id (used in  SLiM) and the `MutationType` object.
+    For each DFE, the dictionary holds a list of tuples that contain the
+    assigned mutation type ids (used in SLiM) and the `MutationType` object.
     This is necessary so that we use the same numeric ids to the mutation types
     in the _add_dfes_to_metadata and slim_makescript steps.
+
+    The assigned mutation type ids is a tuple, that is only of length greater
+    than one if the mutation type is of a sort that is implemented using more than
+    one SLiM mutation type; currently, these are only mutation types with a
+    discretized h-s relationship, and (a) only the first of these mutation types
+    are actually assigned a positive mutation rate in SLiM, but (b) all such
+    mutations are transformed to the other mutation types in the list, and hence
+    never end up in the final tree sequence. (See Recipe 10.6 in the SLiM manual.)
     """
     mid = 0
     dfe_to_mtypes = {}
     for i, d, _ in _enum_dfe_and_intervals(contig):
         dfe_to_mtypes[i] = []
         for mt in d.mutation_types:
-            dfe_to_mtypes[i].append((mid, mt))
+            # the first mutation type will be the one that has the mutation rate
+            # and each new mutation gets converted to one of the *other* types;
+            mid_list = [mid]
             mid += 1
+            if mt.dominance_coeff_list is not None:
+                for _ in mt.dominance_coeff_list:
+                    mid_list.append(mid)
+                    mid += 1
+            dfe_to_mtypes[i].append((tuple(mid_list), mt))
     return dfe_to_mtypes
 
 
@@ -798,9 +830,9 @@ def _add_dfes_to_metadata(ts, contig):
     for i, d, ints in _enum_dfe_and_intervals(contig):
         dfes[i]["intervals"] = ints.tolist()
         dfes[i]["proportions"] = d.proportions
-        for j, (mid, mt) in enumerate(dfe_to_mtypes[i]):
+        for j, (mid_list, mt) in enumerate(dfe_to_mtypes[i]):
             add = {
-                "slim_mutation_type_id": mid,
+                "slim_mutation_type_id": list(mid_list),
                 "is_neutral": mt.is_neutral,
             }
             dfes[i]["mutation_types"][j].update(add)
@@ -1012,7 +1044,7 @@ def slim_makescript(
                     f"refers to a DFE with intervals {dfe_intervals}, not "
                     f"to a single site."
                 )
-            mt_id, mt = slim_mutation_ids[dfe_index][0]
+            mt_id_list, mt = slim_mutation_ids[dfe_index][0]
             if not mt.distribution_type == "f":
                 raise ValueError(
                     f"The single site id '{ee.single_site_id}' referenced by "
@@ -1021,7 +1053,7 @@ def slim_makescript(
                     f"fixed fitness coefficient."
                 )
             coordinate = dfe_intervals[0, 0]
-            mutation_type_id = mt_id
+            mutation_type_id = mt_id_list[0]
         if hasattr(ee, "start_time") and hasattr(ee, "end_time"):
             # Now that GenerationAfter times have been accounted for, we can
             # properly catch invalid start/end times.
@@ -1176,47 +1208,64 @@ def slim_makescript(
         return "".join(s)
 
     # Genomic element types.
+    mutation_callbacks = {}
     dfe_mtypes = _dfe_to_mtypes(contig)
     for j, d, ints in _enum_dfe_and_intervals(contig):
-        # Mutation types.
+        # Mutation types and proportions.
         mut_type_list = []
+        mut_props_list = []
         assert len(dfe_mtypes[j]) == len(d.mutation_types)
-        for mid, m in dfe_mtypes[j]:
-            if len(m.Q_scaled_index) >= 1:
-                distrib_args = [str(arg) for arg in m.distribution_args]
-                for k in m.Q_scaled_index:
-                    distrib_args[m.Q_scaled_index[k]] = (
-                        "Q * " + distrib_args[m.Q_scaled_index[k]]
+        for mt_index, (mid_list, mt) in enumerate(dfe_mtypes[j]):
+            if len(mt.Q_scaled_index) >= 1:
+                distrib_args = [str(arg) for arg in mt.distribution_args]
+                for k in mt.Q_scaled_index:
+                    distrib_args[mt.Q_scaled_index[k]] = (
+                        "Q * " + distrib_args[mt.Q_scaled_index[k]]
                     )
                 distrib_args = ", ".join(distrib_args)
             # dealing with distributions given by "s" Eidos script,
             else:
-                distrib_args = "; ".join([f'"{a}"' for a in m.distribution_args])
-            mut_type_list.append(mid)
-            printsc(
-                f"    initializeMutationType({mid}, {m.dominance_coeff}, "
-                f'"{m.distribution_type}", {distrib_args});'
-            )
-            if not m.convert_to_substitution:
-                # T is the default for WF simulations.
-                printsc(f"    m{mid}.convertToSubstitution = F;")
-            # TODO: when msprime.SLiMMutationModel supports stacking policy,
-            # set policy such that there's at most a single mutation per-site
-            # and individual
-            # printsc(f"    m{mid}.mutationStackGroup = 0;")
-            # printsc(f"    m{mid}.mutationStackPolicy = 'l';")
+                distrib_args = "; ".join([f'"{a}"' for a in mt.distribution_args])
+            if mt.dominance_coeff_list is None:
+                h_list = [mt.dominance_coeff]
+            else:
+                h_list = [0.5] # this value will not matter
+                h_list.extend(mt.dominance_coeff_list)
+                # record here what we'll need to set up the callbacks in script
+                mutation_callbacks[mid_list[0]] = {
+                    "dominance_coeff_breaks" : mt.dominance_coeff_breaks,
+                    "mutation_types" : mid_list[1:],
+                }
+            assert len(mid_list) == len(h_list)
+            first_mt = True
+            for mid, h in zip(mid_list, h_list):
+                # We will assign a proportion of 0.0 to mutation types that are neutral
+                # unless all the mutation types in a DFE are neutral. In such case,
+                # SLiM would not allow all mutation types in a genomic element type to
+                # have 0.0 proportion. And the proportions in SLiM won't matter anyway,
+                # because all the intervals in this fully neutral DFE will have 0.0
+                # mutation rate anyway.
+                # Furthermore, for mutation types with a discretized h-s relationship,
+                # we only mutate to the first assigned mutation type, and remaining ones
+                # are produced by a mutation callback.
+                mut_type_list.append(mid)
+                use_prop = first_mt and ((not mt.is_neutral) or d.is_neutral)
+                p = d.proportions[mt_index] if use_prop else 0.0
+                mut_props_list.append(p)
+                printsc(
+                    f"    initializeMutationType({mid}, {h}, "
+                    f'"{mt.distribution_type}", {distrib_args});'
+                )
+                if not mt.convert_to_substitution:
+                    # T is the default for WF simulations.
+                    printsc(f"    m{mid}.convertToSubstitution = F;")
+                # TODO: when msprime.SLiMMutationModel supports stacking policy,
+                # set policy such that there's at most a single mutation per-site
+                # and individual
+                # printsc(f"    mt{mid}.mutationStackGroup = 0;")
+                # printsc(f"    mt{mid}.mutationStackPolicy = 'l';")
+                first_mt = False
         mut_types = ", ".join([str(mt) for mt in mut_type_list])
-        mut_types = ", ".join([str(mt) for mt in mut_type_list])
-        # We will assign a proportion of 0.0 to mutation types that are neutral
-        # unless all the mutation types in a DFE are neutral. In such case,
-        # SLiM would not allow all mutation types in a genomic element type to
-        # have 0.0 proportion. And the proportions in SLiM won't matter anyway,
-        # because all the intervals in this fully neutral DFE will have 0.0
-        # mutation rate anyway.
-        mut_props_list = [
-            prop if (not mt.is_neutral) or d.is_neutral else 0.0
-            for prop, mt in zip(d.proportions, d.mutation_types)
-        ]
         mut_props = ", ".join(map(str, mut_props_list))
         printsc(
             f"    initializeGenomicElementType({j}, c({mut_types}), c({mut_props}));"
@@ -1350,6 +1399,28 @@ def slim_makescript(
         + ");"
     )
     printsc()
+
+    # Mutation callbacks.
+    printsc("    // Mutations callbacks for h-s relationships, "
+            "one variable for each callback.")
+    mut_types_with_callbacks = list(mutation_callbacks.keys())
+    printsc(
+        f'    defineConstant("mut_types_with_callbacks", c('
+        + ", ".join(map(str, mut_types_with_callbacks))
+        + '));'
+    )
+    for mt in mut_types_with_callbacks:
+        printsc(
+            f'    defineConstant("dominance_coeff_types_{mt}", c('
+            + ", ".join(map(str, mutation_callbacks[mt]['mutation_types']))
+            + '));'
+        )
+
+        printsc(
+            f'    defineConstant("dominance_coeff_breaks_{mt}", c(-INF, '
+            + ", ".join(map(str, mutation_callbacks[mt]['dominance_coeff_breaks']))
+            + ', INF));'
+        )
 
     # Allele frequency conditioning
     op_types = ", ".join(
@@ -1721,7 +1792,7 @@ class _SLiMEngine(stdpopsim.Engine):
         max_id = -1
         for dfe in metadata["stdpopsim"]["DFEs"]:
             for mt in dfe["mutation_types"]:
-                max_id = max(mt["slim_mutation_type_id"], max_id)
+                max_id = max(max(mt["slim_mutation_type_id"]), max_id)
         recap_dfe = {
             "id": "recapitation",
             "description": "DFE used in recapitation",
@@ -1734,7 +1805,7 @@ class _SLiMEngine(stdpopsim.Engine):
                     "distribution_args": [0],
                     "convert_to_substitution": False,
                     "Q_scaled_index": [0],
-                    "slim_mutation_type_id": max_id + 1,
+                    "slim_mutation_type_id": [max_id + 1,],
                     "is_neutral": True,
                 }
             ],
@@ -1797,12 +1868,12 @@ class _SLiMEngine(stdpopsim.Engine):
 
                     # Use msprime.SLiMMutationModel rather than msprime.JC69
                     # for neutral DFEs.  This ensures that there will be a
-                    # 'selection_coef' key in the mutation metadata (e.g. the
+                    # 'selection_coef' key in the mutation metadata (so the
                     # mutation metadata structure will be consistent across the
                     # tree sequence).
                     # TODO: set stacking policy to "l" when supported
                     model = msprime.SLiMMutationModel(
-                        type=mt["slim_mutation_type_id"],
+                        type=mt["slim_mutation_type_id"][0],
                         next_id=_get_next_id(ts),
                     )
 

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -793,7 +793,8 @@ def _dfe_to_mtypes(contig):
     mutation types are actually assigned a positive mutation rate in SLiM, but
     (b) all mutations of the first type are transformed to the other mutation
     types in the list, and hence never end up in the final tree sequence. (See
-    Recipe 10.6 in the SLiM manual.)
+    Recipe 10.6 in the SLiM manual, "Varying the dominance coefficient among
+    mutations".)
     """
     mid = 0
     dfe_to_mtypes = {}

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -250,9 +250,9 @@ class TestCreateMutationType:
 
     def test_dominance_coeff_list(self):
         for dcl, dcb in (
-                ([-0.1, 0.7, 1.2], [-2.1, 1.0]),
-                ([-0.1, -0.7], [-2.1]),
-            ):
+            ([-0.1, 0.7, 1.2], [-2.1, 1.0]),
+            ([-0.1, -0.7], [-2.1]),
+        ):
             mt = dfe.MutationType(dominance_coeff_list=dcl, dominance_coeff_breaks=dcb)
             assert np.allclose(dcl, mt.dominance_coeff_list)
             assert np.allclose(dcb, mt.dominance_coeff_breaks)
@@ -290,19 +290,19 @@ class TestCreateMutationType:
         # can't specify both dominance_coeff and list
         with pytest.raises(ValueError, match="both dominance_coeff and"):
             dfe.MutationType(
-                    dominance_coeff=0.5,
-                    dominance_coeff_list=dcl,
-                    dominance_coeff_breaks=dcb,
+                dominance_coeff=0.5,
+                dominance_coeff_list=dcl,
+                dominance_coeff_breaks=dcb,
             )
         with pytest.raises(ValueError, match="both dominance_coeff and"):
             dfe.MutationType(
-                    dominance_coeff=0.5,
-                    dominance_coeff_list=dcl,
+                dominance_coeff=0.5,
+                dominance_coeff_list=dcl,
             )
         with pytest.raises(ValueError, match="both dominance_coeff and"):
             dfe.MutationType(
-                    dominance_coeff=0.5,
-                    dominance_coeff_breaks=dcb,
+                dominance_coeff=0.5,
+                dominance_coeff_breaks=dcb,
             )
         # must have both coeffs and breaks
         with pytest.raises(ValueError, match="dominance.*no breaks"):
@@ -310,34 +310,34 @@ class TestCreateMutationType:
         # must have at least 2 bins
         with pytest.raises(ValueError, match="dominance.*at least 2"):
             dfe.MutationType(
-                    dominance_coeff_list=[0.2],
-                    dominance_coeff_breaks=[],
+                dominance_coeff_list=[0.2],
+                dominance_coeff_breaks=[],
             )
         # list must be one longer than breaks
         for x in ([], [0.0], dcl):
             with pytest.raises(ValueError, match="dominance.*equal to"):
                 dfe.MutationType(
-                        dominance_coeff_list=dcl,
-                        dominance_coeff_breaks=x,
+                    dominance_coeff_list=dcl,
+                    dominance_coeff_breaks=x,
                 )
         # bad coefficients
-        for x in (np.inf, np.nan, 'abc', [], {}):
+        for x in (np.inf, np.nan, "abc", [], {}):
             with pytest.raises(ValueError, match="dominance.coeff"):
                 dfe.MutationType(
-                        dominance_coeff_list=[x] + dcl[1:],
-                        dominance_coeff_breaks=dcb,
+                    dominance_coeff_list=[x] + dcl[1:],
+                    dominance_coeff_breaks=dcb,
                 )
         # bad breaks
-        for x in (np.inf, np.nan, 'abc', [], {}):
+        for x in (np.inf, np.nan, "abc", [], {}):
             with pytest.raises(ValueError, match="dominance.*break"):
                 dfe.MutationType(
-                        dominance_coeff_list=dcl,
-                        dominance_coeff_breaks=[x] + dcb[1:],
+                    dominance_coeff_list=dcl,
+                    dominance_coeff_breaks=[x] + dcb[1:],
                 )
         with pytest.raises(ValueError, match="nondecreasing"):
             dfe.MutationType(
-                    dominance_coeff_list=dcl,
-                    dominance_coeff_breaks=list(reversed(dcb)),
+                dominance_coeff_list=dcl,
+                dominance_coeff_breaks=list(reversed(dcb)),
             )
 
 

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -248,15 +248,97 @@ class TestCreateMutationType:
             mt = dfe.MutationType(dominance_coeff=dominance_coeff)
             assert mt.dominance_coeff == dominance_coeff
 
+    def test_dominance_coeff_list(self):
+        for dcl, dcb in (
+                ([-0.1, 0.7, 1.2], [-2.1, 1.0]),
+                ([-0.1, -0.7], [-2.1]),
+            ):
+            mt = dfe.MutationType(dominance_coeff_list=dcl, dominance_coeff_breaks=dcb)
+            assert np.allclose(dcl, mt.dominance_coeff_list)
+            assert np.allclose(dcb, mt.dominance_coeff_breaks)
+
+    def test_pass_by_value(self):
+        # make sure that for the arguments that are lists
+        # we can't post-hoc modify them (and thus bypass validation)
+        val = 0.5
+        x = [val]
+        mt = dfe.MutationType(distribution_args=x)
+        x[0] = 2 * val + 1
+        assert mt.distribution_args[0] == val
+        x = [val, val]
+        mt = dfe.MutationType(dominance_coeff_list=x, dominance_coeff_breaks=[0.0])
+        x[0] = 2 * val + 1
+        assert mt.dominance_coeff_list[0] == val
+        x = [val]
+        mt = dfe.MutationType(dominance_coeff_list=[0.0, 0.0], dominance_coeff_breaks=x)
+        x[0] = 2 * val + 1
+        assert mt.dominance_coeff_breaks[0] == val
+
     def test_bad_dominance_coeff(self):
-        for dominance_coeff in (np.inf, np.nan, "abc", [], None, {}):
-            with pytest.raises(ValueError):
+        for dominance_coeff in (np.inf, np.nan, "abc", [], {}):
+            with pytest.raises(ValueError, match="dominance.coeff"):
                 dfe.MutationType(dominance_coeff=dominance_coeff)
 
     def test_bad_distribution_type(self):
         for distribution_type in (1, {}, None, "~", "!", "F"):
             with pytest.raises(ValueError):
                 dfe.MutationType(distribution_type=distribution_type)
+
+    def test_bad_dominance_coeff_list(self):
+        dcl = [-0.1, 0.7, 1.2]
+        dcb = [-2.1, 1.0]
+        # can't specify both dominance_coeff and list
+        with pytest.raises(ValueError, match="both dominance_coeff and"):
+            dfe.MutationType(
+                    dominance_coeff=0.5,
+                    dominance_coeff_list=dcl,
+                    dominance_coeff_breaks=dcb,
+            )
+        with pytest.raises(ValueError, match="both dominance_coeff and"):
+            dfe.MutationType(
+                    dominance_coeff=0.5,
+                    dominance_coeff_list=dcl,
+            )
+        with pytest.raises(ValueError, match="both dominance_coeff and"):
+            dfe.MutationType(
+                    dominance_coeff=0.5,
+                    dominance_coeff_breaks=dcb,
+            )
+        # must have both coeffs and breaks
+        with pytest.raises(ValueError, match="dominance.*no breaks"):
+            dfe.MutationType(dominance_coeff_list=dcl)
+        # must have at least 2 bins
+        with pytest.raises(ValueError, match="dominance.*at least 2"):
+            dfe.MutationType(
+                    dominance_coeff_list=[0.2],
+                    dominance_coeff_breaks=[],
+            )
+        # list must be one longer than breaks
+        for x in ([], [0.0], dcl):
+            with pytest.raises(ValueError, match="dominance.*equal to"):
+                dfe.MutationType(
+                        dominance_coeff_list=dcl,
+                        dominance_coeff_breaks=x,
+                )
+        # bad coefficients
+        for x in (np.inf, np.nan, 'abc', [], {}):
+            with pytest.raises(ValueError, match="dominance.coeff"):
+                dfe.MutationType(
+                        dominance_coeff_list=[x] + dcl[1:],
+                        dominance_coeff_breaks=dcb,
+                )
+        # bad breaks
+        for x in (np.inf, np.nan, 'abc', [], {}):
+            with pytest.raises(ValueError, match="dominance.*break"):
+                dfe.MutationType(
+                        dominance_coeff_list=dcl,
+                        dominance_coeff_breaks=[x] + dcb[1:],
+                )
+        with pytest.raises(ValueError, match="nondecreasing"):
+            dfe.MutationType(
+                    dominance_coeff_list=dcl,
+                    dominance_coeff_breaks=list(reversed(dcb)),
+            )
 
 
 class TestAllDFEs:

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1164,7 +1164,16 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         for t, params in mut_params.items()
         for p in params
     ]
-    assert len(example_mut_types) == 10
+    for dcl, dcb in [([0.0, 1.0], [0.0]), ([-0.2, 1.4, 0.5], [-0.1, 0.1])]:
+        for t in ('f', 'e', 'n'):
+            mt = stdpopsim.MutationType(
+                    distribution_type=t,
+                    distribution_args=mut_params[t][0],
+                    dominance_coeff_list=dcl,
+                    dominance_coeff_breaks=dcb,
+            )
+            example_mut_types.append((t, mt))
+    assert len(example_mut_types) == 16
 
     def get_example_dfes(self):
         # this is in a function because scoping is weird
@@ -1202,7 +1211,6 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         contig = get_test_contig()
         # make theta = 40
         contig.mutation_rate = 20 / (1000 * contig.recombination_map.sequence_length)
-        print(contig.mutation_rate)
         dfes = [
             stdpopsim.DFE(
                 id=str(j),
@@ -1232,7 +1240,6 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
                     ts.tables.sites.position < breaks[j + 1],
                 )
             )[0]
-            print(mt)
             assert len(sites) > 0
             for k in sites:
                 s = ts.site(k)
@@ -1297,12 +1304,17 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
                 is_dfe_neutral &= mt["is_neutral"]
             # Recall a mutation type will have proportion 0.0 in SLiM if it is
             # neutral and not all the mutation types in the corresponding DFE are
-            # neutral. SLiM does not allow a genomicelementtype to have all 0.0
+            # neutral. SLiM does not allow a genomicElementType to have all 0.0
             # proportions.
-            return [
-                prop if (not mt["is_neutral"]) or is_dfe_neutral else 0.0
-                for prop, mt in zip(dfe["proportions"], dfe["mutation_types"])
-            ]
+            print(dfe)
+            prop_list = []
+            for prop, mt in zip(dfe["proportions"], dfe["mutation_types"]):
+                first_mt = True
+                for i in mt['slim_mutation_type_id']:
+                    nonzero_prop = ((not mt["is_neutral"]) or is_dfe_neutral) and first_mt
+                    prop_list.append(prop if nonzero_prop else 0.0)
+                    first_mt = False
+            return prop_list
 
         for i, dfe in enumerate(ts.metadata["stdpopsim"]["DFEs"]):
             if dfe["id"] == "recapitation":
@@ -1319,11 +1331,32 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
                 "intervalStarts": int_starts,
                 "mutationFractions": _slim_proportions(dfe),
                 "mutationTypes": [
-                    mt["slim_mutation_type_id"] for mt in dfe["mutation_types"]
+                    mid
+                    for mt in dfe["mutation_types"]
+                    for mid in mt["slim_mutation_type_id"]
                 ],
             }
-            ge = self.slim_metadata_key0(ge_types, str(i))
             assert ge == ge_from_meta
+
+    def verify_mutation_type_absence(self, contig, ts):
+        # check that the dummy first mutation type of discretized
+        # h-s relationship mutation types are absent
+        mut_type_counts = collections.Counter(
+                x['mutation_type'] for m in ts.mutations() for x in m.metadata['mutation_list']
+        )
+        print('metadata', [x['id'] for x in ts.metadata['stdpopsim']['DFEs']])
+        print('contig', [x.id for x in contig.dfe_list])
+        metadata_ids = [x['id'] for x in ts.metadata['stdpopsim']['DFEs']]
+        has_recap = (metadata_ids[-1] == "recapitation")
+        assert len(contig.dfe_list) + has_recap == len(ts.metadata['stdpopsim']['DFEs'])
+        for dfe, ts_metadata in zip(contig.dfe_list, ts.metadata['stdpopsim']['DFEs']):
+            assert dfe.id == ts_metadata['id']
+            assert len(dfe.mutation_types) == len(ts_metadata['mutation_types'])
+            for mt, md in zip(dfe.mutation_types, ts_metadata['mutation_types']):
+                if mt.dominance_coeff_list is not None:
+                    assert len(mt.dominance_coeff_list) + 1 == len(md['slim_mutation_type_id'])
+                    first_type = md['slim_mutation_type_id'][0]
+                    assert mut_type_counts[first_type] == 0
 
     def verify_genomic_elements(self, contig, ts):
         # compare information about genomic elements as recorded
@@ -1335,6 +1368,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             ts.metadata["SLiM"]["user_metadata"], "genomicElementTypes"
         )
         self.verify_dfes_metadata(ts, ge_types)
+        self.verify_mutation_type_absence(contig, ts)
         assert len(contig.dfe_list) == len(ge_types)
         for j, (dfe, intervals) in enumerate(
             zip(contig.dfe_list, contig.interval_list)
@@ -1343,13 +1377,21 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             ge = self.slim_metadata_key0(ge_types, str(j))
             # checking that the neutral mutations have 0.0 proportion unless
             # all the mutations are neutral in this dfe
-            for mt, dfe_prop, slim_prop in zip(
-                dfe.mutation_types, dfe.proportions, ge["mutationFractions"]
-            ):
+            assert len(dfe.mutation_types) == len(dfe.proportions)
+            ge_index = 0
+            for mt, dfe_prop in zip(dfe.mutation_types, dfe.proportions):
+                slim_prop = ge["mutationFractions"][ge_index]
+                ge_index += 1
                 if mt.is_neutral and not dfe.is_neutral:
                     assert slim_prop == 0.0
                 else:
                     assert slim_prop == dfe_prop
+                if mt.dominance_coeff_list is not None:
+                    for _ in mt.dominance_coeff_list:
+                        slim_prop = ge["mutationFractions"][ge_index]
+                        assert slim_prop == 0.0
+                        ge_index += 1
+            assert ge_index == len(ge["mutationFractions"])
             # "+1" because SLiM's intervals are closed on both ends,
             # stdpopsim's are closed on the left, open on the right
             slim_intervals = np.column_stack(
@@ -1359,20 +1401,36 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
                 ]
             )
             assert_array_equal(intervals, slim_intervals)
-            slim_mut_types = ge["mutationTypes"]
-            assert len(dfe.mutation_types) == len(slim_mut_types)
-            for mt, mt_id in zip(dfe.mutation_types, slim_mut_types):
+            ge_index = 0
+            for mt in dfe.mutation_types:
+                mt_id = ge["mutationTypes"][ge_index]
+                ge_index += 1
                 assert str(mt_id) in mut_types
                 slim_mt = self.slim_metadata_key0(mut_types, str(mt_id))
-                assert mt.dominance_coeff == self.slim_metadata_key0(
-                    slim_mt, "dominanceCoeff"
-                )
+                if mt.dominance_coeff_list is None:
+                    assert mt.dominance_coeff == self.slim_metadata_key0(
+                        slim_mt, "dominanceCoeff"
+                    )
+                else:
+                    assert 0.5 == self.slim_metadata_key0(
+                        slim_mt, "dominanceCoeff"
+                    )
+                    for h in mt.dominance_coeff_list:
+                        mt_id = ge["mutationTypes"][ge_index]
+                        ge_index += 1
+                        assert str(mt_id) in mut_types
+                        slim_mt = self.slim_metadata_key0(mut_types, str(mt_id))
+                        assert np.allclose(
+                                h,
+                                self.slim_metadata_key0(slim_mt, "dominanceCoeff")
+                        )
                 assert mt.distribution_type == self.slim_metadata_key0(
                     slim_mt, "distributionType"
                 )
                 assert len(mt.distribution_args) == len(slim_mt["distributionParams"])
                 for a, b in zip(mt.distribution_args, slim_mt["distributionParams"]):
                     assert a == b
+            assert ge_index == len(ge["mutationTypes"])
 
     def test_no_dfe(self):
         contig = get_test_contig()
@@ -1415,6 +1473,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             samples=self.samples,
             verbosity=3,  # to get metadata output
         )
+        ts.dump("temp.trees")
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
 
@@ -1629,6 +1688,40 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
         assert int(ts.sequence_length) == right - left
+
+    def test_dominance_coeff_list(self):
+        # test that discretized h-s relationships work
+        contig = get_test_contig()
+        L = int(contig.length)
+        dfe0 = stdpopsim.DFE(
+            id="dfe",
+            description="the first one",
+            long_description="hello world",
+            proportions=[1.0],
+            mutation_types=[self.example_mut_types[5][1]],
+        )
+        dfe1 = stdpopsim.DFE(
+            id="dfe",
+            description="the second one",
+            long_description="I'm different but have the same name! =( =(",
+            proportions=[0.2, 0.8],
+            mutation_types=[m for _, m in self.example_mut_types[7:9]],
+        )
+        contig.add_dfe(np.array([[0, 0.5 * L]], dtype="int"), dfe0)
+        contig.add_dfe(np.array([[0.2 * L, 0.4 * L]], dtype="int"), dfe0)
+        contig.add_dfe(np.array([[0.45 * L, L]], dtype="int"), dfe1)
+        contig.add_dfe(np.array([[0.7 * L, 0.9 * L]], dtype="int"), dfe0)
+        assert len(contig.dfe_list) == 5
+        engine = stdpopsim.get_engine("slim")
+        ts = engine.simulate(
+            demographic_model=self.model,
+            contig=contig,
+            samples=self.samples,
+            verbosity=3,  # to get metadata output
+        )
+        self.verify_genomic_elements(contig, ts)
+        self.verify_mutation_rates(contig, ts)
+
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="SLiM not available on windows")

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1165,12 +1165,12 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         for p in params
     ]
     for dcl, dcb in [([0.0, 1.0], [0.0]), ([-0.2, 1.4, 0.5], [-0.1, 0.1])]:
-        for t in ('f', 'e', 'n'):
+        for t in ("f", "e", "n"):
             mt = stdpopsim.MutationType(
-                    distribution_type=t,
-                    distribution_args=mut_params[t][0],
-                    dominance_coeff_list=dcl,
-                    dominance_coeff_breaks=dcb,
+                distribution_type=t,
+                distribution_args=mut_params[t][0],
+                dominance_coeff_list=dcl,
+                dominance_coeff_breaks=dcb,
             )
             example_mut_types.append((t, mt))
     assert len(example_mut_types) == 16
@@ -1310,8 +1310,10 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             prop_list = []
             for prop, mt in zip(dfe["proportions"], dfe["mutation_types"]):
                 first_mt = True
-                for i in mt['slim_mutation_type_id']:
-                    nonzero_prop = ((not mt["is_neutral"]) or is_dfe_neutral) and first_mt
+                for i in mt["slim_mutation_type_id"]:
+                    nonzero_prop = (
+                        (not mt["is_neutral"]) or is_dfe_neutral
+                    ) and first_mt
                     prop_list.append(prop if nonzero_prop else 0.0)
                     first_mt = False
             return prop_list
@@ -1342,20 +1344,24 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         # check that the dummy first mutation type of discretized
         # h-s relationship mutation types are absent
         mut_type_counts = collections.Counter(
-                x['mutation_type'] for m in ts.mutations() for x in m.metadata['mutation_list']
+            x["mutation_type"]
+            for m in ts.mutations()
+            for x in m.metadata["mutation_list"]
         )
-        print('metadata', [x['id'] for x in ts.metadata['stdpopsim']['DFEs']])
-        print('contig', [x.id for x in contig.dfe_list])
-        metadata_ids = [x['id'] for x in ts.metadata['stdpopsim']['DFEs']]
-        has_recap = (metadata_ids[-1] == "recapitation")
-        assert len(contig.dfe_list) + has_recap == len(ts.metadata['stdpopsim']['DFEs'])
-        for dfe, ts_metadata in zip(contig.dfe_list, ts.metadata['stdpopsim']['DFEs']):
-            assert dfe.id == ts_metadata['id']
-            assert len(dfe.mutation_types) == len(ts_metadata['mutation_types'])
-            for mt, md in zip(dfe.mutation_types, ts_metadata['mutation_types']):
+        print("metadata", [x["id"] for x in ts.metadata["stdpopsim"]["DFEs"]])
+        print("contig", [x.id for x in contig.dfe_list])
+        metadata_ids = [x["id"] for x in ts.metadata["stdpopsim"]["DFEs"]]
+        has_recap = metadata_ids[-1] == "recapitation"
+        assert len(contig.dfe_list) + has_recap == len(ts.metadata["stdpopsim"]["DFEs"])
+        for dfe, ts_metadata in zip(contig.dfe_list, ts.metadata["stdpopsim"]["DFEs"]):
+            assert dfe.id == ts_metadata["id"]
+            assert len(dfe.mutation_types) == len(ts_metadata["mutation_types"])
+            for mt, md in zip(dfe.mutation_types, ts_metadata["mutation_types"]):
                 if mt.dominance_coeff_list is not None:
-                    assert len(mt.dominance_coeff_list) + 1 == len(md['slim_mutation_type_id'])
-                    first_type = md['slim_mutation_type_id'][0]
+                    assert len(mt.dominance_coeff_list) + 1 == len(
+                        md["slim_mutation_type_id"]
+                    )
+                    first_type = md["slim_mutation_type_id"][0]
                     assert mut_type_counts[first_type] == 0
 
     def verify_genomic_elements(self, contig, ts):
@@ -1412,17 +1418,14 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
                         slim_mt, "dominanceCoeff"
                     )
                 else:
-                    assert 0.5 == self.slim_metadata_key0(
-                        slim_mt, "dominanceCoeff"
-                    )
+                    assert 0.5 == self.slim_metadata_key0(slim_mt, "dominanceCoeff")
                     for h in mt.dominance_coeff_list:
                         mt_id = ge["mutationTypes"][ge_index]
                         ge_index += 1
                         assert str(mt_id) in mut_types
                         slim_mt = self.slim_metadata_key0(mut_types, str(mt_id))
                         assert np.allclose(
-                                h,
-                                self.slim_metadata_key0(slim_mt, "dominanceCoeff")
+                            h, self.slim_metadata_key0(slim_mt, "dominanceCoeff")
                         )
                 assert mt.distribution_type == self.slim_metadata_key0(
                     slim_mt, "distributionType"
@@ -1721,7 +1724,6 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         )
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
-
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="SLiM not available on windows")


### PR DESCRIPTION
Here's an implementation of the "discretized h-s relationship" discussed at #1488. There *is* a small backwards incompatibility here; that is that the "slim_mutation_id" entry we record in the top-level metadata is now a list instead of a single value. I think this is okay because we'll be doing a new release (and so can mention this), and our storing of things in metadata is not documented yet anyhow.

Note in particular that with this, we will be decoupling the "mutation type" of SLiM from the "mutation type" of stdpopsim (ie a single stdpopsim mutation type may produce mutations of many SLiM mutation types). This is why it was perhaps a lack of foresight to model the DFE machinery after SLiM's mechanics rather than motivating biology. 

To understand what's going on here, read "10.6 Varying the dominance coefficient among mutations" of the SLiM manual.