### PR TITLE
generic DFE from kyriazis

### DIFF
--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -1784,3 +1784,45 @@ def ZhenPos():
 
 
 _species.get_dfe("GammaPos_Z21").register_qc(ZhenPos())
+
+def genericDFE():
+    """
+    gamma distribution based on Kyriazis et al. 2022
+    w/ discrete dominance coefficients
+    and lethal mutations
+    """
+    id = "generic_gamma_dfe"
+    neutral = stdpopsim.MutationType()
+    gamma_mean = -0.0131
+    gamma_shape = 0.186
+    h_values = [0.45, 0.2, 0.05, 0]
+    h_breaks = [0.001, 0.01, 0.1]
+    negative = stdpopsim.MutationType(
+        dominance_coeff_list=h_values,
+        dominance_coeff_breaks=h_breaks,
+        distribution_type="g",
+        distribution_args=[gamma_mean, gamma_shape],
+    )
+    lethal = stdpopsim.MutationType(
+        distribution_type="f",
+        distribution_args=[-1],
+        dominance_coeff=0,
+    )
+
+    ns_proportion = 2.31 / (2.31 + 1.0)
+    lethal_proportion = 0.003 * ns_proportion
+    ns_proportion = ns_proportion - lethal_proportion
+    return stdpopsim.DFE(
+        id=id,
+        description=id,
+        long_description=id,
+        mutation_types=[neutral, negative, lethal],
+        proportions=[
+            (1 - (ns_proportion + lethal_proportion)),
+            ns_proportion,
+            lethal_proportion,
+        ],
+    )
+
+
+_species.get_dfe("Mixed_K23").register_qc(genericDFE())

--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -1785,6 +1785,7 @@ def ZhenPos():
 
 _species.get_dfe("GammaPos_Z21").register_qc(ZhenPos())
 
+
 def genericDFE():
     """
     gamma distribution based on Kyriazis et al. 2022


### PR DESCRIPTION
Addresses #1507 -- I used the parameters (with discrete dominance coefficients) from supplemental section S6 in [Kyriazis et al. 2023](https://doi.org/10.1086/726736), with a 0.3% of *nonsynonymous* mutations being lethal. 
I used the 2.31:1 nonsynonymous:synonymous ratio described in Huber et al. as per the discussion in #1507.