### PR TITLE
exposed assembly name in catalog docs

### DIFF
--- a/docs/_ext/speciescatalog.py
+++ b/docs/_ext/speciescatalog.py
@@ -699,6 +699,15 @@ class SpeciesCatalogDirective(SphinxDirective):
         # genomes:
         genome_section = nodes.section(ids=[f"sec_catalog_{species.id}_genome"])
         genome_section += nodes.title(text="Genome")
+        genome_section += self.make_field_list(
+            [
+                (
+                    "Genome assembly name",
+                    species.genome.assembly_name,
+                    None,
+                )
+            ]
+        )
         if species.genome.bacterial_recombination is True:
             genome_section += self.make_field_list(
                 [


### PR DESCRIPTION
this PR adds the `assembly_name` as a field of the `Genome` in the catalog docs. when rendered it looks like this:

<img width="429" alt="image" src="https://github.com/user-attachments/assets/58c48c48-71b7-4d4a-969d-7e4b6563970d" />


this PR will close #1651 when merged