### PR TITLE
add seeds to slim tests; closes #1201

### DIFF
--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -1149,6 +1149,7 @@ class TestRecombinationMap(PiecewiseConstantSizeMixin):
             samples=samples,
             slim_burn_in=0.1,
             verbosity=3,
+            seed=888,
         )
         self.verify_recombination_map(contig, ts)
 
@@ -1171,6 +1172,7 @@ class TestRecombinationMap(PiecewiseConstantSizeMixin):
             samples=samples,
             slim_burn_in=0.1,
             verbosity=3,
+            seed=456,
         )
         self.verify_recombination_map(contig, ts)
         assert list(ts.breakpoints()) == [0.0, midpoint, contig.length]
@@ -1526,6 +1528,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             verbosity=3,  # to get metadata output
+            seed=135,
         )
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
@@ -1545,6 +1548,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             verbosity=3,  # to get metadata output
+            seed=246,
         )
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
@@ -1562,6 +1566,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             verbosity=3,  # to get metadata output
+            seed=357,
         )
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
@@ -1596,6 +1601,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             verbosity=3,  # to get metadata output
+            seed=468,
         )
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
@@ -1624,6 +1630,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             slim_scaling_factor=10,
             slim_burn_in=0.1,
             verbosity=3,  # to get metadata output
+            seed=579,
             _recap_and_rescale=False,
         )
         assert ts.num_sites > 0
@@ -1640,6 +1647,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             slim_scaling_factor=10,
             slim_burn_in=0.1,
             verbosity=3,
+            seed=147,
             _recap_and_rescale=False,
         )
         assert ts.num_sites == 0
@@ -1658,6 +1666,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             slim_scaling_factor=10,
             slim_burn_in=0.1,
             verbosity=3,
+            seed=258,
             _recap_and_rescale=False,
         )
         assert ts.num_sites == 0
@@ -1676,6 +1685,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             slim_scaling_factor=Q,
             slim_burn_in=0.1,
             verbosity=3,
+            seed=369,
             _recap_and_rescale=False,
         )
         ge_types = self.slim_metadata_key0(
@@ -1708,6 +1718,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             slim_scaling_factor=Q,
             slim_burn_in=0.1,
             verbosity=3,
+            seed=470,
             _recap_and_rescale=False,
         )
         ge_types = self.slim_metadata_key0(
@@ -1757,6 +1768,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             verbosity=3,  # to get metadata output
+            seed=159,
         )
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
@@ -1837,6 +1849,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             verbosity=3,  # to get metadata output
+            seed=260,
         )
         assert len(ts.metadata["stdpopsim"]["DFEs"]) == len(contig.dfe_list) + 1
         # slim mutation type IDs with dominance coeff lists:
@@ -2220,6 +2233,7 @@ class TestAlleleFrequencyConditioning(PiecewiseConstantSizeMixin):
             extended_events=extended_events,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
+            seed=321,
             _recap_and_rescale=False,
         )
         assert ts.num_mutations == 1
@@ -2252,6 +2266,7 @@ class TestAlleleFrequencyConditioning(PiecewiseConstantSizeMixin):
             extended_events=extended_events,
             slim_scaling_factor=10,
             slim_burn_in=0.1,
+            seed=432,
             _recap_and_rescale=False,
         )
         assert ts.num_mutations == 0
@@ -2478,6 +2493,7 @@ class TestChangeMutationFitness(PiecewiseConstantSizeMixin):
             contig=contig,
             samples=self.samples,
             extended_events=extended_events,
+            seed=543,
         )
         referenced_dfe = ts.metadata["stdpopsim"]["DFEs"][1]
         assert referenced_dfe["id"] == "one"
@@ -2694,6 +2710,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
                     slim_burn_in=1,
                     logfile=logfile,
                     logfile_interval=1,
+                    seed=654,
                 )
                 in_sweep, outside_sweep, _ = self._fitness_per_generation(
                     logfile=logfile,
@@ -2737,6 +2754,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
                 slim_burn_in=1,
                 logfile=logfile,
                 logfile_interval=1,
+                seed=654,
             )
             in_sweep, outside_sweep, rejections = self._fitness_per_generation(
                 logfile=logfile,
@@ -2784,6 +2802,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
                 slim_burn_in=1,
                 logfile=logfile,
                 logfile_interval=1,
+                seed=765,
             )
             in_sweep, outside_sweep, rejections = self._fitness_per_generation(
                 logfile=logfile,
@@ -2865,6 +2884,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
                 slim_burn_in=1,
                 logfile=logfile,
                 logfile_interval=1,
+                seed=876,
             )
             p0_in_sweep, p0_outside_sweep, _ = self._fitness_per_generation(
                 logfile=logfile,
@@ -2917,6 +2937,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
             slim_burn_in=1,
             logfile=logfile,
             logfile_interval=1,
+            seed=987,
         )
         p0_in_sweep, p0_outside_sweep, _ = self._fitness_per_generation(
             logfile=logfile,
@@ -2972,6 +2993,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
             slim_burn_in=1,
             logfile=logfile,
             logfile_interval=1,
+            seed=531,
         )
         for i, _ in enumerate(pop_ids):
             in_sweep, outside_sweep, _ = self._fitness_per_generation(
@@ -3024,6 +3046,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
             slim_burn_in=1,
             logfile=logfile,
             logfile_interval=1,
+            seed=642,
         )
         p0_in_sweep, p0_outside_sweep, _ = self._fitness_per_generation(
             logfile=logfile,
@@ -3071,6 +3094,7 @@ class TestSelectionCoeffFromMutation:
                 contig=contig,
                 samples=self.samples,
                 slim_burn_in=10,
+                seed=753,
             )
             is_stacked = [len(m.metadata["mutation_list"]) > 1 for m in ts.mutations()]
             if any(is_stacked):
@@ -3093,6 +3117,7 @@ class TestSelectionCoeffFromMutation:
                 demographic_model=self.model,
                 contig=contig,
                 samples=self.samples,
+                seed=864,
             )
             if ts.num_mutations > 0:
                 break
@@ -3109,6 +3134,7 @@ class TestSelectionCoeffFromMutation:
                 demographic_model=self.model,
                 contig=contig,
                 samples=self.samples,
+                seed=975,
             )
             if ts.num_mutations > 0:
                 break
@@ -3256,7 +3282,7 @@ class TestPloidy:
         contig = stdpopsim.Contig.basic_contig(length=1000, ploidy=2)
         model = stdpopsim.PiecewiseConstantSize(N)
         with caplog.at_level(logging.DEBUG):
-            engine.simulate(model, contig, samples={"pop_0": 2}, verbosity=2)
+            engine.simulate(model, contig, samples={"pop_0": 2}, verbosity=2, seed=9)
         log_str = " ".join([rec.getMessage() for rec in caplog.records])
         # match: "1: p = sim.addSubpop(0, <SLiM population size>);"
         extract_ne = re.compile(".+1: p = sim.addSubpop\\(0, ([0-9]+)\\).+")
@@ -3294,7 +3320,7 @@ class TestPloidy:
         engine = stdpopsim.get_engine("slim")
         for ploidy in [1, 2]:
             contig = stdpopsim.Contig.basic_contig(length=1000, ploidy=ploidy)
-            ts = engine.simulate(model, contig, samples={"pop_0": 2})
+            ts = engine.simulate(model, contig, samples={"pop_0": 2}, seed=8)
             assert ts.num_individuals == 2
             assert ts.num_samples == 2 * ploidy
             individual = ts.tables.nodes.individual
@@ -3306,7 +3332,7 @@ class TestPloidy:
         model = stdpopsim.PiecewiseConstantSize(N)
         engine = stdpopsim.get_engine("slim")
         contig = stdpopsim.Contig.basic_contig(length=1000, ploidy=2)
-        ts = engine.simulate(model, contig, samples={"pop_0": 3})
+        ts = engine.simulate(model, contig, samples={"pop_0": 3}, seed=7)
         ts_hap = stdpopsim.utils.haploidize_individuals(ts)
         assert ts_hap.num_individuals == ts.num_individuals * 2
         for i, j in zip(ts.samples(), ts_hap.samples()):


### PR DESCRIPTION
I'm making these not stochastic; the argument here is that if there's a failure in a *stochastic* test it can be quite hard to track down.