### PR TITLE
DroMel positive DFE

### DIFF
--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -77,12 +77,13 @@ def _ZhenDFE():
     ]
     neutral = stdpopsim.MutationType()
     gamma_shape = 0.33  # shape
-    gamma_mean = -3.96e-04  # expected value
+    gamma_scale = 6.01e-4
+    gamma_mean = gamma_shape * gamma_scale
     h = 0.5  # dominance coefficient
     negative = stdpopsim.MutationType(
         dominance_coeff=h,
         distribution_type="g",  # gamma distribution
-        distribution_args=[gamma_mean, gamma_shape],
+        distribution_args=[round(-2 * gamma_mean, 7), gamma_shape],
     )
     # p. 2 in supplement says that the total sequence length of synonymous sites LS
     # related to the total sequence length of nonsynonymous sites LNS

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -145,3 +145,40 @@ def Gamma_H17():
 
 
 _species.get_dfe("Gamma_H17").register_qc(Gamma_H17())
+
+
+def ZhenPos():
+    id = "GammaPos_H17"
+    description = "Deleterious Gamma DFE with fixed-s beneficials"
+    # Same model as Huber 2017
+    neutral = stdpopsim.MutationType()
+    gamma_shape = 0.33
+    gamma_scale = 1.2e-3
+    gamma_mean = gamma_shape * gamma_scale
+    h = 0.5  # dominance coefficient
+    negative = stdpopsim.MutationType(
+        dominance_coeff=h,
+        distribution_type="g",  # gamma distribution
+        distribution_args=[-2 * gamma_mean, gamma_shape],
+    )
+    # LNS = 2.85 * LS
+    # prop_synonymous = 1/(1+2.85) = 0.26
+    prop_synonymous = 0.26
+    prop_beneficial = (1 - prop_synonymous) * 6.75e-4
+    selection_coefficient = 1.58e-5
+    prop_deleterious = 1 - (prop_synonymous + prop_beneficial)
+    positive = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="f",
+        distribution_args=[selection_coefficient],
+    )
+    return stdpopsim.DFE(
+        id=id,
+        description=description,
+        long_description=description,
+        mutation_types=[neutral, negative, positive],
+        proportions=[prop_synonymous, prop_deleterious, prop_beneficial],
+    )
+
+
+_species.get_dfe("GammaPos_H17").register_qc(ZhenPos())

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -159,7 +159,7 @@ def ZhenPos():
     negative = stdpopsim.MutationType(
         dominance_coeff=h,
         distribution_type="g",  # gamma distribution
-        distribution_args=[-2 * gamma_mean, gamma_shape],
+        distribution_args=[round(-2 * gamma_mean, 4), gamma_shape],
     )
     # LNS = 2.85 * LS
     # prop_synonymous = 1/(1+2.85) = 0.26

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -159,7 +159,7 @@ def ZhenPos():
     negative = stdpopsim.MutationType(
         dominance_coeff=h,
         distribution_type="g",  # gamma distribution
-        distribution_args=[round(-2 * gamma_mean, 4), gamma_shape],
+        distribution_args=[round(-2 * gamma_mean, 7), gamma_shape],
     )
     # LNS = 2.85 * LS
     # prop_synonymous = 1/(1+2.85) = 0.26

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -165,7 +165,7 @@ def ZhenPos():
     # prop_synonymous = 1/(1+2.85) = 0.26
     prop_synonymous = 0.26
     prop_beneficial = (1 - prop_synonymous) * 6.75e-4
-    selection_coefficient = 1.58e-5
+    selection_coefficient = 10 ** (-4.801)
     prop_deleterious = 1 - (prop_synonymous + prop_beneficial)
     positive = stdpopsim.MutationType(
         dominance_coeff=0.5,

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -153,7 +153,7 @@ def ZhenPos():
     # Same model as Huber 2017
     neutral = stdpopsim.MutationType()
     gamma_shape = 0.33
-    gamma_scale = 1.2e-3
+    gamma_scale = 6.01e-4
     gamma_mean = gamma_shape * gamma_scale
     h = 0.5  # dominance coefficient
     negative = stdpopsim.MutationType(


### PR DESCRIPTION
Addresses #1690 

I used the Huber et al. 2017 gamma-distributed DFE with a proportion of nonsynonymous mutations being positively selected. Parameters for the positively-selected mutations were from Table S6 in the [Zhen et al. paper.](https://genome.cshlp.org/content/31/1/110.abstract)