### PR TITLE
clarify add_dfe docs (closes #1580)

### DIFF
--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -710,14 +710,17 @@ class Contig:
         object is added more than once.
 
         For instance, if we do
-        ```
-        a1 = np.array([[0, 100]])
-        a2 = np.array([[50, 120]])
-        contig.add_dfe(a1, dfe1)
-        contig.add_dfe(a2, dfe2)
-        ```
-        then ``dfe1`` applies to the region from 0 to 50 and ``dfe2`` applies
-        to the region from 50 to 120.
+
+        .. code-block:: python
+
+            a1 = np.array([[0, 100]])
+            a2 = np.array([[50, 120]])
+            contig.add_dfe(a1, dfe1)
+            contig.add_dfe(a2, dfe2)
+
+        then ``dfe1`` applies to the region from 0 to 50 (including 0 but not
+        50) and ``dfe2`` applies to the region from 50 to 120 (including 50 but
+        not 120).
 
         Any of the ``intervals`` that fall outside of the contig will be
         clipped to the contig boundaries. If no ``intervals`` overlap the


### PR DESCRIPTION
Also fixed the code display:
![Screenshot from 2025-01-20 07-59-32](https://github.com/user-attachments/assets/e7903313-c3b7-4346-b8b1-9441a800b33f)


tldr; is that stdpopsim, like msprime/tskit, uses [a,b); while SLiM uses [a,b].