### PR TITLE
new checksums

### DIFF
--- a/stdpopsim/catalog/AraTha/annotations.py
+++ b/stdpopsim/catalog/AraTha/annotations.py
@@ -15,7 +15,7 @@ _an = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/AraTha/araport_11_exons.tar.gz"
     ),
-    intervals_sha256="235105850a365f7f171c459d4c5ee50483e0c17e3b2b0232412d22addca9915f",
+    intervals_sha256="1b55a1e42c546a16caf6b0bedb879b8b161bff99677323b7c37f87d7973bb4cf",
     citations=[
         stdpopsim.Citation(
             year=2017,
@@ -44,7 +44,7 @@ _an2 = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/AraTha/araport_11_CDS.tar.gz"
     ),
-    intervals_sha256="c1e1c17a0bf3591e91a4cf85a0ad964d1e9205cc2788c40f855870c589cacca7",
+    intervals_sha256="a66baeb5fd0907fe5b0b0c678c163065c470bb41f639c309d5976ea55e12d513",
     citations=[
         stdpopsim.Citation(
             year=2017,

--- a/stdpopsim/catalog/DroMel/annotations.py
+++ b/stdpopsim/catalog/DroMel/annotations.py
@@ -16,7 +16,7 @@ _an = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/DroMel/FlyBase_BDGP6.32.51_exons.tar.gz"
     ),
-    intervals_sha256="f09b4684505c7c8c86c7739d632c79927b8d329fd60fd55ea3f610b944bb5856",
+    intervals_sha256="665df7639725ca18bde85001bbdc08fbef4450c52a8788e02ba76206e2e03d50",
     citations=[
         stdpopsim.Citation(
             year=2014,
@@ -45,7 +45,7 @@ _an2 = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/DroMel/FlyBase_BDGP6.32.51_CDS.tar.gz"
     ),
-    intervals_sha256="b993c8fc997e1c7ecdad626b7eeceae724cc0e0e477d8ab2f186866a6a0def15",
+    intervals_sha256="3f84b69f7ca558f16cc9b787ee74ba5d16685cb80b2ba8a6ddca4b7b0c4486e0",
     citations=[
         stdpopsim.Citation(
             year=2014,

--- a/stdpopsim/catalog/HomSap/annotations.py
+++ b/stdpopsim/catalog/HomSap/annotations.py
@@ -15,7 +15,7 @@ _an = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/HomSap/ensembl_havana_104_exons.tar.gz"
     ),
-    intervals_sha256="b9df30b3a37cdd26ec625fd80968ff2e412810c045a11dddc458dc606c702c96",
+    intervals_sha256="41160d5ad616d25be13e95fb44c523e2d82dffc942b835b979fdc7c4c01f6d8c",
     citations=[
         stdpopsim.Citation(
             year=2018,
@@ -44,7 +44,7 @@ _an2 = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/HomSap/ensembl_havana_104_CDS.tar.gz"
     ),
-    intervals_sha256="237801b39642b91e733e155dc62960c0b097d3c144eea408327e9dc5f1ac84ae",
+    intervals_sha256="0562bb9fb7d74625a52cd32360066bab0fe1188aaf5022707299fb69eb2b930d",
     citations=[
         stdpopsim.Citation(
             year=2018,

--- a/stdpopsim/catalog/PhoSin/annotations.py
+++ b/stdpopsim/catalog/PhoSin/annotations.py
@@ -15,7 +15,7 @@ _an = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/PhoSin/Phocoena_sinus.mPhoSin1.pri.110_exons.tar.gz"
     ),
-    intervals_sha256="12e767581efc46c5494f800e17011d3e80eb000950f51a98308249afdeb68f87",
+    intervals_sha256="ec95fd1418b8a9a53cd6486fd6a37e699ecd1fce2635df85d8ea4360d53bfbf4",
     citations=[
         stdpopsim.Citation(
             year=2020,
@@ -44,7 +44,7 @@ _an2 = stdpopsim.Annotation(
         "https://stdpopsim.s3-us-west-2.amazonaws.com/"
         "annotations/PhoSin/Phocoena_sinus.mPhoSin1.pri.110_CDS.tar.gz"
     ),
-    intervals_sha256="f44859c4ce99e93f1bacce1da1e620ed41eb2fe1bd75aafe8ac99d54cb6e7a7a",
+    intervals_sha256="3e30657d2db3ac39136684c56d91b6fd04a03112b139b5dd1a2a1b276f456a44",
     citations=[
         stdpopsim.Citation(
             year=2020,


### PR DESCRIPTION
The annotations checksums changed in the vaquita annotation PR #1520 

```
$ python -m pytest
========================================================= test session starts =========================================================
platform linux -- Python 3.8.17, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/chriscs/StdPopSim/Temp1/stdpopsim
configfile: setup.cfg
testpaths: tests
plugins: xdist-3.3.1, cov-4.1.0
4 workers [2416 items]  
............................................................................................................................... [  5%]
............................................................................................................................... [ 10%]
............................................................................................................................... [ 15%]
............................................................................................................................... [ 20%]
............................................................................................................................... [ 26%]
............................................................................................................................... [ 31%]
............................................................................................................................... [ 36%]
............................................................................................................................... [ 42%]
............................................................................................................................... [ 47%]
............................................................................................................................... [ 52%]
............................................................................................................................... [ 57%]
........................................sssssss.s.s.sss......sssssss.....ssss....ssssss.sss...ssssss.ss...ssssss............... [ 63%]
............................................................................................................................... [ 68%]
............................................................................................................................... [ 73%]
............................................................................................................................... [ 78%]
............................................................................................................................... [ 84%]
............................................................................................................................... [ 89%]
............................................................................................................................... [ 94%]
...............................s..............................................
.............
.................................... [ 99%]
...                                                                                                                             [100%]
========================================================== warnings summary ===========================================================
tests/test_dfes.py: 7 warnings
tests/test_masking.py: 2 warnings
tests/test_slim_engine.py: 59 warnings
  /home/chriscs/Software/miniconda3/envs/stdpopsim2/lib/python3.8/site-packages/msprime/ancestry.py:831: TimeUnitsMismatchWarning: The initial_state has time_units=ticks but time is measured in generations in msprime. This may lead to significant discrepancies between the timescales. If you wish to suppress this warning, you can use, e.g., warnings.simplefilter('ignore', msprime.TimeUnitsMismatchWarning)
    warnings.warn(message, TimeUnitsMismatchWarning)

tests/test_utils.py::TestGammaPdf::test_gamma_pdf[x3-a3-loc3-scale3]
  /home/chriscs/StdPopSim/Temp1/stdpopsim/stdpopsim/utils.py:349: RuntimeWarning: invalid value encountered in divide
    y = (x - loc) / scale

tests/test_utils.py::TestGammaPdf::test_gamma_pdf[x3-a3-loc3-scale3]
  /home/chriscs/Software/miniconda3/envs/stdpopsim2/lib/python3.8/site-packages/scipy/stats/_distn_infrastructure.py:2093: RuntimeWarning: invalid value encountered in divide
    x = np.asarray((x - loc)/scale, dtype=dtyp)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 2369 passed, 47 skipped, 70 warnings in 166.26s (0:02:46) ======================================

```