### PR TITLE
adding assembly_name attribute

### DIFF
--- a/stdpopsim/annotations.py
+++ b/stdpopsim/annotations.py
@@ -27,6 +27,9 @@ class Annotation:
     :vartype citations: list of :class:`.Citation`
     :ivar file_pattern: The pattern used to map individual chromosome id strings
         to files
+        :ivar assembly_name: The name of the genome assembly.
+    :vartype assembly_name: str    
+    :ivar str assembly_name: The name of the assembly the annotation is based on
     """
 
     id = attr.ib()
@@ -40,6 +43,7 @@ class Annotation:
     file_pattern = attr.ib()
     annotation_source = attr.ib()
     annotation_type = attr.ib()
+    assembly_name = attr.ib()
 
     def __attrs_post_init__(self):
         self._cache = stdpopsim.CachedData(

--- a/stdpopsim/catalog/AraTha/annotations.py
+++ b/stdpopsim/catalog/AraTha/annotations.py
@@ -27,6 +27,7 @@ _an = stdpopsim.Annotation(
     file_pattern="araport_exons_{id}.txt",
     annotation_source="araport11",
     annotation_type="exon",
+    assembly_name = "TAIR10"
 )
 _species.add_annotations(_an)
 
@@ -56,5 +57,7 @@ _an2 = stdpopsim.Annotation(
     file_pattern="araport_CDS_{id}.txt",
     annotation_source="araport11",
     annotation_type="CDS",
+    assembly_name = "TAIR10"
+
 )
 _species.add_annotations(_an2)

--- a/stdpopsim/catalog/DroMel/annotations.py
+++ b/stdpopsim/catalog/DroMel/annotations.py
@@ -28,6 +28,7 @@ _an = stdpopsim.Annotation(
     file_pattern="flybase_exons_{id}.txt",
     annotation_source="FlyBase",
     annotation_type="exon",
+    assembly_name="BDGP6.32.51",
 )
 _species.add_annotations(_an)
 
@@ -57,5 +58,6 @@ _an2 = stdpopsim.Annotation(
     file_pattern="flybase_CDS_{id}.txt",
     annotation_source="FlyBase",
     annotation_type="CDS",
+    assembly_name="BDGP6.32.51",
 )
 _species.add_annotations(_an2)

--- a/stdpopsim/catalog/HomSap/annotations.py
+++ b/stdpopsim/catalog/HomSap/annotations.py
@@ -27,6 +27,7 @@ _an = stdpopsim.Annotation(
     file_pattern="ensembl_havana_exons_{id}.txt",
     annotation_source="ensembl_havana",
     annotation_type="exon",
+    assembly_name = "GRCh38.p13"
 )
 _species.add_annotations(_an)
 
@@ -56,5 +57,6 @@ _an2 = stdpopsim.Annotation(
     file_pattern="ensembl_havana_CDS_{id}.txt",
     annotation_source="ensembl_havana",
     annotation_type="CDS",
+    assembly_name = "GRCh38.p13",
 )
 _species.add_annotations(_an2)

--- a/stdpopsim/catalog/HomSap/genetic_maps.py
+++ b/stdpopsim/catalog/HomSap/genetic_maps.py
@@ -31,6 +31,7 @@ _gm = stdpopsim.GeneticMap(
     sha256="80f22d9e6cb0e497074ed1bc277e765fa9d8e22f21b2f66c3b10286520f6b68f",
     file_pattern="genetic_map_GRCh37_chr{id}.txt",
     citations=[_hapmap2007.because(stdpopsim.CiteReason.GEN_MAP)],
+    assembly_name="GRCh37",
 )
 _species.add_genetic_map(_gm)
 
@@ -60,6 +61,7 @@ _gm = stdpopsim.GeneticMap(
     sha256="497512ed1c0f8a40e9aa13696049a9f8c3cb062e898921cfd7d85ce9d14c4baa",
     file_pattern="genetic_map_Hg38_chr{id}.txt",
     citations=[_hapmap2007.because(stdpopsim.CiteReason.GEN_MAP)],
+    assembly_name="GRCh38.p13",
 )
 _species.add_genetic_map(_gm)
 
@@ -90,6 +92,7 @@ _gm = stdpopsim.GeneticMap(
             reasons={stdpopsim.CiteReason.GEN_MAP},
         )
     ],
+    assembly_name="GRCh36",
 )
 _species.add_genetic_map(_gm)
 
@@ -131,6 +134,7 @@ _gm = stdpopsim.GeneticMap(
             reasons={stdpopsim.CiteReason.GEN_MAP},
         )
     ],
+    assembly_name="GRCh38.p13",
 )
 _species.add_genetic_map(_gm)
 
@@ -223,5 +227,6 @@ e3cf06041c6ffceb29fbc617c86966948203e166c3399d036c95915e3d5ebdcd
                 reasons={stdpopsim.CiteReason.GEN_MAP},
             )
         ],
+        assembly_name="GRCh38.p13",
     )
     _species.add_genetic_map(_gm)

--- a/stdpopsim/catalog/PhoSin/annotations.py
+++ b/stdpopsim/catalog/PhoSin/annotations.py
@@ -27,6 +27,7 @@ _an = stdpopsim.Annotation(
     file_pattern="Phocoena_sinus.mPhoSin1.pri.110_exon_{id}.txt",
     annotation_source="ensembl",
     annotation_type="exon",
+    assembly_name="mPhoSin1.pri",
 )
 _species.add_annotations(_an)
 
@@ -56,5 +57,6 @@ _an2 = stdpopsim.Annotation(
     file_pattern="Phocoena_sinus.mPhoSin1.pri.110_CDS_{id}.txt",
     annotation_source="ensembl",
     annotation_type="CDS",
+    assembly_name="mPhoSin1.pri",
 )
 _species.add_annotations(_an2)

--- a/stdpopsim/genetic_maps.py
+++ b/stdpopsim/genetic_maps.py
@@ -35,6 +35,7 @@ class GeneticMap:
         description=None,
         long_description=None,
         citations=None,
+        assembly_name=None,
     ):
         self.id = id
         self.species = species
@@ -45,6 +46,7 @@ class GeneticMap:
         self.file_pattern = file_pattern
         self.description = description
         self.citations = citations
+        self.assembly_name = assembly_name
 
         self._cache = stdpopsim.CachedData(
             namespace=f"genetic_maps/{self.species.id}/{id}",


### PR DESCRIPTION
Here's a draft solution for #1252

@grahamgower made a patch described here dealing with genetic map intervals that don't match that of the assembly, which will happen. All described further in #719

I've started the process of adding the assembly names to the Annotation and GeneticMap classes, which would facilitate checking that the resources all belong on the same assembly. 

It's hard to write explicit tests for this using the interval information, especially for annotations, because the tests likely won't fail if the annotation intervals are still within the bounds of the (incorrect) assembly. I think this largely comes down to humans being careful to check that the annotation/genetic maps match the assembly. Adding the attribute really just serves as a helpful reminder during the QC process to verify this, and do a liftover if it's wrong.      

If this is the direction we want to go a few more things need to be done.

- Add `assembly_name` to stubs for generating new species in the catalogue
- Finish population the genetic maps and annotations (I think all annotations are done, but should verify) 
- Flesh out documentation about making sure the assemblies match between resources (I belive there's some stuff about this already concerning the liftover process).
- A test or two checking that assembly name matches for Annotation, GeneticMap, and Genome.
OR 
- Add some warnings when the assembly_name doesn't match between the components.
