### PR TITLE
dromel lognormal DFE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@
   in growing/declining populations not matching (by a small amount) what is listed
   in the model; improved discretization scheme (:user:`petrelharp`, :pr:`1622`)
 
+- Incorrect scaling of the DroMel/LognormalPlusPositive_R16 DFE led to negative selection
+  coefficients that were too large (on the order of 1e-3); scaling was fixed for the
+  log scale (:user:`clararehmann`, :pr:`1699`)
+
 **Breaking changes**:
 
 - The 2018 Browning et al HomSap demographic model previously named

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@
   in the model; improved discretization scheme (:user:`petrelharp`, :pr:`1622`)
 
 - Incorrect scaling of the DroMel/LognormalPlusPositive_R16 DFE led to negative selection
-  coefficients that were too large (on the order of 1e-3); scaling was fixed for the
+  coefficients that were too large (many on the order of -1e3); scaling was fixed for the
   log scale (:user:`clararehmann`, :pr:`1699`)
 
 **Breaking changes**:

--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -78,12 +78,13 @@ def _ZhenDFE():
     ]
     neutral = stdpopsim.MutationType()
     gamma_shape = 0.33  # shape
-    gamma_mean = -3.96e-04  # expected value
+    gamma_scale = 6.01e-4
+    gamma_mean = gamma_shape * gamma_scale
     h = 0.5  # dominance coefficient
     negative = stdpopsim.MutationType(
         dominance_coeff=h,
         distribution_type="g",  # gamma distribution
-        distribution_args=[gamma_mean, gamma_shape],
+        distribution_args=[round(-2 * gamma_mean, 7), gamma_shape],
     )
     # p. 2 in supplement says that the total sequence length of synonymous sites LS
     # related to the total sequence length of nonsynonymous sites LNS

--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -188,5 +188,4 @@ def _RagsdaleDFE():
         citations=citations,
     )
 
-
 _species.add_dfe(_RagsdaleDFE())

--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -91,7 +91,6 @@ def _ZhenDFE():
     # by LNS = 2.85 * LS
     # so this is 1 / (1 + 2.85) = 0.2597402597402597
     prop_synonymous = 0.26
-
     sel_coeff = 10 ** (-4.801)
     prop_beneficials = 6.75e-4
     positive = stdpopsim.MutationType(
@@ -187,5 +186,6 @@ def _RagsdaleDFE():
         proportions=[p_syn, p_negative, p_positive],
         citations=citations,
     )
+
 
 _species.add_dfe(_RagsdaleDFE())

--- a/stdpopsim/catalog/DroMel/dfes.py
+++ b/stdpopsim/catalog/DroMel/dfes.py
@@ -1,4 +1,5 @@
 import stdpopsim
+import math
 
 _species = stdpopsim.get_species("DroMel")
 
@@ -158,18 +159,18 @@ def _RagsdaleDFE():
     # selection strengths
     S_positive = 39.9
     s_positive = S_positive / 2 / Ne
-    # TODO: these are *not* scale and shape parameters:
-    # the arguments to lognorm are meanlog and sdlog.
-    # Rename these after checking!
-    scale_negative = 5.42 / 2 / Ne
-    shape_negative = 3.36
+    # double for DaDi
+    s_positive = 2 * s_positive
+    meanlog = 5.42 - math.log(2 * Ne)
+    sdlog = 3.36
     h = 0.5
-
+    # double for DaDi, on the log scale
+    meanlog = meanlog + math.log(2)
     synonymous = stdpopsim.MutationType()
     negative = stdpopsim.MutationType(
         dominance_coeff=h,
         distribution_type="ln",  # negative log-normal distribution
-        distribution_args=[scale_negative, shape_negative],
+        distribution_args=[meanlog, sdlog],
     )
     positive = stdpopsim.MutationType(
         dominance_coeff=h,

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -160,6 +160,8 @@ def RagsdalePos():
     prop_nonsynonymous = prop_nonsynonymous - prop_beneficial
     # beneficial selection coefficient
     sval_pos = 39.9 / Ne / 2
+    # scale for DaDi
+    sval_pos = 2 * sval_pos
     positive = stdpopsim.MutationType(
         dominance_coeff=0.5,
         distribution_type="f",
@@ -167,8 +169,8 @@ def RagsdalePos():
     )
     # lognormal DFE parameters for deleterious mutations,
     # scale by 2Ne
-    muval = 5.42 / Ne / 2
-    sigmaval = 3.36 / Ne / 2
+    muval = 5.42 - math.log(2 * Ne)
+    sigmaval = 3.36
     # adjust mu so that mean is 2x former mean
     # (to match DaDi's scaling)
     expectedmean = math.exp(muval + (sigmaval**2 / 2))

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -147,6 +147,43 @@ def Gamma_H17():
 _species.get_dfe("Gamma_H17").register_qc(Gamma_H17())
 
 
+def ZhenPos():
+    id = "GammaPos_H17"
+    description = "Deleterious Gamma DFE with fixed-s beneficials"
+    # Same model as Huber 2017
+    neutral = stdpopsim.MutationType()
+    gamma_shape = 0.33
+    gamma_scale = 6.01e-4
+    gamma_mean = gamma_shape * gamma_scale
+    h = 0.5  # dominance coefficient
+    negative = stdpopsim.MutationType(
+        dominance_coeff=h,
+        distribution_type="g",  # gamma distribution
+        distribution_args=[round(-2 * gamma_mean, 7), gamma_shape],
+    )
+    # LNS = 2.85 * LS
+    # prop_synonymous = 1/(1+2.85) = 0.26
+    prop_synonymous = 0.26
+    prop_beneficial = (1 - prop_synonymous) * 6.75e-4
+    selection_coefficient = 10 ** (-4.801)
+    prop_deleterious = 1 - (prop_synonymous + prop_beneficial)
+    positive = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="f",
+        distribution_args=[selection_coefficient],
+    )
+    return stdpopsim.DFE(
+        id=id,
+        description=description,
+        long_description=description,
+        mutation_types=[neutral, negative, positive],
+        proportions=[prop_synonymous, prop_deleterious, prop_beneficial],
+    )
+
+
+_species.get_dfe("GammaPos_H17").register_qc(ZhenPos())
+
+
 def RagsdalePos():
     id = "RagsdalePos"
     description = "lognormal DFE based on Ragsdale et al. 2021"

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -1,5 +1,5 @@
 import msprime
-
+import math
 import stdpopsim
 
 
@@ -145,3 +145,47 @@ def Gamma_H17():
 
 
 _species.get_dfe("Gamma_H17").register_qc(Gamma_H17())
+
+
+def RagsdalePos():
+    id = "RagsdalePos"
+    description = "lognormal DFE based on Ragsdale et al. 2021"
+    neutral = stdpopsim.MutationType()
+    # selection coefficients are scaled by 2xeffective population size
+    Ne = 2.8e6
+    # NS = 2.5 * S
+    prop_synonymous = 1 / (1 + 2.5)
+    prop_nonsynonymous = 1 - prop_synonymous
+    prop_beneficial = 0.0079 * prop_nonsynonymous
+    prop_nonsynonymous = prop_nonsynonymous - prop_beneficial
+    # beneficial selection coefficient
+    sval_pos = 39.9 / Ne / 2
+    positive = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="f",
+        distribution_args=[sval_pos],
+    )
+    # lognormal DFE parameters for deleterious mutations,
+    # scale by 2Ne
+    muval = -5.42 / Ne / 2
+    sigmaval = 3.36 / Ne / 2
+    # adjust mu so that mean is 2x former mean
+    # (to match DaDi's scaling)
+    expectedmean = math.exp(muval + (sigmaval**2 / 2))
+    targetmean = expectedmean * 2
+    muval = math.log(targetmean) - (sigmaval**2 / 2)
+    negative = stdpopsim.MutationType(
+        dominance_coeff=0.5,
+        distribution_type="ln",
+        distribution_args=[muval, sigmaval],
+    )
+    return stdpopsim.DFE(
+        id=id,
+        description=description,
+        long_description=description,
+        mutation_types=[neutral, negative, positive],
+        proportions=[prop_synonymous, prop_nonsynonymous, prop_beneficial],
+    )
+
+
+_species.get_dfe("LognormalPlusPositive_R16").register_qc(RagsdalePos())

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -183,6 +183,7 @@ def ZhenPos():
 
 _species.get_dfe("GammaPos_H17").register_qc(ZhenPos())
 
+
 def RagsdalePos():
     id = "RagsdalePos"
     description = "lognormal DFE based on Ragsdale et al. 2021"

--- a/stdpopsim/qc/DroMel.py
+++ b/stdpopsim/qc/DroMel.py
@@ -167,7 +167,7 @@ def RagsdalePos():
     )
     # lognormal DFE parameters for deleterious mutations,
     # scale by 2Ne
-    muval = -5.42 / Ne / 2
+    muval = 5.42 / Ne / 2
     sigmaval = 3.36 / Ne / 2
     # adjust mu so that mean is 2x former mean
     # (to match DaDi's scaling)

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -813,7 +813,10 @@ class QcdCatalogDFETestMixin(CatalogDFETestMixin):
         for i in range(len(mt1)):
             assert mt1[i].dominance_coeff == mt2[i].dominance_coeff
             assert mt1[i].distribution_type == mt2[i].distribution_type
-            assert np.allclose(mt1[i].distribution_args, mt2[i].distribution_args)
+            if all(isinstance(x, str) for x in mt1[i].distribution_args):
+                assert mt1[i].distribution_args == mt2[i].distribution_args
+            else:
+                assert np.allclose(mt1[i].distribution_args, mt2[i].distribution_args)
             assert mt1[i].convert_to_substitution == mt2[i].convert_to_substitution
 
     def test_proporitions_match(self):


### PR DESCRIPTION
Addresses #1697

I used the parameters from tables S1 (LogNormal distribution parameters, positive selection coefficient) and S2 (proportion of NS mutations that are positive). Because the parameters in S1 are scaled by 2Ne, I divided them by 2Ne using the effective population size from Huber et al. 

Since the paper used DaDi to infer their DFEs, I rescaled the mu term so that the expected mean (X = exp(mu + (sigma^2)/2)) of the LogNormal distribution was two times the inferred mean (after scaling by 2Ne). 