### PR TITLE
positive-containing DFE from Zhen et al 2021 (GammaPos_Z21, HomSap and DroMel)

### DIFF
--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -47,12 +47,72 @@ def _HuberDFE():
         description=description,
         long_description=long_description,
         mutation_types=[neutral, negative],
-        proportions=[prop_synonymous, 1 - prop_synonymous],  # LNS = 2.85 x LS
+        proportions=[prop_synonymous, 1 - prop_synonymous],
         citations=citations,
     )
 
 
 _species.add_dfe(_HuberDFE())
+
+
+def _ZhenDFE():
+    id = "GammaPos_H17"
+    description = "Deleterious Gamma DFE with fixed-s beneficials"
+    long_description = """
+    The DFE estimated from D.melanogaster-simulans data estimated in Zhen et al
+    (2021, https://dx.doi.org/10.1101/gr.256636.119).
+    This uses the demographic model and deleterious-only DFE from
+    Huber et al (2017), and then the number of nonsynonymous differences
+    to simulans to estimate a proportion of nonsynonmyous differences
+    and (single) selection coefficient. So, this is the "Gamma_H17" DFE,
+    with some proportion of positive selection with fixed s.
+    """
+    citations = [
+        stdpopsim.Citation(
+            author="Zhen et al.",
+            year=2021,
+            doi="https://dx.doi.org/10.1101/gr.256636.119",
+            reasons={stdpopsim.CiteReason.DFE},
+        )
+    ]
+    neutral = stdpopsim.MutationType()
+    gamma_shape = 0.33  # shape
+    gamma_mean = -3.96e-04  # expected value
+    h = 0.5  # dominance coefficient
+    negative = stdpopsim.MutationType(
+        dominance_coeff=h,
+        distribution_type="g",  # gamma distribution
+        distribution_args=[gamma_mean, gamma_shape],
+    )
+    # p. 2 in supplement says that the total sequence length of synonymous sites LS
+    # related to the total sequence length of nonsynonymous sites LNS
+    # by LNS = 2.85 * LS
+    # so this is 1 / (1 + 2.85) = 0.2597402597402597
+    prop_synonymous = 0.26
+
+    sel_coeff = 10 ** (-4.801)
+    prop_beneficials = 6.75e-4
+    positive = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="f",
+        distribution_args=[sel_coeff],
+    )
+
+    return stdpopsim.DFE(
+        id=id,
+        description=description,
+        long_description=long_description,
+        mutation_types=[neutral, negative, positive],
+        proportions=[
+            prop_synonymous,
+            (1 - prop_synonymous) * (1 - prop_beneficials),
+            (1 - prop_synonymous) * prop_beneficials,
+        ],
+        citations=citations,
+    )
+
+
+_species.add_dfe(_ZhenDFE())
 
 
 def _RagsdaleDFE():

--- a/stdpopsim/catalog/HomSap/dfes.py
+++ b/stdpopsim/catalog/HomSap/dfes.py
@@ -199,7 +199,6 @@ def _KyriazisDFE():
 _species.add_dfe(_KyriazisDFE())
 
 
-
 def _RodriguesDFE():
     id = "PosNeg_R24"
     description = "Deleterious Gamma and Beneficial Exponential DFE"
@@ -295,7 +294,8 @@ def _ZhenDFE():
         distribution_args=[gamma_mean, gamma_shape],
     )
     # p. 2 in supplement says that the total sequence length of synonymous sites LS
-    # related to the total sequence length LNS by LNS = 2.31 * LS
+    # related to the total sequence length of nonsynonymous sites LNS
+    # by LNS = 2.31 * LS
     # so, this is 1 / (1 + 2.31) = 0.3021148036253776
     prop_synonymous = 0.3
 


### PR DESCRIPTION
This is as recommended by @klohmueller over in #1469. It's really just Huber et al's Gamma_H17 except a proportion `p` of the changes are beneficial with coefficient `s`; [the paper](https://genome.cshlp.org/content/31/1/110.abstract) shows that `p` and `s` are highly confounded (and `ps` can be estimated better); but these are the MLE values. These values are using divergence to chimp.

Kirk said:
> For a DFE with positive selection in humans—we could use this one from Table S6 of Zhen et al. (2021). This DFE is for nonsynonymous mutations. We inferred 1.55% of nonsynonymous mutations were positively selected in humans with a s of 0.0001124605. The remaining nonsynonymous mutations came from a DFE for negative selection (parameters for this are in Table S3). The shape parameter is 0.19 and the scale (beta) in terms of s is 0.074.

What I've implemented is this, and I've verified all those parameters above - so, I figure this is actually mostly QC'ed (since Kirk pulled out those numbers and I verified them). So, I'm tempted to just put in the QC code also - but that wouldn't catch coding errors.

*Edit:* I've also added the estimated one for DroMelfrom Table S6 as above.