### PR TITLE
LogNormal DFE for humans

### DIFF
--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -1835,12 +1835,18 @@ def HuberLog():
     """
     id = "Huber2017_lognormal_dfe"
     neutral = stdpopsim.MutationType()
-    muval = -7.37 + math.log(2)
+    # mu and sigma values from table s3
+    muvalD = -7.37
     sigmaval = 4.58
+    expectedmean = math.exp(muvalD + (1 / 2) * (sigmaval**2))
+    # converting DaDi to SLiM selection coefficients -
+    targetmean = 2 * expectedmean
+    muvalS = math.log(targetmean) - (1 / 2) * (sigmaval**2)
+
     negative = stdpopsim.MutationType(
         dominance_coeff=0.5,
         distribution_type="ln",  # lognormal distribution
-        distribution_args=[muval, sigmaval],
+        distribution_args=[muvalS, sigmaval],
     )
 
     return stdpopsim.DFE(

--- a/stdpopsim/qc/HomSap.py
+++ b/stdpopsim/qc/HomSap.py
@@ -1827,3 +1827,29 @@ def genericDFE():
 
 
 _species.get_dfe("Mixed_K23").register_qc(genericDFE())
+
+
+def HuberLog():
+    """
+    lognormal DFE from Huber et al. 2017 PNAS.
+    """
+    id = "Huber2017_lognormal_dfe"
+    neutral = stdpopsim.MutationType()
+    muval = -7.37 + math.log(2)
+    sigmaval = 4.58
+    negative = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="ln",  # lognormal distribution
+        distribution_args=[muval, sigmaval],
+    )
+
+    return stdpopsim.DFE(
+        id=id,
+        description=id,
+        long_description=id,
+        mutation_types=[neutral, negative],
+        proportions=[0.3, 0.7],
+    )
+
+
+_species.get_dfe("LogNormal_H17").register_qc(HuberLog())

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -813,7 +813,10 @@ class QcdCatalogDFETestMixin(CatalogDFETestMixin):
         for i in range(len(mt1)):
             assert mt1[i].dominance_coeff == mt2[i].dominance_coeff
             assert mt1[i].distribution_type == mt2[i].distribution_type
-            assert np.allclose(mt1[i].distribution_args, mt2[i].distribution_args)
+            if all(isinstance(x, str) for x in mt1[i].distribution_args):
+                assert mt1[i].distribution_args == mt2[i].distribution_args
+            else:
+                assert np.allclose(mt1[i].distribution_args, mt2[i].distribution_args)
             assert mt1[i].convert_to_substitution == mt2[i].convert_to_substitution
 
     def test_proporitions_match(self):


### PR DESCRIPTION
addresses #1484

I used table S3 from [Huber et al. 2017](https://doi.org/10.1073/pnas.1619508114) for the parameters and refactored the mu value of the LogNormal distribution to account for DaDi vs. SLiM scaling. I also modified the DFE tests so that they can accept LogNormal distribution arguments (which are strings, not floats).