### PR TITLE
add pos & neg DFE from Rodrigues et al (PosNeg_R24 in HomSap)

### DIFF
--- a/stdpopsim/catalog/HomSap/dfes.py
+++ b/stdpopsim/catalog/HomSap/dfes.py
@@ -207,7 +207,6 @@ def _RodriguesDFE():
     description = "Deleterious Gamma and Beneficial Exponential DFE"
     long_description = """
     The best-fitting DFE simulated by Rodrigues et al (2024),
-    https://doi.org/10.1093/genetics/iyae006,
     from among 57 simulated scenarios with varying amounts of positive
     and negative selection. Fit was based on similarity of diversity
     and divergence across the great ape clade in simulations; the shape

--- a/stdpopsim/catalog/HomSap/dfes.py
+++ b/stdpopsim/catalog/HomSap/dfes.py
@@ -200,3 +200,66 @@ def _KyriazisDFE():
 
 
 _species.add_dfe(_KyriazisDFE())
+
+
+def _RodriguesDFE():
+    id = "PosNeg_R24"
+    description = "Deleterious Gamma and Beneficial Exponential DFE"
+    long_description = """
+    The best-fitting DFE simulated by Rodrigues et al (2024),
+    https://doi.org/10.1093/genetics/iyae006,
+    from among 57 simulated scenarios with varying amounts of positive
+    and negative selection. Fit was based on similarity of diversity
+    and divergence across the great ape clade in simulations; the shape
+    of the DFE was not inferred, only the proportion of positive and
+    negative mutations; the shape of the deleterious portion of the DFE
+    was obtained from Castellano et al (2019),
+    https://doi.org/10.1534/genetics.119.302494.
+    """
+    citations = [
+        stdpopsim.Citation(
+            author="Rodrigues et al.",
+            year=2024,
+            doi="https://doi.org/10.1093/genetics/iyae006",
+            reasons={stdpopsim.CiteReason.DFE},
+        ),
+        stdpopsim.Citation(
+            author="Castellano et al.",
+            year=2019,
+            doi="https://doi.org/10.1534/genetics.119.302494",
+            reasons={stdpopsim.CiteReason.DFE},
+        ),
+    ]
+    neutral = stdpopsim.MutationType()
+    # parameters from row 32 in Table S1, based on
+    # identification of rates in Figure 9
+    neg_mean = -3e-2
+    neg_shape = 0.16
+    negative = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="g",  # gamma distribution
+        distribution_args=[neg_mean, neg_shape],
+    )
+    pos_mean = 1e-2
+    positive = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="e",  # exponential distribution
+        distribution_args=[pos_mean],
+    )
+    total_rate = 2e-8
+    pos_rate = 1e-12
+    neg_rate = 1.2e-8
+    prop_pos = pos_rate / total_rate
+    prop_neg = neg_rate / total_rate
+    neutral_prop = 1 - prop_pos - prop_neg
+    return stdpopsim.DFE(
+        id=id,
+        description=description,
+        long_description=long_description,
+        mutation_types=[neutral, negative, positive],
+        proportions=[neutral_prop, prop_pos, prop_neg],
+        citations=citations,
+    )
+
+
+_species.add_dfe(_RodriguesDFE())


### PR DESCRIPTION
Motivation: we'd like to have a DFE containing positive mutations that aren't all at one fixed value of `s`.

[Rodrigues, Kern & Ralph](https://academic.oup.com/genetics/article/226/4/iyae006/7577595) doesn't exactly infer such a DFE, in the sense of using a validated inference procedure, but does explore parameter space and find a best-fitting DFE - so, I think it counts, and since it is simulation-based, we know it produces roughly reasonable simulations. The targets of inference are only the proportions of positive and negative selection; the negative part of the DFE is from [Castellano et al](https://academic.oup.com/genetics/article/226/4/iyae006/7577595), which I also cite here; the positive part is based on "expert knowledge" (i.e., something that seems reasonable).

So, in the popsim spirit of "best guess based on current state of knowledge", I think this is a good one to put in. Other opinions welcome (esp if they propose a better alternative such DFE?).

Note that the method uses all the great apes, and so could reasonably be applied to any of them.