### PR TITLE
Add chromosome ploidy tests to MusMus and PhoSin

### DIFF
--- a/stdpopsim/catalog/MusMus/species.py
+++ b/stdpopsim/catalog/MusMus/species.py
@@ -160,6 +160,7 @@ _species = stdpopsim.Species(
     name="Mus musculus",
     common_name="Mouse",
     genome=_genome,
+    ploidy=_species_ploidy,
     generation_time=0.75,
     population_size=500000,
     citations=[

--- a/stdpopsim/catalog/PhoSin/species.py
+++ b/stdpopsim/catalog/PhoSin/species.py
@@ -131,6 +131,7 @@ _species = stdpopsim.Species(
     name="Phocoena sinus",
     common_name="Vaquita",
     genome=_genome,
+    ploidy=_species_ploidy,
     ##########################
     # Robinson et al. (2022) and Morin et al. (2021) assumed an average
     # generation time of 11.9 years in their analyses/calibrations.

--- a/tests/test_MusMus.py
+++ b/tests/test_MusMus.py
@@ -97,3 +97,33 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize(
+        ["name", "ploidy"],
+        {
+            "1": 2,
+            "2": 2,
+            "3": 2,
+            "4": 2,
+            "5": 2,
+            "6": 2,
+            "7": 2,
+            "8": 2,
+            "9": 2,
+            "10": 2,
+            "11": 2,
+            "12": 2,
+            "13": 2,
+            "14": 2,
+            "15": 2,
+            "16": 2,
+            "17": 2,
+            "18": 2,
+            "19": 2,
+            "X": 2,
+            "Y": 1,
+            "MT": 1,
+        }.items(),
+    )
+    def test_chromosome_ploidy(self, name, ploidy):
+        assert ploidy == self.genome.get_chromosome(name).ploidy

--- a/tests/test_PhoSin.py
+++ b/tests/test_PhoSin.py
@@ -93,3 +93,33 @@ class TestGenomeData(test_species.GenomeTestBase):
     )
     def test_mutation_rate(self, name, rate):
         assert rate == pytest.approx(self.genome.get_chromosome(name).mutation_rate)
+
+    @pytest.mark.parametrize(
+        ["name", "ploidy"],
+        {
+            "1": 2,
+            "2": 2,
+            "3": 2,
+            "4": 2,
+            "5": 2,
+            "6": 2,
+            "7": 2,
+            "8": 2,
+            "9": 2,
+            "10": 2,
+            "11": 2,
+            "12": 2,
+            "13": 2,
+            "14": 2,
+            "15": 2,
+            "16": 2,
+            "17": 2,
+            "18": 2,
+            "19": 2,
+            "20": 2,
+            "21": 2,
+            "X": 2,
+        }.items(),
+    )
+    def test_chromosome_ploidy(self, name, ploidy):
+        assert ploidy == self.genome.get_chromosome(name).ploidy


### PR DESCRIPTION
Addendum to #1619.

These got added prior to updating the test stubs, so were missing QC tests for ploidy.

Also made the species' ploidy explicit in `catalog/*/species.py` for these two species (it was defaulting to the correct value).