### PR TITLE
include separate sexes property

### DIFF
--- a/docs/_ext/speciescatalog.py
+++ b/docs/_ext/speciescatalog.py
@@ -102,6 +102,7 @@ class SpeciesCatalogDirective(SphinxDirective):
                 ],
             ),
             ("Ploidy", species.ploidy, None),
+            ("Separate sexes", species.separate_sexes, None),
             (
                 "Population size",
                 species.population_size,

--- a/stdpopsim/catalog/AedAeg/species.py
+++ b/stdpopsim/catalog/AedAeg/species.py
@@ -80,6 +80,7 @@ _species = stdpopsim.Species(
     ensembl_id="aedes_aegypti_lvpagwg",
     name="Aedes aegypti",
     common_name="Yellow fever mosquito",
+    separate_sexes=True,
     genome=_genome,
     generation_time=1 / 15,
     ploidy=_species_ploidy,

--- a/stdpopsim/catalog/AnaPla/species.py
+++ b/stdpopsim/catalog/AnaPla/species.py
@@ -269,6 +269,7 @@ _species = stdpopsim.Species(
     # "endangered endemics in Hawaii and New Zealand. The assembly, "
     # "recombination rates, and default Ne were estimtaed with wild Chinese "
     # "mallards.",
+    separate_sexes=True,
     genome=_genome,
     # generation time estimate from Lavertsky et al. (2020):
     # Generation time (G) was calculated as G = \alpha + (s/(1 − s)),

--- a/stdpopsim/catalog/AnoCar/species.py
+++ b/stdpopsim/catalog/AnoCar/species.py
@@ -106,6 +106,7 @@ _species = stdpopsim.Species(
     ensembl_id="anolis_carolinensis",
     name="Anolis carolinensis",
     common_name="Anole lizard",
+    separate_sexes=True,
     genome=_genome,
     generation_time=1.5,
     # they live between 1-2 years after they are able to mate

--- a/stdpopsim/catalog/AnoGam/species.py
+++ b/stdpopsim/catalog/AnoGam/species.py
@@ -99,6 +99,7 @@ _species = stdpopsim.Species(
     ensembl_id="anopheles_gambiae",
     name="Anopheles gambiae",
     common_name="Anopheles gambiae",
+    separate_sexes=True,
     genome=_genome,
     generation_time=1 / 11,
     # based on theta = 4 Ne u in Gabon population, rounded

--- a/stdpopsim/catalog/ApiMel/species.py
+++ b/stdpopsim/catalog/ApiMel/species.py
@@ -155,6 +155,10 @@ _species = stdpopsim.Species(
     ensembl_id="apis_mellifera",
     name="Apis mellifera",
     common_name="Apis mellifera (DH4)",
+    # Drones are "flying gametes" and so at a rough level they
+    # act like a hermarphoditic population of queens; so this
+    # might be changed when implementing haplodiploidy.
+    separate_sexes=False,
     genome=_genome,
     generation_time=2,
     population_size=2e05,

--- a/stdpopsim/catalog/AraTha/species.py
+++ b/stdpopsim/catalog/AraTha/species.py
@@ -59,6 +59,7 @@ _species = stdpopsim.Species(
     ensembl_id="arabidopsis_thaliana",
     name="Arabidopsis thaliana",
     common_name="A. thaliana",
+    separate_sexes=False,
     genome=_genome,
     generation_time=1.0,
     population_size=10**4,

--- a/stdpopsim/catalog/BosTau/species.py
+++ b/stdpopsim/catalog/BosTau/species.py
@@ -97,6 +97,7 @@ _species = stdpopsim.Species(
     ensembl_id="bos_taurus",
     name="Bos taurus",
     common_name="Cattle",
+    separate_sexes=True,
     genome=_genome,
     generation_time=5,
     population_size=62000,  # ancestral Ne in _MacLeodEtAl

--- a/stdpopsim/catalog/CaeEle/species.py
+++ b/stdpopsim/catalog/CaeEle/species.py
@@ -124,6 +124,7 @@ _species = stdpopsim.Species(
     ensembl_id="caenorhabditis_elegans",
     name="Caenorhabditis elegans",
     common_name="C. elegans",
+    separate_sexes=False,
     genome=_genome,
     generation_time=0.01,  # One of the estimates reported
     # by the paper is ~150 generations per year (0.00666).

--- a/stdpopsim/catalog/CanFam/species.py
+++ b/stdpopsim/catalog/CanFam/species.py
@@ -150,6 +150,7 @@ _species = stdpopsim.Species(
     ensembl_id="canis_lupus_familiaris",
     name="Canis familiaris",
     common_name="Dog",
+    separate_sexes=True,
     genome=_genome,
     population_size=13000,  # ancestral dog size
     generation_time=3,

--- a/stdpopsim/catalog/ChlRei/species.py
+++ b/stdpopsim/catalog/ChlRei/species.py
@@ -105,6 +105,7 @@ _species = stdpopsim.Species(
     ensembl_id="chlamydomonas_reinhardtii",
     name="Chlamydomonas reinhardtii",
     common_name="Chlamydomonas reinhardtii",
+    separate_sexes=False,
     genome=_genome,
     generation_time=1 / 876,
     population_size=1.4 * 1e-7,

--- a/stdpopsim/catalog/DroMel/species.py
+++ b/stdpopsim/catalog/DroMel/species.py
@@ -124,6 +124,7 @@ _species = stdpopsim.Species(
     ensembl_id="drosophila_melanogaster",
     name="Drosophila melanogaster",
     common_name="D. melanogaster",
+    separate_sexes=True,
     genome=_genome,
     generation_time=0.1,
     # Population size is the older of two population sizes estimated by

--- a/stdpopsim/catalog/DroSec/species.py
+++ b/stdpopsim/catalog/DroSec/species.py
@@ -98,6 +98,7 @@ _species = stdpopsim.Species(
     ensembl_id="drosophila_sechellia",
     name="Drosophila sechellia",
     common_name="Drosophila sechellia",
+    separate_sexes=True,
     genome=_genome,
     generation_time=0.05,
     population_size=100000,

--- a/stdpopsim/catalog/EscCol/species.py
+++ b/stdpopsim/catalog/EscCol/species.py
@@ -65,6 +65,7 @@ _species = stdpopsim.Species(
     # We use the K-12 strain, because the parameters we're using more
     # closely match this strain than the ensembl default (HUSEC2011).
     ensembl_id="escherichia_coli_str_k_12_substr_mg1655_gca_000005845",
+    separate_sexes=False,
     genome=_genome,
     # E. coli K-12 strain MG1655 "doubling time during steady-state growth in
     # Luria-Bertani broth was 20 min".

--- a/stdpopsim/catalog/GasAcu/species.py
+++ b/stdpopsim/catalog/GasAcu/species.py
@@ -119,6 +119,7 @@ _species = stdpopsim.Species(
     ensembl_id="gasterosteus_aculeatus",
     name="Gasterosteus aculeatus",
     common_name="Three-spined stickleback",
+    separate_sexes=True,
     genome=_genome,
     generation_time=2,  # PSMC description at the Materials and Methods.
     population_size=1e4,  # From PSMC results.

--- a/stdpopsim/catalog/GorGor/species.py
+++ b/stdpopsim/catalog/GorGor/species.py
@@ -143,6 +143,7 @@ _species = stdpopsim.Species(
     ensembl_id="gorilla_gorilla",
     name="Gorilla gorilla",
     common_name="Gorilla",
+    separate_sexes=True,
     genome=_genome,
     generation_time=19.0,
     population_size=_Ne,

--- a/stdpopsim/catalog/HelAnn/species.py
+++ b/stdpopsim/catalog/HelAnn/species.py
@@ -104,6 +104,7 @@ _species = stdpopsim.Species(
     ensembl_id="helianthus_annuus",
     name="Helianthus annuus",
     common_name="Helianthus annuus",
+    separate_sexes=False,
     genome=_genome,
     generation_time=1.0,
     population_size=673968,

--- a/stdpopsim/catalog/HelMel/species.py
+++ b/stdpopsim/catalog/HelMel/species.py
@@ -104,6 +104,7 @@ _species = stdpopsim.Species(
     ensembl_id="heliconius_melpomene",
     name="Heliconius melpomene",
     common_name="Heliconius melpomene",
+    separate_sexes=True,
     genome=_genome,
     generation_time=35 / 365,  # 35 days
     # population size from the first of two datasets in Pardo-Diaz et al 2012

--- a/stdpopsim/catalog/HomSap/species.py
+++ b/stdpopsim/catalog/HomSap/species.py
@@ -127,6 +127,7 @@ _species = stdpopsim.Species(
     ensembl_id="homo_sapiens",
     name="Homo sapiens",
     common_name="Human",
+    separate_sexes=True,
     genome=_genome,
     generation_time=30,
     population_size=10**4,

--- a/stdpopsim/catalog/MusMus/species.py
+++ b/stdpopsim/catalog/MusMus/species.py
@@ -159,6 +159,7 @@ _species = stdpopsim.Species(
     ensembl_id="mus_musculus",
     name="Mus musculus",
     common_name="Mouse",
+    separate_sexes=True,
     genome=_genome,
     ploidy=_species_ploidy,
     generation_time=0.75,

--- a/stdpopsim/catalog/OrySat/species.py
+++ b/stdpopsim/catalog/OrySat/species.py
@@ -120,6 +120,7 @@ _species = stdpopsim.Species(
     ensembl_id="oryza_sativa",
     name="Oryza sativa",
     common_name="Asian rice",
+    separate_sexes=False,
     genome=_genome,
     generation_time=1,
     population_size=46875,

--- a/stdpopsim/catalog/PanTro/species.py
+++ b/stdpopsim/catalog/PanTro/species.py
@@ -90,6 +90,7 @@ _species = stdpopsim.Species(
     ensembl_id="pan_troglodytes",
     name="Pan troglodytes",
     common_name="Chimpanzee",
+    separate_sexes=True,
     genome=_genome,
     generation_time=24.6,
     population_size=16781,

--- a/stdpopsim/catalog/PapAnu/species.py
+++ b/stdpopsim/catalog/PapAnu/species.py
@@ -112,6 +112,7 @@ _species = stdpopsim.Species(
     ensembl_id="papio_anubis",
     name="Papio anubis",
     common_name="Olive baboon",
+    separate_sexes=True,
     genome=_genome,
     generation_time=11,  # Generation time from Wu et al section
     # "Inferring split times of humans and baboons"

--- a/stdpopsim/catalog/PhoSin/species.py
+++ b/stdpopsim/catalog/PhoSin/species.py
@@ -130,6 +130,7 @@ _species = stdpopsim.Species(
     ensembl_id="phocoena_sinus",
     name="Phocoena sinus",
     common_name="Vaquita",
+    separate_sexes=True,
     genome=_genome,
     ploidy=_species_ploidy,
     ##########################

--- a/stdpopsim/catalog/PonAbe/species.py
+++ b/stdpopsim/catalog/PonAbe/species.py
@@ -127,6 +127,7 @@ _species = stdpopsim.Species(
     ensembl_id="pongo_abelii",
     name="Pongo abelii",
     common_name="Sumatran orangutan",
+    separate_sexes=True,
     genome=_genome,
     # generation time used by Nater et al., citing Wich et al.
     generation_time=25,

--- a/stdpopsim/catalog/RatNor/species.py
+++ b/stdpopsim/catalog/RatNor/species.py
@@ -133,6 +133,7 @@ _species = stdpopsim.Species(
     ensembl_id="rattus_norvegicus",
     name="Rattus norvegicus",
     common_name="Rat",
+    separate_sexes=True,
     genome=_genome,
     ploidy=_species_ploidy,
     # some notes on the generation time

--- a/stdpopsim/catalog/StrAga/species.py
+++ b/stdpopsim/catalog/StrAga/species.py
@@ -96,6 +96,7 @@ _species = stdpopsim.Species(
     ensembl_id="streptococcus_agalactiae_GCA_001017915",
     name="Streptococcus agalactiae",
     common_name="Group B Streptococcus",
+    separate_sexes=False,
     genome=_genome,
     generation_time=1 / 365,  # year / generations
     population_size=140000,

--- a/stdpopsim/catalog/SusScr/species.py
+++ b/stdpopsim/catalog/SusScr/species.py
@@ -114,6 +114,7 @@ _species = stdpopsim.Species(
     ensembl_id="sus_scrofa",
     name="Sus scrofa",
     common_name="Pig",
+    separate_sexes=True,
     genome=_genome,
     ploidy=_ploidy,
     # Servanty et al. (2011) on page 837 write:

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -68,8 +68,9 @@ def _escape_eidos(s):
     return "\\\\".join(s.split("\\"))
 
 
+# this is the start of the initialize() block,
+# right after optional initialization calls that must come first
 _slim_upper = """
-initialize() {
     if (!exists("dry_run"))
         defineConstant("dry_run", F);
     if (!exists("verbosity"))
@@ -1197,6 +1198,9 @@ def slim_makescript(
 
     pop_names_str = ", ".join(map(lambda x: f'"{x}"', pop_names))
 
+    printsc("initialize() {\n")
+    if contig.species.separate_sexes:
+        printsc("    initializeSex();\n")
     printsc(
         string.Template(_slim_upper).substitute(
             scaling_factor=scaling_factor,
@@ -1591,6 +1595,13 @@ class _SLiMEngine(stdpopsim.Engine):
         Simulate the demographic model using SLiM.
         See :meth:`.Engine.simulate()` for definitions of the
         ``demographic_model``, ``contig``, and ``samples`` parameters.
+
+        The SLiM engine can also adjust aspects of the simulation to match
+        the life history of the species. At present, this is only:
+
+        * ``separate_sexes``: if the species has separate sexes, SLiM
+            will use a two-sex Wright-Fisher model (instead of the default
+            hermaphroditic WF model)
 
         :param seed: The seed for the random number generator.
         :type seed: int

--- a/stdpopsim/species.py
+++ b/stdpopsim/species.py
@@ -118,6 +118,10 @@ class Species:
         Where no common name for the species exist, use the most common
         abbreviation, e.g., "E. Coli".
     :vartype common_name: str
+    :ivar separate_sexes: Whether the species has two separate sexes or
+        not (if not, it is hermaphroditic). Note that at present,
+        haplodiploid species have this set to False.
+    :vartype separate_sexes: bool
     :ivar genome: The :class:`.Genome` instance describing the details
         of this species' genome.
     :vartype genome: stdpopsim.Genome
@@ -153,6 +157,7 @@ class Species:
     id = attr.ib(type=str, kw_only=True)
     name = attr.ib(type=str, kw_only=True)
     common_name = attr.ib(type=str, kw_only=True)
+    separate_sexes = attr.ib(type=bool, kw_only=True)
     genome = attr.ib(type=int, kw_only=True)
     generation_time = attr.ib(default=0, kw_only=True)
     ploidy = attr.ib(default=2, type=int, kw_only=True)

--- a/tests/test_AraTha.py
+++ b/tests/test_AraTha.py
@@ -9,6 +9,7 @@ class TestSpecies(test_species.SpeciesTestBase):
     def test_basic_attributes(self):
         assert self.species.population_size == 10**4
         assert self.species.generation_time == 1
+        assert self.species.separate_sexes is False
 
 
 class TestGenome(test_species.GenomeTestBase):

--- a/tests/test_DroMel.py
+++ b/tests/test_DroMel.py
@@ -14,6 +14,7 @@ class TestSpecies(test_species.SpeciesTestBase):
     def test_basic_attributes(self):
         self.species.population_size == 1720600
         self.species.generation_time == 0.1
+        self.species.separate_sexes is True
 
 
 class TestGenome(test_species.GenomeTestBase):

--- a/tests/test_EscCol.py
+++ b/tests/test_EscCol.py
@@ -17,6 +17,7 @@ class TestSpecies(test_species.SpeciesTestBase):
         # 20 minutes per generation
         generation_time = 1.0 / (525600 / 20)
         assert round(abs(self.species.generation_time - generation_time), 7) == 0
+        assert self.species.separate_sexes is False
 
 
 class TestGenome(test_species.GenomeTestBase):

--- a/tests/test_HomSap.py
+++ b/tests/test_HomSap.py
@@ -15,6 +15,7 @@ class TestSpecies(test_species.SpeciesTestBase):
     def test_basic_attributes(self):
         assert self.species.population_size == 10**4
         assert self.species.generation_time == 30
+        assert self.species.separate_sexes is True
 
 
 class TestGenome(test_species.GenomeTestBase):

--- a/tests/test_PanTro.py
+++ b/tests/test_PanTro.py
@@ -24,6 +24,9 @@ class TestSpecies(test_species.SpeciesTestBase):
     def test_qc_generation_time(self):
         assert self.species.generation_time == 24.6
 
+    def test_separate_sexes(self):
+        assert self.species.separate_sexes is True
+
 
 class TestGenome(test_species.GenomeTestBase):
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -69,6 +69,7 @@ class AnnotationTestClass(stdpopsim.Annotation):
             name="Test species",
             common_name="Testy McTestface",
             genome=genome,
+            separate_sexes=False,
         )
         super().__init__(
             species=_species,

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -57,9 +57,12 @@ class TestFetchBibtex:
             citation.fetch_bibtex()
 
     def test_get_bibtex_404(self):
-        # Tests a 404
+        # Tests a 404.  The previous URL here, http://doi.org/url-does-not-exist,
+        # started just not responding.
         citation = stdpopsim.Citation(
-            doi="http://doi.org/url-does-not-exist", author="Authors", year="2000"
+            doi="http://github.com/popsim-consortium/this_is_not_a_repo",
+            author="Authors",
+            year="2000",
         )
         with pytest.raises(urllib.error.HTTPError):
             citation.fetch_bibtex()

--- a/tests/test_genetic_maps.py
+++ b/tests/test_genetic_maps.py
@@ -68,6 +68,7 @@ class GeneticMapTestClass(stdpopsim.GeneticMap):
             name="Test species",
             common_name="Testy McTestface",
             genome=genome,
+            separate_sexes=True,
         )
         super().__init__(
             species=_species,

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -428,6 +428,15 @@ class TestContig(object):
         contig = stdpopsim.Contig.basic_contig(length=1000)
         assert contig.ploidy == 2
 
+    def test_species_property_default(self):
+        contig = stdpopsim.Contig.basic_contig(length=1000)
+        assert contig.species.separate_sexes is False
+
+    def test_species_property(self):
+        species = stdpopsim.get_species("AnaPla")
+        contig = species.get_contig("chr2")
+        assert contig.species == species
+
 
 class TestGeneConversion(object):
     def test_mean_gene_conversion(self):


### PR DESCRIPTION
This is an attempt at adding the "separate sexes" property, referred to in #1753 and needed by (the correct fix to) #1743.
This needs some testing on the SLiM side before merging.

This sounds minor but actually hits a lot of things:
0. All species now have a `separate_sexes` property, which is boolean. Even honeybees.
1. This will change the simulation results of any sexual species when using the SLiM engine. Not by much, but it is a change.
2. Since `simulate` only gets `demographic_model` and `contig` as arguments (not `species`), to get the species-specific information into `simulate` to allow  the recipe to depend on species attributes like this, I have added the property `species` to the `Contig` class.
3. We can't make `species` a *required* argument to `Contig`, since that would be backwards-incompatible: people make genetic contigs. So, my compromise is that if a Contig is created with `species=None` then it gets an ad-hoc created genetic Species that will have any required parameters at default values (eg `separate_sexes=False`).

Other notes:
- thanks to the new chromosome support in SLiM we don't need to specify sex determination system
- msprime does nothing with this information.