### PR TITLE
bump min python version

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,7 +25,7 @@ Requirements
 Library requirements for ``stdpopsim`` should be installed automatically when using
 either conda or pip.
 
-``stdpopsim`` requires Python 3.5 or later.
+``stdpopsim`` requires Python 3.10 or later.
 
 
 .. _sec_installation_conda:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,9 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Bio-Informatics
 keywords = simulations, selection, recombination map, models
@@ -31,7 +30,7 @@ project_urls =
 packages = stdpopsim
 zip_safe = False
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.10
 install_requires =
     msprime >= 1.0.4
     attrs >= 19.1.0


### PR DESCRIPTION
@bhaller reports that running
```
stdpopsim -e slim --slim-script --slim-scaling-factor 10 HomSap -g HapMapII_GRCh38 -c chr22 --left 10000000 --right 20000000 -o foo.ts -d OutOfAfrica_2T12 AFR:1 EUR:2
```
results in
```
Traceback (most recent call last):
 File "/Users/bhaller/Library/Python/3.9/bin/stdpopsim", line 8, in <module>
  sys.exit(stdpopsim_main())
 File "/Users/bhaller/Library/Python/3.9/lib/python/site-packages/stdpopsim/cli.py", line 1157, in stdpopsim_main
  run(args)
 File "/Users/bhaller/Library/Python/3.9/lib/python/site-packages/stdpopsim/cli.py", line 1148, in run
  args.runner(args)
 File "/Users/bhaller/Library/Python/3.9/lib/python/site-packages/stdpopsim/cli.py", line 868, in run_simulation
  ts = engine.simulate(**kwargs)
 File "/Users/bhaller/Library/Python/3.9/lib/python/site-packages/stdpopsim/slim_engine.py", line 1687, in simulate
  with _slim_tempdir() as st:
 File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 119, in __enter__
  return next(self.gen)
 File "/Users/bhaller/Library/Python/3.9/lib/python/site-packages/stdpopsim/slim_engine.py", line 1669, in _slim_tempdir
  tempdir = tempfile.TemporaryDirectory(
TypeError: __init__() got an unexpected keyword argument 'ignore_cleanup_errors'
```
Indeed, the argument `ignore_cleanup_errors` was introduced in python 3.10:
![Screenshot From 2025-05-29 11-53-13](https://github.com/user-attachments/assets/cb907d6d-6280-4676-9141-1a6e44da0451)
