### PR TITLE
bug fix in PosNeg_R24

### DIFF
--- a/stdpopsim/catalog/HomSap/dfes.py
+++ b/stdpopsim/catalog/HomSap/dfes.py
@@ -253,7 +253,7 @@ def _RodriguesDFE():
         description=description,
         long_description=long_description,
         mutation_types=[neutral, negative, positive],
-        proportions=[neutral_prop, prop_neg, prop_pos],
+        proportions=[neutral_prop, prop_pos, prop_neg],
         citations=citations,
     )
 


### PR DESCRIPTION
The proportions of negative and positive mutations were swapped. (I still need to formally QC this, but for now I think we should patch it).