### PR TITLE
Squash unintended recombination rate test warnings

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,10 +34,19 @@ class DemographicModelTestMixin:
 
     @pytest.mark.filterwarnings("ignore:.*Zigzag_1S14.*:UserWarning")
     def test_simulation_runs(self):
-        # With a recombination_map of None, we simulate a coalescent without
-        # recombination in msprime, with mutation rate equal to rate from model.
+        # When model has no specific recombination rate,
+        #   we simulate coalescent without recombination.
+        # Otherwise, we use the rate from the model.
+        # We use mutation rate equal to rate from model
+        #  (or species when the model does not have one.
+        if self.model.recombination_rate is None:
+            recombination_rate = 0
+        else:
+            recombination_rate = self.model.recombination_rate
         contig = stdpopsim.Contig.basic_contig(
-            length=100, mutation_rate=self.model.mutation_rate
+            length=100,
+            mutation_rate=self.model.mutation_rate,
+            recombination_rate=recombination_rate,
         )
         # Generate vector with 2 samples for each pop with sampling enabled
         samples = {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,11 +34,10 @@ class DemographicModelTestMixin:
 
     @pytest.mark.filterwarnings("ignore:.*Zigzag_1S14.*:UserWarning")
     def test_simulation_runs(self):
-        # When model has no specific recombination rate,
-        #   we simulate coalescent without recombination.
-        # Otherwise, we use the rate from the model.
-        # We use mutation rate equal to rate from model
-        #  (or species when the model does not have one.
+        # For the purposes of testing the model, here we use the
+        # model's mutation and recombination rate if it has them;
+        # otherwise, we use zero recombination and the species
+        # mutation rate.
         if self.model.recombination_rate is None:
             recombination_rate = 0
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -438,7 +438,9 @@ class TestRecombinationRates:
         contig = species.get_contig(length=100)
         assert model.recombination_rate != contig.recombination_map.mean_rate
         contig = species.get_contig(
-            length=100, recombination_rate=model.recombination_rate
+            length=100,
+            mutation_rate=model.mutation_rate,
+            recombination_rate=model.recombination_rate,
         )
         assert model.recombination_rate == contig.recombination_map.mean_rate
 


### PR DESCRIPTION
Following upon https://github.com/popsim-consortium/stdpopsim/pull/1626 I now figured out that it was not mitochondrion that was causing the errors, but the fact that model tests in `DemographicModelTestMixin:test_simulation_runs` are ran without recombination, which rightly issued the unintended warning when a model has it's specific rec rate.

We test these warnings in `TestRecombinationRates:test_recombination_rate_warning` and `TestRecombinationRates:test_recombination_rate_match` so I provide this fix to get rid of the unintended recombination rate test warnings.