### PR TITLE
SLiM population size trajectory adjustment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@
 
 - Factor of two error fixed in HomSap/Gamma_K17 DFE (:user:`RyanGutenkunst`, :pr:`1478`)
 
+- Discretization for exponential growth using the SLiM engine led to the final size
+  in growing/declining populations not matching (by a small amount) what is listed
+  in the model; improved discretization scheme (:user:`petrelharp`, :pr:`1622`)
+
 **Breaking changes**:
 
 - The `time_units` attribute of tree sequence metadata is now set to "generations"

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -524,7 +524,7 @@ _slim_main = """
 
     // Sample individuals.
     for (i in 0:(ncol(sampling_episodes)-1)) {
-        pop = drop(sampling_episodes[0,i]);
+        pop = drop(asInteger(sampling_episodes[0,i]));
         n = sampling_episodes[1,i];
         g = time_to_tick(sampling_episodes[2,i]);
 
@@ -671,24 +671,24 @@ _slim_debug_output = """
 // This is for development purposes, and the format of this metadata
 // is subject to change or may even be removed!
 1 first() {
-	if (verbosity >= 3) {
-		metadata.setValue("population_sizes", Dictionary());
-	}
+    if (verbosity >= 3) {
+        metadata.setValue("population_sizes", Dictionary());
+    }
 }
 
 1: late() {
-	if (verbosity >= 3) {
-		popsizes = metadata.getValue("population_sizes");
-		for (pop in sim.subpopulations) {
-			traj = popsizes.getValue(pop.name);
-			if (isNULL(traj)) {
-				traj = Dictionary();
-				popsizes.setValue(pop.name, traj);
-			}
-			traj.setValue("t", c(traj.getValue("t"), community.tick));
-			traj.setValue("N", c(traj.getValue("N"), pop.individualCount));
-		}
-	}
+    if (verbosity >= 3) {
+        popsizes = metadata.getValue("population_sizes");
+        for (pop in sim.subpopulations) {
+            traj = popsizes.getValue(pop.name);
+            if (isNULL(traj)) {
+                traj = Dictionary();
+                popsizes.setValue(pop.name, traj);
+            }
+            traj.setValue("t", c(traj.getValue("t"), community.tick));
+            traj.setValue("N", c(traj.getValue("N"), pop.individualCount));
+        }
+    }
 }
 
 """
@@ -966,7 +966,7 @@ def slim_makescript(
             # SLiM simulates a diploid population, so rescale population size
             # depending on contig ploidy. If/when the SLiM simulation is
             # converted to a haploid model, this rescaling should be removed.
-            N[i, j] = (pop.end_size * contig.ploidy / 2)
+            N[i, j] = pop.end_size * contig.ploidy / 2
             growth_rates[i, j] = pop.growth_rate
 
     admixture_pulses = []

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -92,7 +92,9 @@ initialize() {
 
 
 _slim_lower = """
-    defineConstant("N", asInteger(_N/Q));
+    // Note: these are floats because rounding causes error in population
+    // growth: exp(round(x)*r*t) != round(exp(x*r*t))
+    defineConstant("N", _N/Q);
 
     initializeTreeSeq(timeUnit="generations");
     initializeRecombinationRate(recombination_rates, recombination_ends);
@@ -138,6 +140,8 @@ function (integer)epoch(integer G, integer $g) {
 }
 
 // Return the population size of pop at generation g.
+// This function returns values consistent with the continuous-time
+// msprime model, not taking into account discretization effects.
 function (integer)pop_size_at(integer G, integer$ pop, integer$ g) {
     e = epoch(G, g);
     N0 = N[e,pop];
@@ -146,14 +150,14 @@ function (integer)pop_size_at(integer G, integer$ pop, integer$ g) {
         N_g = N0;
     } else {
         g_diff = g - G[e-1];
-        N_g = asInteger(round(N0*exp(r*g_diff)));
+        N_g = N0*exp(r*g_diff);
     }
-    return N_g;
+    return asInteger(round(N_g));
 }
 
-// Return the number of generations that separate t0 and t1.
-function (integer)gdiff(numeric$ t0, numeric t1) {
-    return asInteger(round((t0-t1)/generation_time/Q));
+// Return the tick number for a given number of years ago.
+function (integer)time_to_tick(numeric t) {
+    return G0 - asInteger(t/generation_time/Q);
 }
 
 // Output tree sequence file and end the simulation.
@@ -254,9 +258,9 @@ _slim_main = """
     // Initial populations.
     for (i in 0:(num_populations-1)) {
         if (N[0,i] > 0) {
-            check_size(i, N[0,i], community.tick);
-            dbg("p = sim.addSubpop("+i+", "+N[0,i]+");");
-            p = sim.addSubpop(i, N[0,i]);
+            check_size(i, asInteger(round(N[0,i])), community.tick);
+            dbg("p = sim.addSubpop("+i+", "+asInteger(round(N[0,i]))+");");
+            p = sim.addSubpop(i, asInteger(round(N[0,i])));
             dbg("p.name = '"+pop_names[i]+"';");
             p.name = pop_names[i];
         }
@@ -270,7 +274,7 @@ _slim_main = """
     i = 0;
     for (j in 0:(num_populations-1)) {
         for (k in 0:(num_populations-1)) {
-            if (j==k | N[i,j] == 0 | N[i,k] == 0) {
+            if (j==k | N[i,j] < 1 | N[i,k] < 1) {
                 next;
             }
 
@@ -282,11 +286,11 @@ _slim_main = """
     }
 
     // The end of the burn-in is the starting tick, and corresponds to
-    // time T_start. All remaining events are relative to this tick.
-    N_max = max(N[0,0:(num_populations-1)]);
-    G_start = community.tick + asInteger(round(burn_in * N_max));
-    T_start = max(_T);
-    G = G_start + gdiff(T_start, _T);
+    // tick G_start. All remaining events are relative to this tick.
+    N_max = asInteger(round(max(N[0,0:(num_populations-1)])));
+    G_start = 1 + asInteger(round(burn_in * N_max));
+    defineConstant("G0", asInteger(max(_T) / generation_time / Q + G_start));
+    G = time_to_tick(_T);
     G_end = max(G);
 
     /*
@@ -307,15 +311,15 @@ _slim_main = """
                 n_checkpoints = n_checkpoints + 1;
 
                 // Unconditionally save the state before the mutation is drawn.
-                g = G_start + gdiff(T_start, drawn_mutations[0,i]);
+                g = time_to_tick(drawn_mutations[0,i]);
                 community.registerLateEvent(NULL, "{save();}", g, g);
             }
         }
     }
     if (length(condition_on_allele_frequency) > 0) {
         for (i in 0:(ncol(condition_on_allele_frequency)-1)) {
-            g_start = G_start + gdiff(T_start, condition_on_allele_frequency[0,i]);
-            g_end = G_start + gdiff(T_start, condition_on_allele_frequency[1,i]);
+            g_start = time_to_tick(condition_on_allele_frequency[0,i]);
+            g_end = time_to_tick(condition_on_allele_frequency[1,i]);
             mut_type = asInteger(condition_on_allele_frequency[2,i]);
             pop_id = asInteger(condition_on_allele_frequency[3,i]);
             op = op_types[asInteger(drop(condition_on_allele_frequency[4,i]))];
@@ -337,10 +341,10 @@ _slim_main = """
     // Split events.
     if (length(subpopulation_splits) > 0 ) {
         for (i in 0:(ncol(subpopulation_splits)-1)) {
-            g = G_start + gdiff(T_start, subpopulation_splits[0,i]);
-            newpop = drop(subpopulation_splits[1,i]);
-            size = asInteger(subpopulation_splits[2,i] / Q);
-            oldpop = subpopulation_splits[3,i];
+            g = time_to_tick(subpopulation_splits[0,i]);
+            newpop = asInteger(drop(subpopulation_splits[1,i]));
+            size = asInteger(round(subpopulation_splits[2,i] / Q));
+            oldpop = asInteger(subpopulation_splits[3,i]);
             check_size(newpop, size, g);
             community.registerLateEvent(NULL,
                 "{dbg(self.source); " +
@@ -357,22 +361,21 @@ _slim_main = """
             for (j in 0:(num_populations-1)) {
                 // Change population size if this hasn't already been taken
                 // care of by sim.addSubpop() or sim.addSubpopSplit().
-                if (N[i,j] != N[i-1,j] & N[i-1,j] != 0) {
-                    check_size(j, N[i,j], g);
+                if ((N[i,j] != N[i-1,j] | growth_rates[i-1,j] != 0) & N[i-1,j] >= 1) {
+                    check_size(j, asInteger(N[i,j]), g);
                     community.registerLateEvent(NULL,
                         "{dbg(self.source); " +
-                        "p"+j+".setSubpopulationSize("+N[i,j]+");}",
+                        "p"+j+".setSubpopulationSize("+asInteger(round(N[i,j]))+");}",
                         g, g);
                 }
 
                 if (growth_rates[i,j] != 0) {
                     growth_phase_start = g+1;
-                    if (i == num_epochs-1) {
-                        growth_phase_end = G[i];
-                    } else {
-                        // We already registered a size change at tick G[i].
-                        growth_phase_end = G[i] - 1;
-                    }
+                    growth_phase_end = G[i] - 1;
+                    // this is the number of ticks that the pop will grow for
+                    growth_phase_ticks = growth_phase_end - growth_phase_start;
+                    // but this is the amount of continuous time the pop model grows for
+                    growth_phase_length = growth_phase_ticks + 1;
 
                     if (growth_phase_start >= growth_phase_end) {
                         // Demographic models could have duplicate epoch times,
@@ -386,7 +389,7 @@ _slim_main = """
                     check_size(j, N_growth_phase_end, growth_phase_end);
 
                     N0 = N[i,j];
-                    r = Q * growth_rates[i,j];
+                    r = Q * growth_rates[i,j] * growth_phase_length / growth_phase_ticks;
                     community.registerLateEvent(NULL,
                         "{" +
                             "dbg(self.source); " +
@@ -403,7 +406,7 @@ _slim_main = """
         for (i in 1:(num_epochs-1)) {
             for (j in 0:(num_populations-1)) {
                 for (k in 0:(num_populations-1)) {
-                    if (j==k | N[i,j] == 0 | N[i,k] == 0) {
+                    if (j==k | N[i,j] < 1 | N[i,k] < 1) {
                         next;
                     }
 
@@ -426,7 +429,7 @@ _slim_main = """
     // Admixture pulses.
     if (length(admixture_pulses) > 0 ) {
         for (i in 0:(ncol(admixture_pulses)-1)) {
-            g = G_start + gdiff(T_start, admixture_pulses[0,i]);
+            g = time_to_tick(admixture_pulses[0,i]);
             dest = asInteger(admixture_pulses[1,i]);
             src = asInteger(admixture_pulses[2,i]);
             rate = admixture_pulses[3,i];
@@ -444,7 +447,7 @@ _slim_main = """
     // Draw mutations.
     if (length(drawn_mutations) > 0) {
         for (i in 0:(ncol(drawn_mutations)-1)) {
-            g = G_start + gdiff(T_start, drawn_mutations[0,i]);
+            g = time_to_tick(drawn_mutations[0,i]);
             mut_type = asInteger(drawn_mutations[1,i]);
             pop_id = asInteger(drawn_mutations[2,i]);
             coordinate = asInteger(drawn_mutations[3,i]);
@@ -458,8 +461,8 @@ _slim_main = """
     // Setup fitness callbacks.
     if (length(fitness_callbacks) > 0) {
         for (i in 0:(ncol(fitness_callbacks)-1)) {
-            g_start = G_start + gdiff(T_start, fitness_callbacks[0,i]);
-            g_end = G_start + gdiff(T_start, fitness_callbacks[1,i]);
+            g_start = time_to_tick(fitness_callbacks[0,i]);
+            g_end = time_to_tick(fitness_callbacks[1,i]);
             mut_type = asInteger(fitness_callbacks[2,i]);
             pop_id = asInteger(fitness_callbacks[3,i]);
             selection_coeff = Q * fitness_callbacks[4,i];
@@ -523,7 +526,7 @@ _slim_main = """
     for (i in 0:(ncol(sampling_episodes)-1)) {
         pop = drop(sampling_episodes[0,i]);
         n = sampling_episodes[1,i];
-        g = G_start + gdiff(T_start, sampling_episodes[2,i]);
+        g = time_to_tick(sampling_episodes[2,i]);
 
         // Check that there will be at least n individuals for sampling.
         N_g = pop_size_at(G, pop, g);
@@ -662,6 +665,30 @@ _slim_debug_output = """
         );
         metadata.setValue("mutationRates", mr);
     }
+}
+
+// Save populations size information in tree sequence metadata
+// This is for development purposes, and the format of this metadata
+// is subject to change or may even be removed!
+1 first() {
+	if (verbosity >= 3) {
+		metadata.setValue("population_sizes", Dictionary());
+	}
+}
+
+1: late() {
+	if (verbosity >= 3) {
+		popsizes = metadata.getValue("population_sizes");
+		for (pop in sim.subpopulations) {
+			traj = popsizes.getValue(pop.name);
+			if (isNULL(traj)) {
+				traj = Dictionary();
+				popsizes.setValue(pop.name, traj);
+			}
+			traj.setValue("t", c(traj.getValue("t"), community.tick));
+			traj.setValue("N", c(traj.getValue("N"), pop.individualCount));
+		}
+	}
 }
 
 """
@@ -932,14 +959,14 @@ def slim_makescript(
     T = [round(e.start_time * demographic_model.generation_time) for e in epochs]
     migration_matrices = [e.migration_matrix for e in epochs]
 
-    N = np.empty(shape=(dd.num_populations, len(epochs)), dtype=int)
+    N = np.empty(shape=(dd.num_populations, len(epochs)), dtype=float)
     growth_rates = np.empty(shape=(dd.num_populations, len(epochs)), dtype=float)
     for j, epoch in enumerate(epochs):
         for i, pop in enumerate(epoch.populations):
             # SLiM simulates a diploid population, so rescale population size
             # depending on contig ploidy. If/when the SLiM simulation is
             # converted to a haploid model, this rescaling should be removed.
-            N[i, j] = int(pop.end_size * contig.ploidy / 2)
+            N[i, j] = (pop.end_size * contig.ploidy / 2)
             growth_rates[i, j] = pop.growth_rate
 
     admixture_pulses = []
@@ -1302,7 +1329,8 @@ def slim_makescript(
     printsc()
 
     # Population sizes.
-    printsc("    // Population sizes in each epoch.")
+    printsc("    // Population sizes at the beginning of each epoch")
+    printsc("    // (will be rounded).")
     printsc(
         "    _N = "
         + matrix2str(

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -842,12 +842,12 @@ class TestWarningsAndErrors:
         model = stdpopsim.PiecewiseConstantSize(100)
         samples = {"pop_0": 1}
 
-        with pytest.raises(stdpopsim.SLiMException):
+        with pytest.raises(stdpopsim.SLiMException, match="is zero at tick 1"):
             engine.simulate(
                 demographic_model=model,
                 contig=contig,
                 samples=samples,
-                slim_scaling_factor=200,
+                slim_scaling_factor=300,
                 dry_run=True,
             )
 
@@ -882,7 +882,7 @@ class TestWarningsAndErrors:
                 demographic_model=model,
                 contig=contig,
                 samples=samples,
-                slim_scaling_factor=200,
+                slim_scaling_factor=300,
                 dry_run=True,
             )
 
@@ -3077,6 +3077,79 @@ class TestSelectionCoeffFromMutation:
             stdpopsim.selection_coeff_from_mutation("foo", next(ts.mutations()))
         with pytest.raises(ValueError, match="must be a"):
             stdpopsim.selection_coeff_from_mutation(ts, "bar")
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="SLiM not available on windows")
+class TestPopSizes:
+    """
+    Test that population sizes are set correctly.
+    Thanks to discretization artifacts, this is a bit tricky in phases
+    of exponential growth: suppose we are growing at rate r for the
+    time period [t, t+T), starting from size x. In discrete time, at
+    time t we set the size to x; then subsequently we re-set the size
+    only T-1 times. (One consideration is that we re-set sizes in `late`,
+    which doesn't take effect until the next tick, so a reset in the final
+    time step has no effect.) This means that the continuous-time msprime model
+    that we base this on is growing for total time T, but the SLiM model grows
+    in T-1 time steps. Furthermore, we'd like both the final and initial sizes
+    to be exactly what they are supposed to be. This amounts to approximating
+    exp(r*t) over the interval [0,T] by exp(r*t*T/(T-1)). Probably something
+    nicer could be done, but this is close. The approximation is better for
+    smaller growth rates.
+    """
+
+    def verify_pop_sizes(self, model, samples, generation_time=1):
+        species = stdpopsim.get_species("HomSap")
+        contig = species.get_contig("chr17", left=1e7, right=1e7 + 1e4)
+        engine = stdpopsim.get_engine("slim")
+        sp_model = stdpopsim.DemographicModel(
+            id="test",
+            description="foo",
+            long_description="fooooooo",
+            generation_time=generation_time,
+            model=model,
+        )
+        ts = engine.simulate(
+            sp_model, contig, samples, seed=123, slim_burn_in=0.0, verbosity=3
+        )
+        slim_sizes = ts.metadata["SLiM"]["user_metadata"]["population_sizes"][0]
+        dd = model.debug()
+        T = ts.metadata["SLiM"]["cycle"]
+        for pop in slim_sizes:
+            k = [x.name for x in model.populations].index(pop)
+            pop_t = np.array(slim_sizes[pop][0]["t"])
+            pop_N = np.array(slim_sizes[pop][0]["N"])
+            dd_N = dd.population_size_trajectory(T - pop_t)[:, k]
+            np.testing.assert_allclose(pop_N, dd_N, rtol=0.01)
+
+    @pytest.mark.parametrize("generation_time", [1, 3])
+    def test_pop_growth(self, generation_time):
+        model = msprime.Demography()
+        model.add_population(initial_size=100, name="pop_0", growth_rate=0.003)
+        model.add_population_parameters_change(time=100, growth_rate=0.0)
+        samples = {"pop_0": 100}
+        self.verify_pop_sizes(model, samples, generation_time=generation_time)
+
+    @pytest.mark.parametrize("generation_time", [1, 3])
+    def test_pop_resize(self, generation_time):
+        model = msprime.Demography()
+        model.add_population(initial_size=100, name="pop_0")
+        model.add_population_parameters_change(time=10, initial_size=75)
+        model.add_population_parameters_change(time=20, initial_size=150)
+        samples = {"pop_0": 100}
+        self.verify_pop_sizes(model, samples, generation_time=generation_time)
+
+    @pytest.mark.parametrize("generation_time", [1, 3])
+    def test_pop_split(self, generation_time):
+        model = msprime.Demography()
+        model.add_population(initial_size=100, name="pop_0")
+        model.add_population(initial_size=70, name="pop_1", growth_rate=0.001)
+        model.add_population(initial_size=130, name="pop_2", growth_rate=-0.001)
+        model.add_population_split(
+            time=150, derived=["pop_1", "pop_2"], ancestral="pop_0"
+        )
+        samples = {"pop_1": 70, "pop_2": 130}
+        self.verify_pop_sizes(model, samples, generation_time=generation_time)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="SLiM not available on windows")

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -3125,11 +3125,14 @@ class TestPopSizes:
             k = [x.name for x in model.populations].index(pop)
             pop_t = np.array(slim_sizes[pop][0]["t"])
             pop_N = np.array(slim_sizes[pop][0]["N"])
+            # Mostly we expect dd_N and pop_N to be close; however, time
+            # discretization artifacts and the fact that addSubpopSplit
+            # is recorded by the logging differently than setSubpopulationSize
+            # means we need to check the adjacent time interval as well.
             dd_N = dd.population_size_trajectory(np.floor((T - pop_t) * Q))[:, k] / Q
             dd_N1 = (
                 dd.population_size_trajectory(np.floor((T - pop_t + 1) * Q))[:, k] / Q
             )
-            # np.testing.assert_allclose(pop_N, dd_N, rtol=0.01)
             assert np.all(
                 np.logical_or(
                     np.isclose(pop_N, dd_N, rtol=0.01),


### PR DESCRIPTION
We did not have robust checks for SLiM's population size trajectories. That's a good bit better now (although we could probably think of more complicated demographic scenarios to check). Issues I uncovered:
- we were effectively computing population sizes during growth phases by doing
   `round(round(exp(-r*t)*final_size) * exp(r*t))`; since `round` and `exp` don't commute,
  this is not ideal; so I removed the inner `round` (storing initial sizes as floats not ints)
- since population sizes are set in `late()` but these don't take effect until the next time step, the final population sizes was not what you'd think (it was more like what it would have been in the previous time step); I've changed the growth rate used by SLiM slightly so that they agree. A better fix might be to do all that stuff in `early()` but that's a giant can of worms with unknown consequences in everything else, so not going there.

There's definitely the possibility that I've majorly messed something up, so someone should have a very careful review of this.

Closes #1589.