### PR TITLE
Fix infinite hang in test_incorrect_url

### DIFF
--- a/stdpopsim/utils.py
+++ b/stdpopsim/utils.py
@@ -89,6 +89,10 @@ def download(url, filename):
         # Amend the error message to include the url.
         e.msg += f": {url}"
         raise e
+    except urllib.error.URLError as e:
+        # URLError can occur for DNS failures, connection errors, etc.
+        # Wrap it with additional context about the URL.
+        raise OSError(f"Failed to download {url}: {e.reason}") from e
 
 
 def sha256(filename):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -139,7 +139,8 @@ class TestAnnotationDownload(tests.CacheWritingTest):
 
     def test_incorrect_url(self):
         an = AnnotationTestClass()
-        an.intervals_url = "http://asdfwersdf.com/foozip"
+        # Use localhost with a port that won't be listening - fails fast without DNS
+        an.intervals_url = "http://localhost:0/foozip"
         with pytest.raises(OSError):
             an.download()
 


### PR DESCRIPTION
The test was attempting to connect to a fake domain, causing DNS
resolution to hang indefinitely. Changed to use localhost:0 which
fails fast without DNS lookup.

Also add URLError handling to utils.download() to properly catch
DNS and connection failures.

Fixes #1767