### PR TITLE
added fetch depth 0 to checkout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
patching docs workflow to checkout the repo with the full tag history so that version/release info can be included in the docs

will close #680 (again)