### PR TITLE
remove custom log message editing (closes #1545)

### DIFF
--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -13,6 +13,7 @@ import tempfile
 import pathlib
 import shutil
 import os
+import re
 import inspect
 
 import msprime
@@ -54,6 +55,12 @@ class CLIFormatter(logging.Formatter):
     # DEBUG: Write out debug messages for the user/developer.
     def format(self, record):
         if record.name == "py.warnings":
+            if len(record.args) > 0:
+                # trim the ugly warnings.warn message
+                match = re.search(
+                    r"Warning:\s*(.*?)\s*warnings.warn\(", record.args[0], re.DOTALL
+                )
+                record.args = (match.group(1),)
             self._style = logging.PercentStyle("WARNING: %(message)s")
         else:
             if record.levelno == logging.WARNING:

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -13,7 +13,6 @@ import tempfile
 import pathlib
 import shutil
 import os
-import re
 import inspect
 
 import msprime
@@ -55,11 +54,6 @@ class CLIFormatter(logging.Formatter):
     # DEBUG: Write out debug messages for the user/developer.
     def format(self, record):
         if record.name == "py.warnings":
-            # trim the ugly warnings.warn message
-            match = re.search(
-                r"Warning:\s*(.*?)\s*warnings.warn\(", record.args[0], re.DOTALL
-            )
-            record.args = (match.group(1),)
             self._style = logging.PercentStyle("WARNING: %(message)s")
         else:
             if record.levelno == logging.WARNING:


### PR DESCRIPTION
I looked at this a fair bit, and tried to figure out why the [`LogRecord` object](https://docs.python.org/3/library/logging.html#logrecord-objects) that previously had non-empty `args` now has empty logs, and also how to have a unit test for this, but didn't manage to on both counts.

On the other hand, I don't actually think this code was actually doing anything:
```
$ python3 -m stdpopsim -e slim --slim-scaling-factor 10 HomSap -c chr22 --left 10000000 --right 10010000 -o foo1.ts -d Africa_1T12 AFR:100
Simulation information:
    Engine: slim (4.1)
    Model id: Africa_1T12
    Model description: African population
    Population: number_samples (sampling_time_generations):
        AFR: 100 (0)
Contig Description:
    Contig origin: chr22:10000000-10010000
    Contig length: 10000.0
    Contig ploidy: 2
    Mean recombination rate: 2.1057233894035443e-08
    Mean mutation rate: 2.36e-08
    Genetic map: None

WARNING: /home/peter/projects/popsim-consortium/stdpopsim/stdpopsim/slim_engine.py:1602: SLiMScalingFactorWarning: You're using a scaling factor (10.0). This should give similar results for many situations, but is not equivalent, especially in the presence of selection. When using rescaling, you should be careful---do checks and compare results across different values of the scaling factor.
  warnings.warn(

WARNING: /home/peter/projects/tskit-dev/treestuff_venv/lib/python3.11/site-packages/msprime/ancestry.py:831: TimeUnitsMismatchWarning: The initial_state has time_units=ticks but time is measured in generations in msprime. This may lead to significant discrepancies between the timescales. If you wish to suppress this warning, you can use, e.g., warnings.simplefilter('ignore', msprime.TimeUnitsMismatchWarning)
  warnings.warn(message, TimeUnitsMismatchWarning)
```

The odd "warnings.warn(" lines are merely printing the line in the source code where the warning is raised, but the code was not removing that entirely.