### PR TITLE
AWS maintenance

### DIFF
--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -27,6 +27,11 @@ on:
         description: "Resource ID as defined in the catalog (e.g. HapMapII_GRCh38)"
         required: true
         type: string
+      dry_run:
+        description: "If true, run all validation but skip the actual S3 upload"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: s3-upload
@@ -187,6 +192,7 @@ jobs:
           echo "SHA256 verified."
 
       - name: Check if S3 object already exists
+        if: ${{ inputs.dry_run != true }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -201,6 +207,7 @@ jobs:
           echo "Confirmed: s3://stdpopsim/$DEST does not exist yet."
 
       - name: Upload to S3
+        if: ${{ inputs.dry_run != true }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -213,6 +220,20 @@ jobs:
           echo "Upload complete."
           echo "S3 URL: https://stdpopsim.s3-us-west-2.amazonaws.com/$DEST"
           echo "SHA256: ${{ inputs.expected_sha256 }}"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "=== DRY RUN COMPLETE ==="
+          echo "All validation passed. Skipped S3 upload."
+          echo ""
+          echo "  Species:  ${{ inputs.species_id }}"
+          echo "  Type:     ${{ inputs.resource_type }}"
+          echo "  Resource: ${{ inputs.resource_id }}"
+          echo "  S3 dest:  s3://stdpopsim/${{ inputs.s3_destination }}"
+          echo "  SHA256:   ${{ inputs.expected_sha256 }}"
+          echo ""
+          echo "To perform the actual upload, re-run without --dry-run."
 
       - name: Clean up draft release
         if: always()

--- a/maintenance/upload_to_s3.sh
+++ b/maintenance/upload_to_s3.sh
@@ -3,15 +3,20 @@
 # Upload a tarball to the stdpopsim S3 bucket via GitHub Actions.
 #
 # Usage:
-#   ./maintenance/upload_to_s3.sh <local-file> <species-id> <genetic_map|annotation> <resource-id>
+#   ./maintenance/upload_to_s3.sh [--dry-run] <local-file> <species-id> <genetic_map|annotation> <resource-id>
 #
 # Examples:
 #   ./maintenance/upload_to_s3.sh data/HapMapII_GRCh38.tar.gz HomSap genetic_map HapMapII_GRCh38
 #   ./maintenance/upload_to_s3.sh data/ensembl_havana_104_exons_v1.tar.gz HomSap annotation ensembl_havana_104_exons
+#   ./maintenance/upload_to_s3.sh --dry-run data/test.tar.gz HomSap genetic_map HapMapII_GRCh38
 #
 # The script looks up the resource in the stdpopsim catalog to find the
 # expected S3 URL and SHA256, verifies the local file matches, then uploads
 # via a GitHub Actions workflow.
+#
+# Options:
+#   --dry-run  Run all validation (local + remote) but skip the actual S3 upload.
+#              The workflow will still run to verify everything end-to-end.
 #
 # Prerequisites:
 #   - GitHub CLI (gh) installed and authenticated
@@ -22,16 +27,24 @@ set -euo pipefail
 
 REPO="popsim-consortium/stdpopsim"
 WORKFLOW="upload-to-s3.yml"
+DRY_RUN=false
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# --- Parse --dry-run flag ---
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY_RUN=true
+    shift
+fi
+
 # --- Validate arguments ---
 if [ $# -ne 4 ]; then
-    echo "Usage: $0 <local-file> <species-id> <genetic_map|annotation> <resource-id>" >&2
+    echo "Usage: $0 [--dry-run] <local-file> <species-id> <genetic_map|annotation> <resource-id>" >&2
     echo "" >&2
     echo "Examples:" >&2
     echo "  $0 data/HapMapII_GRCh38.tar.gz HomSap genetic_map HapMapII_GRCh38" >&2
     echo "  $0 data/exons_v1.tar.gz HomSap annotation ensembl_havana_104_exons" >&2
+    echo "  $0 --dry-run data/test.tar.gz HomSap genetic_map HapMapII_GRCh38" >&2
     exit 1
 fi
 
@@ -39,6 +52,11 @@ LOCAL_FILE="$1"
 SPECIES_ID="$2"
 RESOURCE_TYPE="$3"
 RESOURCE_ID="$4"
+
+if [ "$DRY_RUN" = true ]; then
+    echo "*** DRY RUN MODE — will validate but skip S3 upload ***"
+    echo ""
+fi
 
 [ -f "$LOCAL_FILE" ] || die "File not found: $LOCAL_FILE"
 
@@ -174,10 +192,15 @@ gh workflow run "$WORKFLOW" \
     --field "expected_sha256=$SHA256" \
     --field "species_id=$SPECIES_ID" \
     --field "resource_type=$RESOURCE_TYPE" \
-    --field "resource_id=$RESOURCE_ID"
+    --field "resource_id=$RESOURCE_ID" \
+    --field "dry_run=$DRY_RUN"
 
 echo ""
-echo "Workflow triggered successfully."
+if [ "$DRY_RUN" = true ]; then
+    echo "Dry-run workflow triggered. It will validate everything but skip the S3 upload."
+else
+    echo "Workflow triggered successfully."
+fi
 echo ""
 echo "Monitor the upload with:"
 echo "  gh run list --repo $REPO --workflow $WORKFLOW --limit 3"


### PR DESCRIPTION
this is a workflow that aims to securely deal with uploading new artifacts (genetic maps / annotations) to the AWS site. 
 - Adds a local helper script (`maintenance/upload_to_s3.sh`) that validates uploads against the
  catalog before triggering the workflow
  - AWS credentials are now stored as GitHub repo secrets, accessible only through a protected
  environment requiring admin approval
  
   A maintainer runs the local script pointing at a tarball and the catalog entry it corresponds to:

  `./maintenance/upload_to_s3.sh data/HapMapII_GRCh38.tar.gz HomSap genetic_map HapMapII_GRCh38`

  The script:
  1. Looks up the species, genetic map/annotation in the stdpopsim catalog
  2. Verifies the local file's SHA256 matches the catalog entry
  3. Creates a temporary draft GitHub release to transport the file
  4. Triggers the GitHub Actions workflow

  The workflow then:
  1. Checks out the repo and re-validates against the catalog 
  2. Downloads the asset and verifies SHA256 again
  3. Checks that the S3 destination doesn't already exist (no overwrites)
  4. Uploads to S3
  5. Cleans up the draft release

This is in a draft state currently and will need some review