### PR TITLE
Squashing unintended test warnings due to model recombination rate

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -438,7 +438,9 @@ class TestRecombinationRates:
         contig = species.get_contig(length=100)
         assert model.recombination_rate != contig.recombination_map.mean_rate
         contig = species.get_contig(
-            length=100, recombination_rate=model.recombination_rate
+            length=100,
+            mutation_rate=model.mutation_rate,
+            recombination_rate=model.recombination_rate,
         )
         assert model.recombination_rate == contig.recombination_map.mean_rate
 


### PR DESCRIPTION
As triggered by https://github.com/popsim-consortium/stdpopsim/issues/1598#issuecomment-2551983948 I looked into the test warnings due to model specific mutation and recombination rate.

One test warning was not intended, so I fixed that.

I am a bit confused what to do with these ones:

```
> python3 -m pytest tests/test_models.py
========================================================================= test session starts =========================================================================
platform darwin -- Python 3.12.7, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/ggorjanc/Storages/GitBox/popsim/stdpopsim/stdpopsim_fork
configfile: setup.cfg
plugins: xdist-3.6.1
4 workers [275 items]   
............................................................................................................................................................... [ 57%]
....................................................................................................................                                            [100%]
========================================================================== warnings summary ===========================================================================
tests/test_models.py::TestBosTauHolsteinFriesian_1M13::test_simulation_runs
  /Users/ggorjanc/Storages/GitBox/popsim/stdpopsim/stdpopsim_fork/stdpopsim/engines.py:125: UserWarning: The demographic model has recombination rate 1e-08, but this simulation used the contig's recombination rate 0.0. Patterns of linkage may be different than expected for this species. For details see documentation at https://popsim-consortium.github.io/stdpopsim-docs/stable/tutorial.html
    warnings.warn(

tests/test_models.py::TestBosTauAngus_1B16::test_simulation_runs
  /Users/ggorjanc/Storages/GitBox/popsim/stdpopsim/stdpopsim_fork/stdpopsim/engines.py:125: UserWarning: The demographic model has recombination rate 5e-09, but this simulation used the contig's recombination rate 0.0. Patterns of linkage may be different than expected for this species. For details see documentation at https://popsim-consortium.github.io/stdpopsim-docs/stable/tutorial.html
    warnings.warn(

tests/test_models.py::TestBosTauHolsteinFriesian_1B16::test_simulation_runs
  /Users/ggorjanc/Storages/GitBox/popsim/stdpopsim/stdpopsim_fork/stdpopsim/engines.py:125: UserWarning: The demographic model has recombination rate 3.66e-09, but this simulation used the contig's recombination rate 0.0. Patterns of linkage may be different than expected for this species. For details see documentation at https://popsim-consortium.github.io/stdpopsim-docs/stable/tutorial.html
    warnings.warn(

tests/test_models.py::TestBosTauFleckvieh_1B16::test_simulation_runs
  /Users/ggorjanc/Storages/GitBox/popsim/stdpopsim/stdpopsim_fork/stdpopsim/engines.py:125: UserWarning: The demographic model has recombination rate 3.89e-09, but this simulation used the contig's recombination rate 0.0. Patterns of linkage may be different than expected for this species. For details see documentation at https://popsim-consortium.github.io/stdpopsim-docs/stable/tutorial.html
    warnings.warn(

tests/test_models.py::TestBosTauJersey_1B16::test_simulation_runs
  /Users/ggorjanc/Storages/GitBox/popsim/stdpopsim/stdpopsim_fork/stdpopsim/engines.py:125: UserWarning: The demographic model has recombination rate 4.58e-09, but this simulation used the contig's recombination rate 0.0. Patterns of linkage may be different than expected for this species. For details see documentation at https://popsim-consortium.github.io/stdpopsim-docs/stable/tutorial.html
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 275 passed, 5 warnings in 1.06s ===================================================================
```

As indicated by @nspope these seem to come from mitochondria (that have rec rate of 0), but I am getting lost in the code of how these tests are autogenerated and called. Can anyone suggest what I could do to capture these tests - they are making noise that we probably don't want?
