### PR TITLE
Adding DMEs to a contig

### DIFF
--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -829,9 +829,9 @@ def add_simulate_species_parser(parser, species):
                 intervals_summary_str = f"[{left}, {right})"
 
             dfe = species.get_dfe(args.dfe)
-            contig.add_dfe(
+            contig.add_dme(
                 intervals=intervals,
-                DFE=dfe,
+                DME=dfe,
             )
             logger.info(
                 f"Applying selection under the DFE model {dfe.id} "

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -772,7 +772,9 @@ class Contig:
         self.dme_list = value
 
     def add_dfe(self, intervals, DFE):
-        """Alias for :meth:`add_dme`, see there for more details."""
+        """
+        Alias for :meth:`add_dme`, see there for more details.
+        """
         self.add_dme(intervals, DFE)
 
     def add_dme(self, intervals, DME):

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -785,7 +785,7 @@ class Contig:
                 "add_dfe is deprecated. Please use add_dme."
             )
         )
-        self.add_dme(self, intervals, DFE)
+        self.add_dme(intervals, DFE)
 
     def add_dme(self, intervals, DME):
         """

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -253,6 +253,13 @@ class Contig:
     mutational effects (DMEs), gene conversion rates and recombination rates
     that are needed to simulate this region.
 
+    Note that distributions of fitness effects (DFEs) are a special case
+    of DMEs, and so DFEs are supported and can be can be used anywhere that
+    calls for a DME. Additionally, all functions and attributes based on DMEs
+    have an aliased version with `dfe` instead of `dme`. For example,
+    ``dfe_list`` is an alias of ``dme_list``, :meth:`.add_dfe` is an alias of
+    :meth:`.add_dme`, and so on.
+
     Information about variants that affect traits
     or fitness are contained in the ``dme_list``
     and ``interval_list``. These must be of the same length, and the k-th DME
@@ -307,6 +314,9 @@ class Contig:
     :ivar dme_list: A list of :class:`.DME` objects.
         By default, the only DME is completely neutral and affects no traits.
     :vartype dme_list: list
+    :ivar dfe_list: Alias of the `dme_list` keyword argument. Note that only
+        one of `dme_list` or `dfe_list` may be specified.
+    :vartype dfe_list: list
     :ivar coordinates: The location of the contig on a named chromosome,
         as a tuple of the form `(chromosome, left, right)`. If `None`, the contig
         is assumed to be generic (i.e. it does not inherit a coordinate system
@@ -342,16 +352,19 @@ class Contig:
     inclusion_mask = attr.ib(default=None)
     exclusion_mask = attr.ib(default=None)
     dme_list = attr.ib(factory=list)
-    _dfe_list = attr.ib(factory=list, alias="dfe_list")
     interval_list = attr.ib(factory=list)
     coordinates = attr.ib(default=None, type=tuple)
     species = attr.ib(default=None, kw_only=True)
+    # _dfe_list only gets used in the initialization and subsequently
+    # gets deleted. It should not be used anywhere else.
+    _dfe_list = attr.ib(factory=list, alias="dfe_list")
 
     def __attrs_post_init__(self):
-        if len(self._dfe_list) > 0 and len(self.dme_list) > 0:
-            raise ValueError("Cannot specify both dme_list and dfe_list.")
         if len(self._dfe_list) > 0:
+            if len(self.dme_list) > 0:
+                raise ValueError("Cannot specify both dme_list and dfe_list.")
             self.dme_list = self._dfe_list
+        del self._dfe_list
 
         if self.coordinates is None:
             self.coordinates = (None, 0, int(self.length))
@@ -689,6 +702,7 @@ class Contig:
             return f"{chromosome}:{left}-{right}"
 
     def dfe_breakpoints(self, *, relative_coordinates=None):
+        """Alias for :meth:`dme_breakpoints`, see there for more details."""
         return self.dme_breakpoints(relative_coordinates=relative_coordinates)
 
     def dme_breakpoints(self, *, relative_coordinates=None):
@@ -734,6 +748,7 @@ class Contig:
         return breaks, dme_labels
 
     def clear_dfes(self):
+        """Alias for :meth:`clear_dmes`, see there for more details."""
         self.clear_dmes()
 
     def clear_dmes(self):
@@ -753,6 +768,7 @@ class Contig:
         self.dme_list = value
 
     def add_dfe(self, intervals, DFE):
+        """Alias for :meth:`add_dme`, see there for more details."""
         self.add_dme(intervals, DFE)
 
     def add_dme(self, intervals, DME):

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -748,7 +748,9 @@ class Contig:
         return breaks, dme_labels
 
     def clear_dfes(self):
-        """Alias for :meth:`clear_dmes`, see there for more details."""
+        """
+        Alias for :meth:`clear_dmes`, see there for more details.
+        """
         self.clear_dmes()
 
     def clear_dmes(self):

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -314,7 +314,7 @@ class Contig:
     :ivar dme_list: A list of :class:`.DME` objects.
         By default, the only DME is completely neutral and affects no traits.
     :vartype dme_list: list
-    :ivar dfe_list: Alias of the `dme_list` keyword argument. Note that only
+    :ivar dfe_list: Alias of the `dme_list` keyword argument. Only
         one of `dme_list` or `dfe_list` may be specified.
     :vartype dfe_list: list
     :ivar coordinates: The location of the contig on a named chromosome,

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -348,6 +348,18 @@ class Contig:
     species = attr.ib(default=None, kw_only=True)
 
     def __attrs_post_init__(self):
+        if self._dfe_list and self.dme_list:
+            raise ValueError(
+                "Cannot specify both dme_list and dfe_list."
+            )
+        if len(self._dfe_list) > 0:
+            warnings.warn(
+                stdpopsim.DeprecatedFeatureWarning(
+                    "Use of dfe_list is deprecated. Please use dme_list."
+                )
+            )
+            self.dme_list = self._dfe_list
+
         if self.coordinates is None:
             self.coordinates = (None, 0, int(self.length))
         _, left, right = self.coordinates
@@ -364,17 +376,6 @@ class Contig:
                 genome=None,
                 ensembl_id="none",
             )
-        if self._dfe_list and self.dme_list:
-            raise ValueError(
-                "Cannot specify both dme_list and dfe_list."
-            )
-        if len(self._dfe_list) > 0:
-            warnings.warn(
-                stdpopsim.DeprecatedFeatureWarning(
-                    "Use of dfe_list is deprecated. Please use dme_list."
-                )
-            )
-            self.dme_list = self._dfe_list
 
     @staticmethod
     def basic_contig(

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -250,12 +250,13 @@ class Contig:
     """
     Class representing a contiguous region of genome that is to be simulated.
     This contains the information about mutation rates, distributions of
-    fitness effects (DFEs), gene conversion rates and recombination rates
+    mutational effects (DMEs), gene conversion rates and recombination rates
     that are needed to simulate this region.
 
-    Information about targets of selection are contained in the ``dfe_list``
-    and ``interval_list``. These must be of the same length, and the k-th DFE
-    applies to the k-th interval; see :meth:`.add_dfe` for more information.
+    Information about variants that affect traits
+    or fitness are contained in the ``dme_list``
+    and ``interval_list``. These must be of the same length, and the k-th DME
+    applies to the k-th interval; see :meth:`.add_dme` for more information.
 
     One attribute of the Contig is ``species``, which is necessary to pass
     on aspects of life history important for simulation. However, generic
@@ -299,12 +300,13 @@ class Contig:
     :ivar exclude: If True, ``mask_intervals`` specify regions to exclude. If False,
         ``mask_intervals`` specify regions in keep.
     :vartype exclude: bool
-    :ivar dfe_list: A list of :class:`.DFE` objects.
-        By default, the only DFE is completely neutral.
-    :vartype dfe_list: list
     :ivar interval_list: A list of :class:`np.array` objects containing integers.
-        By default, the inital interval list spans the whole chromosome with the
-        neutral DFE.
+        These specify where each DME provided in dme_list is applied.
+        By default, the inital interval list spans the whole chromosome with
+        DME where variants have no effects on traits or fitness.
+    :ivar dme_list: A list of :class:`.DME` objects.
+        By default, the only DME is completely neutral and affects no traits.
+    :vartype dme_list: list
     :ivar coordinates: The location of the contig on a named chromosome,
         as a tuple of the form `(chromosome, left, right)`. If `None`, the contig
         is assumed to be generic (i.e. it does not inherit a coordinate system
@@ -339,7 +341,8 @@ class Contig:
     genetic_map = attr.ib(default=None)
     inclusion_mask = attr.ib(default=None)
     exclusion_mask = attr.ib(default=None)
-    dfe_list = attr.ib(factory=list)
+    dme_list = attr.ib(factory=list)
+    _dfe_list = attr.ib(factory=list, alias="dfe_list")
     interval_list = attr.ib(factory=list)
     coordinates = attr.ib(default=None, type=tuple)
     species = attr.ib(default=None, kw_only=True)
@@ -348,9 +351,9 @@ class Contig:
         if self.coordinates is None:
             self.coordinates = (None, 0, int(self.length))
         _, left, right = self.coordinates
-        self.add_dfe(
+        self.add_dme(
             np.array([[left, right]]),
-            stdpopsim.dfe.neutral_dfe(),
+            stdpopsim.traits.neutral_dfe(),
         )
         if self.species is None:
             self.species = stdpopsim.species.Species(
@@ -361,6 +364,17 @@ class Contig:
                 genome=None,
                 ensembl_id="none",
             )
+        if self._dfe_list and self.dme_list:
+            raise ValueError(
+                "Cannot specify both dme_list and dfe_list."
+            )
+        if len(self._dfe_list) > 0:
+            warnings.warn(
+                stdpopsim.DeprecatedFeatureWarning(
+                    "Use of dfe_list is deprecated. Please use dme_list."
+                )
+            )
+            self.dme_list = self._dfe_list
 
     @staticmethod
     def basic_contig(
@@ -681,29 +695,37 @@ class Contig:
             return f"{chromosome}:{left}-{right}"
 
     def dfe_breakpoints(self, *, relative_coordinates=None):
+        warnings.warn(
+            stdpopsim.DeprecatedFeatureWarning(
+                "dfe_breakpoints is deprecated. Please use dme_breakpoints."
+            )
+        )
+        return self.dme_breakpoints(relative_coordinates=relative_coordinates)
+
+    def dme_breakpoints(self, *, relative_coordinates=None):
         """
         Returns two things: the sorted vector of endpoints of all intervals across
-        all DFEs in the contig, and a vector of integer labels for these intervals,
-        saying which DFE goes with which interval.
+        all DMEs in the contig, and a vector of integer labels for these intervals,
+        saying which DME goes with which interval.
         This provides a complementary method to tell which bit of the contig
-        has which DFE attached, which may be more convenient than the list of two-column
+        has which DME attached, which may be more convenient than the list of two-column
         arrays provided by interval_list.
 
-        Suppose there are n+1 unique interval endpoints across all the DFE intervals
+        Suppose there are n+1 unique interval endpoints across all the DME intervals
         in :attr:`.interval_list`.  (If the intervals in that list
         cover the whole genome, the number of intervals is n.)
-        This method returns a tuple of two things: ``breaks, dfe_labels``.
+        This method returns a tuple of two things: ``breaks, dme_labels``.
         "breaks" is the array containing those n+1 unique endpoints, in increasing order,
-        and "dfe" is the array of length n containing the index of the DFE
+        and "dme" is the array of length n containing the index of the DME
         the applies to that interval. So, ``breaks[0]`` is always 0, and
         ``breaks[n+1]`` is always the length of the contig, and
-        ``dfe_labels[k] = j`` if
+        ``dme_labels[k] = j`` if
         ``[breaks[k], breaks[k+1]]`` is an interval in ``contig.interval_list[j]``,
-        i.e., if ``contig.dfe_list[j]`` applies to the interval starting at
-        ``breaks[k]``.  Some intervals may not be covered by a DFE, in which
+        i.e., if ``contig.dme_list[j]`` applies to the interval starting at
+        ``breaks[k]``.  Some intervals may not be covered by a DME, in which
         case they will have the label ``-1`` (beware of python indexing!).
 
-        :return: A tuple (breaks, dfe_labels).
+        :return: A tuple (breaks, dme_labels).
         """
         if relative_coordinates is not None:
             warnings.warn(
@@ -717,27 +739,63 @@ class Contig:
         breaks = np.unique(
             np.vstack(self.interval_list + [[[0, int(self.length)]]])  # also sorted
         )
-        dfe_labels = np.full(len(breaks) - 1, -1, dtype="int")
+        dme_labels = np.full(len(breaks) - 1, -1, dtype="int")
         for j, intervals in enumerate(self.interval_list):
-            dfe_labels[np.isin(breaks[:-1], intervals[:, 0], assume_unique=True)] = j
-        return breaks, dfe_labels
+            dme_labels[np.isin(breaks[:-1], intervals[:, 0], assume_unique=True)] = j
+        return breaks, dme_labels
 
     def clear_dfes(self):
+        warnings.warn(
+            stdpopsim.DeprecatedFeatureWarning(
+                "The original_coordinates property is deprecated, "
+                "since contigs are no longer shifted to be relative to their "
+                "left endpoint: use Contig.coordinates instead."
+            )
+        )
+        self.clear_dmes()
+
+    def clear_dmes(self):
         """
-        Removes all DFEs from the contig (as well as the corresponding list of
+        Removes all DMEs from the contig (as well as the corresponding list of
         intervals).
         """
-        self.dfe_list = []
+        self.dme_list = []
         self.interval_list = []
 
+    @property
+    def dfe_list(self):
+        warnings.warn(
+            stdpopsim.DeprecatedFeatureWarning(
+                "contig.dfe_list is deprecated. Please use contig.dme_list"
+            )
+        )
+        return self.dme_list
+
+    @dfe_list.setter
+    def dfe_list(self, value):
+        warnings.warn(
+            stdpopsim.DeprecatedFeatureWarning(
+                "contig.dfe_list is deprecated. Please use contig.dme_list"
+            )
+        )
+        self.dme_list = value
+
     def add_dfe(self, intervals, DFE):
+        warnings.warn(
+            stdpopsim.DeprecatedFeatureWarning(
+                "add_dfe is deprecated. Please use add_dme."
+            )
+        )
+        self.add_dme(self, intervals, DFE)
+
+    def add_dme(self, intervals, DME):
         """
-        Adds the provided DFE to the contig, applying to the regions of the
+        Adds the provided DME to the contig, applying to the regions of the
         contig specified in ``intervals``. These intervals are also *removed*
-        from the intervals of any previously-present DFEs - in other words,
-        more recently-added DFEs take precedence. Each DFE added in this way
+        from the intervals of any previously-present DMEs - in other words,
+        more recently-added DMEs take precedence. Each DME added in this way
         carries its own MutationTypes: no mutation types are shared between
-        DFEs added by different calls to ``add_dfe( )``, even if the same DFE
+        DMEs added by different calls to ``add_dme( )``, even if the same DME
         object is added more than once.
 
         For instance, if we do
@@ -746,26 +804,26 @@ class Contig:
 
             a1 = np.array([[0, 100]])
             a2 = np.array([[50, 120]])
-            contig.add_dfe(a1, dfe1)
-            contig.add_dfe(a2, dfe2)
+            contig.add_dme(a1, dme1)
+            contig.add_dme(a2, dme2)
 
-        then ``dfe1`` applies to the region from 0 to 50 (including 0 but not
-        50) and ``dfe2`` applies to the region from 50 to 120 (including 50 but
+        then ``dme1`` applies to the region from 0 to 50 (including 0 but not
+        50) and ``dme2`` applies to the region from 50 to 120 (including 50 but
         not 120).
 
         Any of the ``intervals`` that fall outside of the contig will be
         clipped to the contig boundaries. If no ``intervals`` overlap the
-        contig, an "empty" DFE will be added with a warning.
+        contig, an "empty" DME will be added with a warning.
 
         :param array intervals: A valid set of intervals.
-        :param DFE dfe: A DFE object.
+        :param DME dme: A DME object.
         """
         _, left, right = self.coordinates
         intervals = stdpopsim.utils.clip_intervals(intervals, left, right)
         stdpopsim.utils._check_intervals_validity(intervals, start=left, end=right)
         for j, ints in enumerate(self.interval_list):
             self.interval_list[j] = stdpopsim.utils.mask_intervals(ints, intervals)
-        self.dfe_list.append(DFE)
+        self.dme_list.append(DME)
         self.interval_list.append(intervals)
 
     def add_single_site(
@@ -828,9 +886,9 @@ class Contig:
             description=description,
             long_description=long_description,
         )
-        self.add_dfe(
+        self.add_dme(
             intervals=np.array([[coordinate, coordinate + 1]], dtype="int"),
-            DFE=dfe,
+            DME=dfe,
         )
 
     @property
@@ -838,43 +896,43 @@ class Contig:
         """
         Returns True if the contig has no non-neutral mutation types.
         """
-        return all(mt.is_neutral for d in self.dfe_list for mt in d.mutation_types)
+        return all(mt.is_neutral for d in self.dme_list for mt in d.mutation_types)
 
     def mutation_types(self):
         """
         Provides information about the MutationTypes assigned to this Contig,
-        along with information about which DFE they correspond to. This is
+        along with information about which DME they correspond to. This is
         useful because when simulating with SLiM, the mutation types are
         assigned numeric IDs in the order provided here (e.g., in the order
-        encountered when iterating over the DFEs); this method provides an easy
-        way to map back from their numeric ID to the DFE that each MutationType
+        encountered when iterating over the DMEs); this method provides an easy
+        way to map back from their numeric ID to the DME that each MutationType
         corresponds to.
 
         This method returns a list of dictionaries of length equal to the
-        number of MutationTypes in all DFEs of the contig, each dictionary
-        containing three things: ``"dfe_id"``: the ID of the DFE this
+        number of MutationTypes in all DMEs of the contig, each dictionary
+        containing three things: ``"dme_id"``: the ID of the DME this
         MutationType comes from; ``mutation_type``: the mutation type; and
         ``id``: the index in the list.
 
         For instance, if ``muts`` is a list of mutation objects in a SLiM tree
-        sequence, then the following code will print the IDs of the DFEs that
+        sequence, then the following code will print the IDs of the DMEs that
         each comes from:
 
         .. code-block:: python
 
             mut_types = contig.mutation_types()
             for m in muts:
-                dfe_ids = [mut_types[k]["dfe_id"] for md in m.metadata["muation_list"]]
-                print(f"Mutation {m.id} has mutations from DFE(s) {','.join(dfe_ids)}")
+                dme_ids = [mut_types[k]["dme_id"] for md in m.metadata["muation_list"]]
+                print(f"Mutation {m.id} has mutations from DME(s) {','.join(dme_ids)}")
 
         """
         id = 0
         mut_types = []
-        for d in self.dfe_list:
+        for d in self.dme_list:
             for mt in d.mutation_types:
                 mut_types.append(
                     {
-                        "dfe_id": d.id,
+                        "dme_id": d.id,
                         "mutation_type": mt,
                         "id": id,
                     }
@@ -888,7 +946,7 @@ class Contig:
             "Contig(length={:.2G}, mutation_rate={:.2G}, "
             "recombination_rate={:.2G}, bacterial_recombination={}, "
             "gene_conversion_fraction={}, gene_conversion_length={}, "
-            "genetic_map={}, origin={}, dfe_list={}, "
+            "genetic_map={}, origin={}, dme_list={}, "
             "interval_list={}, species={})"
         ).format(
             self.length,
@@ -899,7 +957,7 @@ class Contig:
             self.gene_conversion_length,
             gmap,
             self.origin,
-            self.dfe_list,
+            self.dme_list,
             self.interval_list,
             self.species.id,
         )

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -702,7 +702,9 @@ class Contig:
             return f"{chromosome}:{left}-{right}"
 
     def dfe_breakpoints(self, *, relative_coordinates=None):
-        """Alias for :meth:`dme_breakpoints`, see there for more details."""
+        """
+        Alias for :meth:`dme_breakpoints`, see there for more details.
+        """
         return self.dme_breakpoints(relative_coordinates=relative_coordinates)
 
     def dme_breakpoints(self, *, relative_coordinates=None):

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -302,8 +302,8 @@ class Contig:
     :vartype exclude: bool
     :ivar interval_list: A list of :class:`np.array` objects containing integers.
         These specify where each DME provided in dme_list is applied.
-        By default, the inital interval list spans the whole chromosome with
-        DME where variants have no effects on traits or fitness.
+        By default, the initial interval list spans the whole chromosome with
+        a DME whose variants have no effects on traits or fitness.
     :ivar dme_list: A list of :class:`.DME` objects.
         By default, the only DME is completely neutral and affects no traits.
     :vartype dme_list: list
@@ -348,14 +348,9 @@ class Contig:
     species = attr.ib(default=None, kw_only=True)
 
     def __attrs_post_init__(self):
-        if self._dfe_list and self.dme_list:
+        if len(self._dfe_list) > 0 and len(self.dme_list) > 0:
             raise ValueError("Cannot specify both dme_list and dfe_list.")
         if len(self._dfe_list) > 0:
-            warnings.warn(
-                stdpopsim.DeprecatedFeatureWarning(
-                    "Use of dfe_list is deprecated. Please use dme_list."
-                )
-            )
             self.dme_list = self._dfe_list
 
         if self.coordinates is None:
@@ -694,11 +689,6 @@ class Contig:
             return f"{chromosome}:{left}-{right}"
 
     def dfe_breakpoints(self, *, relative_coordinates=None):
-        warnings.warn(
-            stdpopsim.DeprecatedFeatureWarning(
-                "dfe_breakpoints is deprecated. Please use dme_breakpoints."
-            )
-        )
         return self.dme_breakpoints(relative_coordinates=relative_coordinates)
 
     def dme_breakpoints(self, *, relative_coordinates=None):
@@ -744,13 +734,6 @@ class Contig:
         return breaks, dme_labels
 
     def clear_dfes(self):
-        warnings.warn(
-            stdpopsim.DeprecatedFeatureWarning(
-                "The original_coordinates property is deprecated, "
-                "since contigs are no longer shifted to be relative to their "
-                "left endpoint: use Contig.coordinates instead."
-            )
-        )
         self.clear_dmes()
 
     def clear_dmes(self):
@@ -763,28 +746,13 @@ class Contig:
 
     @property
     def dfe_list(self):
-        warnings.warn(
-            stdpopsim.DeprecatedFeatureWarning(
-                "contig.dfe_list is deprecated. Please use contig.dme_list"
-            )
-        )
         return self.dme_list
 
     @dfe_list.setter
     def dfe_list(self, value):
-        warnings.warn(
-            stdpopsim.DeprecatedFeatureWarning(
-                "contig.dfe_list is deprecated. Please use contig.dme_list"
-            )
-        )
         self.dme_list = value
 
     def add_dfe(self, intervals, DFE):
-        warnings.warn(
-            stdpopsim.DeprecatedFeatureWarning(
-                "add_dfe is deprecated. Please use add_dme."
-            )
-        )
         self.add_dme(intervals, DFE)
 
     def add_dme(self, intervals, DME):

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -259,6 +259,7 @@ class Contig:
     have an aliased version with `dfe` instead of `dme`. For example,
     ``dfe_list`` is an alias of ``dme_list``, :meth:`.add_dfe` is an alias of
     :meth:`.add_dme`, and so on.
+    We encourage new code to use `dme` rather than `dfe`, however.
 
     Information about variants that affect traits
     or fitness are contained in the ``dme_list``

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -349,9 +349,7 @@ class Contig:
 
     def __attrs_post_init__(self):
         if self._dfe_list and self.dme_list:
-            raise ValueError(
-                "Cannot specify both dme_list and dfe_list."
-            )
+            raise ValueError("Cannot specify both dme_list and dfe_list.")
         if len(self._dfe_list) > 0:
             warnings.warn(
                 stdpopsim.DeprecatedFeatureWarning(

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -761,7 +761,7 @@ def get_slim_mutation_rate_map(contig):
     """
     Returns a tuple with the breakpoints and rates of mutations for SLiM.
     """
-    breaks, dfe_labels = contig.dfe_breakpoints()  # beware -1 labels
+    breaks, dfe_labels = contig.dme_breakpoints()  # beware -1 labels
     slim_fractions = np.array(
         [
             sum(
@@ -771,7 +771,7 @@ def get_slim_mutation_rate_map(contig):
                     if (not mt.is_neutral)
                 ]
             )
-            for d in contig.dfe_list
+            for d in contig.dme_list
         ]
         + [0]
     )  # append 0 for the -1 labels
@@ -805,16 +805,16 @@ def _enum_dfe_and_intervals(contig):
     function we can ensure these two steps assigns numeric ids to the DFEs in the
     same way.
     """
-    assert len(contig.dfe_list) == len(contig.interval_list)
-    for i, (d, ints) in enumerate(zip(contig.dfe_list, contig.interval_list)):
+    assert len(contig.dme_list) == len(contig.interval_list)
+    for i, (d, ints) in enumerate(zip(contig.dme_list, contig.interval_list)):
         yield i, d, ints
 
 
 def _dfe_to_mtypes(contig):
     """
     Assigns mutation type ids to each of the mutation types contained in this
-    `Contig`. This function will return a dictionary with `len(contig.dfe_list)`
-    elements, in which the position of the DFE in `contig.dfe_list` is the key.
+    `Contig`. This function will return a dictionary with `len(contig.dme_list)`
+    elements, in which the position of the DFE in `contig.dme_list` is the key.
     For each DFE, the dictionary holds a list of tuples that contain the
     assigned mutation type ids (used in SLiM) and the `MutationType` object.
     This is necessary so that we use the same numeric ids to the mutation types
@@ -863,7 +863,7 @@ def _add_dfes_to_metadata(ts, contig):
     schema = tables.metadata_schema.asdict()
     metadata = tables.metadata
     schema["properties"].update(_raw_stdpopsim_top_level_schema)
-    dfes = _get_json(contig.dfe_list)
+    dfes = _get_json(contig.dme_list)
     dfe_to_mtypes = _dfe_to_mtypes(contig)
     for i, d, ints in _enum_dfe_and_intervals(contig):
         dfes[i]["intervals"] = ints.tolist()
@@ -1048,7 +1048,7 @@ def slim_makescript(
         coordinate = None
         if hasattr(ee, "single_site_id"):
             dfe_index = [
-                i for i, x in enumerate(contig.dfe_list) if x.id == ee.single_site_id
+                i for i, x in enumerate(contig.dme_list) if x.id == ee.single_site_id
             ]
             if len(dfe_index) != 1:
                 raise ValueError(
@@ -1640,7 +1640,7 @@ class _SLiMEngine(stdpopsim.Engine):
             raise ValueError("slim_scaling_factor must be positive")
         if slim_burn_in < 0:
             raise ValueError("slim_burn_in must be non-negative")
-        if len(contig.dfe_list) == 0:
+        if len(contig.dme_list) == 0:
             raise ValueError("SLiM requires at least one DFE.")
 
         if slim_scaling_factor != 1:
@@ -1923,7 +1923,7 @@ class _SLiMEngine(stdpopsim.Engine):
         ts = self._simplify_remembered(ts)
 
         # Adding neutral mutations to simulation and recapitation periods
-        breaks, dfe_labels = contig.dfe_breakpoints()  # beware -1 labels
+        breaks, dfe_labels = contig.dme_breakpoints()  # beware -1 labels
         for i, dfe in enumerate(ts.metadata["stdpopsim"]["DFEs"]):
             assert len(dfe["proportions"]) == len(dfe["mutation_types"])
             for prop, mt in zip(dfe["proportions"], dfe["mutation_types"]):

--- a/stdpopsim/traits.py
+++ b/stdpopsim/traits.py
@@ -603,7 +603,7 @@ class DFE(DistributionOfMutationEffects):
     Class representing a "Distribution of Fitness Effects", i.e., a DFE.
     The class records the different *mutation types*, and the *proportions*
     with which they occur. The overall rate of mutations will be determined
-    by the Contig to which the DFE is applied (see :meth:`.Contig.add_dfe`).
+    by the Contig to which the DME is applied (see :meth:`.Contig.add_dme`).
 
     This is a specialization of :class:`.DistributionOfMutationEffects`
     to distributions that only affect fitness, and have associated publications

--- a/stdpopsim/traits.py
+++ b/stdpopsim/traits.py
@@ -603,7 +603,7 @@ class DFE(DistributionOfMutationEffects):
     Class representing a "Distribution of Fitness Effects", i.e., a DFE.
     The class records the different *mutation types*, and the *proportions*
     with which they occur. The overall rate of mutations will be determined
-    by the Contig to which the DME is applied (see :meth:`.Contig.add_dme`).
+    by the Contig to which the DFE is applied (see :meth:`.Contig.add_dme`).
 
     This is a specialization of :class:`.DistributionOfMutationEffects`
     to distributions that only affect fitness, and have associated publications

--- a/tests/test_dfes.py
+++ b/tests/test_dfes.py
@@ -580,9 +580,9 @@ class TestCreateDFE:
             mutation_rate=1e-6,
             ploidy=2,
         )
-        contig.add_dfe(
+        contig.add_dme(
             intervals=np.array([[0, contig.length / 2]], dtype="int"),
-            DFE=d,
+            DME=d,
         )
         model = stdpopsim.PiecewiseConstantSize(1000)
         samples = {"pop_0": 1}
@@ -784,10 +784,10 @@ class DFETestMixin:
             mutation_rate=1e-8,  # Ne=1e3 and length=1e6 so theta=40
             ploidy=2,
         )
-        contig.clear_dfes()
-        contig.add_dfe(
+        contig.clear_dmes()
+        contig.add_dme(
             intervals=np.array([[0, contig.length / 2]], dtype="int"),
-            DFE=self.dfe,
+            DME=self.dfe,
         )
 
         model = stdpopsim.PiecewiseConstantSize(1000)

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -124,7 +124,7 @@ class TestBehaviour:
                 mutation_types=mt,
             )
         ]
-        contig.add_dfe(intervals=np.array([[0, 50]]), DFE=dfes[0])
+        contig.add_dme(intervals=np.array([[0, 50]]), DME=dfes[0])
         engine = stdpopsim.get_engine("msprime")
         with pytest.raises(ValueError):
             engine.simulate(model, contig, samples, seed=1)
@@ -141,7 +141,7 @@ class TestBehaviour:
                 mutation_types=mt,
             )
         ]
-        contig.add_dfe(intervals=np.array([[0, 50]]), DFE=dfes[0])
+        contig.add_dme(intervals=np.array([[0, 50]]), DME=dfes[0])
         engine = stdpopsim.get_engine("msprime")
         engine.simulate(model, contig, samples, seed=1)
 

--- a/tests/test_genetic_maps.py
+++ b/tests/test_genetic_maps.py
@@ -15,7 +15,6 @@ import stdpopsim
 from stdpopsim import utils
 import tests
 
-
 # Here we download all the genetic map tarballs in one go and store
 # then in the local cache directory, _test_cache. Tests are then run
 # with the download URLs redirected to local files, which makes them

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -38,7 +38,11 @@ class TestContig(object):
             contig.dfe_list[0].id = "def"
         assert contig.dme_list[0].id == "def"
         contig.dme_list[0].id = "abc"
-        assert contig.dfe_list[0].id == "abc"
+        with pytest.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            dfe_id = contig.dfe_list[0].id
+        assert dfe_id == "abc"
         with pytest.warns(
             stdpopsim.DeprecatedFeatureWarning
         ):

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -19,7 +19,7 @@ class TestContig(object):
     )
 
     def test_dfe_list_aliasing(self):
-        with pytests.warns(
+        with pytest.warns(
             stdpopsim.DeprecatedFeatureWarning
         ):
             contig = stdpopsim.Contig(dfe_list=[self.example_dfe])
@@ -49,8 +49,8 @@ class TestContig(object):
 
     def test_clear_dfes(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        contif.add_dme(
-            intervals=np.array([[10, 30], [50, 100]]),
+        contig.add_dme(
+            np.array([[10, 30], [50, 100]]),
             self.example_dfe
         )
         assert len(contig.dme_list) > 0
@@ -62,18 +62,18 @@ class TestContig(object):
         assert len(contig.dme_list) == 0
         assert len(contig.interval_list) == 0
 
-    def test_add_dfe():
+    def test_add_dfe(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
         with pytest.warns(
             stdpopsim.DeprecatedFeatureWarning
         ):
             contig.add_dfe(
-                intervals=np.array([[10, 30], [50, 100]]),
+                np.array([[10, 30], [50, 100]]),
                 self.example_dfe
             )
         contig_dme = stdpopsim.Contig.basic_contig(length=100)
         contig_dme.add_dme(
-            intervals=np.array([[10, 30], [50, 100]]),
+            np.array([[10, 30], [50, 100]]),
             self.example_dfe
         )
         assert np.allclose(contig.interval_list, contig_dme.interval_list)
@@ -206,7 +206,7 @@ class TestContig(object):
             if clear:
                 dme_ids = []
                 true_ints = []
-            mlse:
+            else:
                 true_ints = [np.array([[0, 10]])]
                 dme_ids = ["neutral"]
             dme_ids += [dme.id for dme in dmes]

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -18,14 +18,75 @@ class TestContig(object):
         mutation_types=[stdpopsim.MutationType() for _ in range(2)],
     )
 
-    def verify_dfe_breakpoints(self, contig):
-        breaks, dfe_labels = contig.dfe_breakpoints()
+    def test_dfe_list_aliasing(self):
+        with pytests.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            contig = stdpopsim.Contig(dfe_list=[self.example_dfe])
+        assert contig.dme_list[0].id == self.example_dfe.id
+        with pytest.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            contig.dfe_list[0].id = "def"
+        assert contig.dme_list[0].id == "def"
+        contig.dme_list[0].id = "abc"
+        assert contig.dfe_list[0].id == "abc"
+        with pytest.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            contig.dfe_list = ['a']
+        assert len(contig.dme_list) == 0 and contig.dme_list[0] == 'a'
+
+    def test_dfe_breakpoints(self):
+        contig = stdpopsim.Contig.basic_contig(length=100)
+        with pytest.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            dfe_res1, dfe_res2 = contig.dfe_breakpoints()
+        dme_res1, dme_res2 = contig.dme_breakpoints()
+        assert np.allclose(dfe_res1, dme_res1)
+        assert np.allclose(dfe_res2, dme_res2)
+
+    def test_clear_dfes(self):
+        contig = stdpopsim.Contig.basic_contig(length=100)
+        contif.add_dme(
+            intervals=np.array([[10, 30], [50, 100]]),
+            self.example_dfe
+        )
+        assert len(contig.dme_list) > 0
+        assert len(contig.interval_list) > 0
+        with pytest.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            contig.clear_dfes()
+        assert len(contig.dme_list) == 0
+        assert len(contig.interval_list) == 0
+
+    def test_add_dfe():
+        contig = stdpopsim.Contig.basic_contig(length=100)
+        with pytest.warns(
+            stdpopsim.DeprecatedFeatureWarning
+        ):
+            contig.add_dfe(
+                intervals=np.array([[10, 30], [50, 100]]),
+                self.example_dfe
+            )
+        contig_dme = stdpopsim.Contig.basic_contig(length=100)
+        contig_dme.add_dme(
+            intervals=np.array([[10, 30], [50, 100]]),
+            self.example_dfe
+        )
+        assert np.allclose(contig.interval_list, contig_dme.interval_list)
+        assert contig.dme_list[0].id == contig_dme.dme_list[0].id
+
+    def verify_dme_breakpoints(self, contig):
+        breaks, dme_labels = contig.dme_breakpoints()
         for j, intervals in enumerate(contig.interval_list):
             for left, right in intervals:
                 assert left in breaks
                 assert right in breaks
                 k = np.searchsorted(breaks, left)
-                assert dfe_labels[k] == j
+                assert dme_labels[k] == j
 
     def test_default_gc(self):
         contig = stdpopsim.Contig.basic_contig(length=42)
@@ -82,49 +143,49 @@ class TestContig(object):
         with pytest.raises(ValueError, match="shorter than the gene conv"):
             _ = sp.get_contig(length=100000)
 
-    def test_default_dfe(self):
+    def test_default_dme(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        assert len(contig.dfe_list) == 1
+        assert len(contig.dme_list) == 1
         assert len(contig.interval_list) == 1
-        assert contig.dfe_list[0].id == "neutral"
+        assert contig.dme_list[0].id == "neutral"
         assert np.all(contig.interval_list[0] == np.array([[0, contig.length]]))
 
-    def test_add_dfe_errors(self):
+    def test_add_dme_errors(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
         # bad intervals
         with pytest.raises(ValueError):
-            contig.add_dfe(np.array([10, 20]), self.example_dfe)
+            contig.add_dme(np.array([10, 20]), self.example_dfe)
         with pytest.raises(ValueError):
-            contig.add_dfe("abc", self.example_dfe)
+            contig.add_dme("abc", self.example_dfe)
 
-    def test_dfe_breakpoints(self):
+    def test_dme_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        contig.clear_dfes()
+        contig.clear_dmes()
         mt = stdpopsim.MutationType()
         for j in range(3):
-            dfe = stdpopsim.DFE(
+            dme = stdpopsim.DFE(
                 id=str(j),
                 description="test",
                 long_description="test test",
                 mutation_types=[mt],
             )
-            contig.add_dfe(
+            contig.add_dme(
                 np.array(
                     [[(j + 1) * 5, (j + 1) * 10], [(j + 1) * 20, (j + 1) * 20 + 1]],
                     dtype="int",
                 ),
-                dfe,
+                dme,
             )
-        self.verify_dfe_breakpoints(contig)
+        self.verify_dme_breakpoints(contig)
 
-    def test_add_dfe(self):
+    def test_add_dme(self):
         for clear in (True, False):
             contig = stdpopsim.Contig.basic_contig(length=100)
             if clear:
-                contig.clear_dfes()
+                contig.clear_dmes()
             props = [0.3, 0.7]
             mt = [stdpopsim.MutationType() for _ in props]
-            dfes = [
+            dmes = [
                 stdpopsim.DFE(
                     id=str(j),
                     description="test",
@@ -134,34 +195,34 @@ class TestContig(object):
                 )
                 for j in range(3)
             ]
-            contig.add_dfe(
+            contig.add_dme(
                 intervals=np.array([[10, 30], [50, 100]]),
-                DFE=dfes[0],
+                DME=dmes[0],
             )
-            contig.add_dfe(intervals=np.array([[30, 40]]), DFE=dfes[1])
-            contig.add_dfe(intervals=np.array([[20, 60]]), DFE=dfes[2])
-            assert len(contig.dfe_list) == 4 - clear
+            contig.add_dme(intervals=np.array([[30, 40]]), DME=dmes[1])
+            contig.add_dme(intervals=np.array([[20, 60]]), DME=dmes[2])
+            assert len(contig.dme_list) == 4 - clear
             assert len(contig.mutation_types()) == 7 - clear
             if clear:
-                dfe_ids = []
+                dme_ids = []
                 true_ints = []
-            else:
+            mlse:
                 true_ints = [np.array([[0, 10]])]
-                dfe_ids = ["neutral"]
-            dfe_ids += [dfe.id for dfe in dfes]
+                dme_ids = ["neutral"]
+            dme_ids += [dme.id for dme in dmes]
             true_ints += [
                 np.array([[10, 20], [60, 100]]),
                 np.empty((0, 2)),
                 np.array([[20, 60]]),
             ]
-            for d, i in zip(contig.dfe_list, dfe_ids):
+            for d, i in zip(contig.dme_list, dme_ids):
                 assert d.id == i
             for a1, a2 in zip(contig.interval_list, true_ints):
                 assert np.all(a1.shape == a2.shape)
                 assert np.all(a1 == a2)
-            self.verify_dfe_breakpoints(contig)
+            self.verify_dme_breakpoints(contig)
 
-    def test_add_dfe_interval_formats(self):
+    def test_add_dme_interval_formats(self):
         L = 50818
         for intervals in (
             [[0, L]],
@@ -169,7 +230,7 @@ class TestContig(object):
             ([0, int(0.2 * L)], [int(0.6 * L), L]),
         ):
             contig = stdpopsim.Contig.basic_contig(length=L)
-            contig.add_dfe(intervals=intervals, DFE=self.example_dfe)
+            contig.add_dme(intervals=intervals, DME=self.example_dfe)
             np.testing.assert_array_equal(intervals, contig.interval_list[1])
         with pytest.raises(ValueError, match="must be a numpy array"):
             stdpopsim.utils._check_intervals_validity([[0, 1]])
@@ -178,7 +239,7 @@ class TestContig(object):
         for neutral in (True, False):
             for dist in ("f", "e"):
                 contig = stdpopsim.Contig.basic_contig(length=100)
-                contig.clear_dfes()
+                contig.clear_dmes()
                 props = [0.3, 0.7]
                 if neutral:
                     s = 0
@@ -190,7 +251,7 @@ class TestContig(object):
                     )
                     for _ in props
                 ]
-                dfes = [
+                dmes = [
                     stdpopsim.DFE(
                         id=str(j),
                         description="test",
@@ -200,11 +261,11 @@ class TestContig(object):
                     )
                     for j in range(2)
                 ]
-                contig.add_dfe(
+                contig.add_dme(
                     intervals=np.array([[10, 30], [50, 100]]),
-                    DFE=dfes[0],
+                    DME=dmes[0],
                 )
-                contig.add_dfe(intervals=np.array([[30, 40]]), DFE=dfes[1])
+                contig.add_dme(intervals=np.array([[30, 40]]), DME=dmes[1])
                 # exponential with mean zero doesn't count as neutral!
                 assert contig.is_neutral is (neutral and dist == "f")
 
@@ -347,48 +408,48 @@ class TestContig(object):
         assert x == ox
         assert y == oy
 
-    def test_add_dfe_coordinate_system(self):
+    def test_add_dme_coordinate_system(self):
         chrom = "chr2"
         species = stdpopsim.get_species("HomSap")
         contig_interval = [200000, 300000]
-        original_dfe_interval = np.array([[190000, 210000], [290000, 310000]])
-        bad_dfe_interval = np.array([[0, 10000], [90000, 100000]])
+        original_dme_interval = np.array([[190000, 210000], [290000, 310000]])
+        bad_dme_interval = np.array([[0, 10000], [90000, 100000]])
         contig = species.get_contig(
             chrom, left=contig_interval[0], right=contig_interval[1]
         )
         # Correctly specified coordinate system
-        contig.add_dfe(
-            intervals=original_dfe_interval,
+        contig.add_dme(
+            intervals=original_dme_interval,
             DFE=self.example_dfe,
         )
         # Coordinate system mismatch. Shifted DFE intervals all fall outside of
         # `contig.origin` so the added DFE is empty: throw a warning
         with pytest.warns(UserWarning, match="No intervals remain"):
-            contig.add_dfe(
-                intervals=bad_dfe_interval,
-                DFE=self.example_dfe,
+            contig.add_dme(
+                intervals=bad_dme_interval,
+                DME=self.example_dfe,
             )
 
-    def test_dfe_breakpoints_coordinate_system(self):
+    def test_dme_breakpoints_coordinate_system(self):
         chrom = "chr2"
         species = stdpopsim.get_species("HomSap")
         contig_interval = [200000, 300000]
-        dfe_interval = [[190000, 210000], [290000, 310000]]
+        dme_interval = [[190000, 210000], [290000, 310000]]
         contig = species.get_contig(
             chrom, left=contig_interval[0], right=contig_interval[1]
         )
-        contig.add_dfe(
-            intervals=dfe_interval,
-            DFE=self.example_dfe,
+        contig.add_dme(
+            intervals=dme_interval,
+            DME=self.example_dfe,
         )
-        breakpoints, _ = contig.dfe_breakpoints()
+        breakpoints, _ = contig.dme_breakpoints()
         for x, y in zip(breakpoints, [0, 200000, 210000, 290000, 300000]):
             assert x == y
 
         with pytest.warns(
             stdpopsim.DeprecatedFeatureWarning, match="relative_coordinates argument"
         ):
-            ob, _ = contig.dfe_breakpoints(relative_coordinates=True)
+            ob, _ = contig.dme_breakpoints(relative_coordinates=True)
         for x, y in zip(breakpoints, ob):
             assert x == y
 

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -19,10 +19,18 @@ class TestContig(object):
     )
 
     def test_dfe_list_aliasing(self):
+        chr_id = "chr2"
+        species = stdpopsim.get_species("HomSap")
+        genmap = "HapMapII_GRCh38"
+        chrom = species.get_contig(chr_id, genetic_map=genmap)
         with pytest.warns(
             stdpopsim.DeprecatedFeatureWarning
         ):
-            contig = stdpopsim.Contig(dfe_list=[self.example_dfe])
+            contig = stdpopsim.Contig(
+                recombination_map=chrom.recombination_map,
+                mutation_rate=1e-8,
+                dfe_list=[self.example_dfe],
+            )
         assert contig.dme_list[0].id == self.example_dfe.id
         with pytest.warns(
             stdpopsim.DeprecatedFeatureWarning
@@ -35,7 +43,7 @@ class TestContig(object):
             stdpopsim.DeprecatedFeatureWarning
         ):
             contig.dfe_list = ['a']
-        assert len(contig.dme_list) == 0 and contig.dme_list[0] == 'a'
+        assert len(contig.dme_list) == 1 and contig.dme_list[0] == 'a'
 
     def test_dfe_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
@@ -420,7 +428,7 @@ class TestContig(object):
         # Correctly specified coordinate system
         contig.add_dme(
             intervals=original_dme_interval,
-            DFE=self.example_dfe,
+            DME=self.example_dfe,
         )
         # Coordinate system mismatch. Shifted DFE intervals all fall outside of
         # `contig.origin` so the added DFE is empty: throw a warning

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -81,6 +81,8 @@ class TestContig(object):
             contig.dfe_list = ["a"]
             assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
             assert contig.dfe_list == contig.dme_list
+            with pytest.raises(AttributeError):
+                contig._dfe_list
 
     def test_dfe_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -88,8 +88,8 @@ class TestContig(object):
         contig = stdpopsim.Contig.basic_contig(length=100)
         dfe_res1, dfe_res2 = contig.dfe_breakpoints()
         dme_res1, dme_res2 = contig.dme_breakpoints()
-        assert all(dfe_res1 == dme_res1)
-        assert all(dfe_res2 == dme_res2)
+        np.testing.assert_equal(dfe_res1, dme_res1, strict=True)
+        np.testing.assert_equal(dfe_res2, dme_res2, strict=True)
 
     def test_clear_dfes(self):
         contig = stdpopsim.Contig.basic_contig(length=100)

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -23,37 +23,27 @@ class TestContig(object):
         species = stdpopsim.get_species("HomSap")
         genmap = "HapMapII_GRCh38"
         chrom = species.get_contig(chr_id, genetic_map=genmap)
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
             contig = stdpopsim.Contig(
                 recombination_map=chrom.recombination_map,
                 mutation_rate=1e-8,
                 dfe_list=[self.example_dfe],
             )
         assert contig.dme_list[0].id == self.example_dfe.id
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
             contig.dfe_list[0].id = "def"
         assert contig.dme_list[0].id == "def"
         contig.dme_list[0].id = "abc"
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
             dfe_id = contig.dfe_list[0].id
         assert dfe_id == "abc"
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
-            contig.dfe_list = ['a']
-        assert len(contig.dme_list) == 1 and contig.dme_list[0] == 'a'
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
+            contig.dfe_list = ["a"]
+        assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
 
     def test_dfe_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
             dfe_res1, dfe_res2 = contig.dfe_breakpoints()
         dme_res1, dme_res2 = contig.dme_breakpoints()
         assert np.allclose(dfe_res1, dme_res1)
@@ -61,33 +51,20 @@ class TestContig(object):
 
     def test_clear_dfes(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        contig.add_dme(
-            np.array([[10, 30], [50, 100]]),
-            self.example_dfe
-        )
+        contig.add_dme(np.array([[10, 30], [50, 100]]), self.example_dfe)
         assert len(contig.dme_list) > 0
         assert len(contig.interval_list) > 0
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
             contig.clear_dfes()
         assert len(contig.dme_list) == 0
         assert len(contig.interval_list) == 0
 
     def test_add_dfe(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        with pytest.warns(
-            stdpopsim.DeprecatedFeatureWarning
-        ):
-            contig.add_dfe(
-                np.array([[10, 30], [50, 100]]),
-                self.example_dfe
-            )
+        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
+            contig.add_dfe(np.array([[10, 30], [50, 100]]), self.example_dfe)
         contig_dme = stdpopsim.Contig.basic_contig(length=100)
-        contig_dme.add_dme(
-            np.array([[10, 30], [50, 100]]),
-            self.example_dfe
-        )
+        contig_dme.add_dme(np.array([[10, 30], [50, 100]]), self.example_dfe)
         assert np.allclose(contig.interval_list, contig_dme.interval_list)
         assert contig.dme_list[0].id == contig_dme.dme_list[0].id
 

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -42,7 +42,7 @@ class TestContig(object):
             dfe_list=[self.example_dfe],
         )
         with pytest.raises(AttributeError):
-                contig._dfe_list
+            contig._dfe_list
 
     def test_dfe_list_setter(self):
         chr_id = "chr2"
@@ -76,11 +76,7 @@ class TestContig(object):
             mutation_types=[stdpopsim.MutationType() for _ in range(2)],
         )
 
-        list_of_dfe_lists = [
-            [],
-            [self.example_dfe],
-            [self.example_dfe, example_dfe2]
-        ]
+        list_of_dfe_lists = [[], [self.example_dfe], [self.example_dfe, example_dfe2]]
 
         for dfe_list in list_of_dfe_lists:
 

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -18,6 +18,19 @@ class TestContig(object):
         mutation_types=[stdpopsim.MutationType() for _ in range(2)],
     )
 
+    def test_dfe_and_dme_initalization(self):
+        chr_id = "chr2"
+        species = stdpopsim.get_species("HomSap")
+        genmap = "HapMapII_GRCh38"
+        chrom = species.get_contig(chr_id, genetic_map=genmap)
+        with pytest.raises(ValueError):
+            stdpopsim.Contig(
+                recombination_map=chrom.recombination_map,
+                mutation_rate=1e-8,
+                dfe_list=[self.example_dfe],
+                dme_list=[self.example_dfe],
+            )
+
     def test_dfe_list_aliasing(self):
         chr_id = "chr2"
         species = stdpopsim.get_species("HomSap")

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -36,28 +36,23 @@ class TestContig(object):
         species = stdpopsim.get_species("HomSap")
         genmap = "HapMapII_GRCh38"
         chrom = species.get_contig(chr_id, genetic_map=genmap)
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            contig = stdpopsim.Contig(
-                recombination_map=chrom.recombination_map,
-                mutation_rate=1e-8,
-                dfe_list=[self.example_dfe],
-            )
+        contig = stdpopsim.Contig(
+            recombination_map=chrom.recombination_map,
+            mutation_rate=1e-8,
+            dfe_list=[self.example_dfe],
+        )
         assert contig.dme_list[0].id == self.example_dfe.id
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            contig.dfe_list[0].id = "def"
+        contig.dfe_list[0].id = "def"
         assert contig.dme_list[0].id == "def"
         contig.dme_list[0].id = "abc"
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            dfe_id = contig.dfe_list[0].id
+        dfe_id = contig.dfe_list[0].id
         assert dfe_id == "abc"
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            contig.dfe_list = ["a"]
+        contig.dfe_list = ["a"]
         assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
 
     def test_dfe_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            dfe_res1, dfe_res2 = contig.dfe_breakpoints()
+        dfe_res1, dfe_res2 = contig.dfe_breakpoints()
         dme_res1, dme_res2 = contig.dme_breakpoints()
         assert np.allclose(dfe_res1, dme_res1)
         assert np.allclose(dfe_res2, dme_res2)
@@ -67,15 +62,13 @@ class TestContig(object):
         contig.add_dme(np.array([[10, 30], [50, 100]]), self.example_dfe)
         assert len(contig.dme_list) > 0
         assert len(contig.interval_list) > 0
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            contig.clear_dfes()
+        contig.clear_dfes()
         assert len(contig.dme_list) == 0
         assert len(contig.interval_list) == 0
 
     def test_add_dfe(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
-        with pytest.warns(stdpopsim.DeprecatedFeatureWarning):
-            contig.add_dfe(np.array([[10, 30], [50, 100]]), self.example_dfe)
+        contig.add_dfe(np.array([[10, 30], [50, 100]]), self.example_dfe)
         contig_dme = stdpopsim.Contig.basic_contig(length=100)
         contig_dme.add_dme(np.array([[10, 30], [50, 100]]), self.example_dfe)
         assert np.allclose(contig.interval_list, contig_dme.interval_list)

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -31,6 +31,38 @@ class TestContig(object):
                 dme_list=[self.example_dfe],
             )
 
+    def test_dfe_list_deletion_upon_initalization(self):
+        chr_id = "chr2"
+        species = stdpopsim.get_species("HomSap")
+        genmap = "HapMapII_GRCh38"
+        chrom = species.get_contig(chr_id, genetic_map=genmap)
+        contig = stdpopsim.Contig(
+            recombination_map=chrom.recombination_map,
+            mutation_rate=1e-8,
+            dfe_list=[self.example_dfe],
+        )
+        with pytest.raises(AttributeError):
+                contig._dfe_list
+
+    def test_dfe_list_setter(self):
+        chr_id = "chr2"
+        species = stdpopsim.get_species("HomSap")
+        genmap = "HapMapII_GRCh38"
+        chrom = species.get_contig(chr_id, genetic_map=genmap)
+        contig = stdpopsim.Contig(
+            recombination_map=chrom.recombination_map,
+            mutation_rate=1e-8,
+            dfe_list=[self.example_dfe],
+        )
+        contig.dfe_list[0].id = "def"
+        assert contig.dme_list[0].id == "def"
+        contig.dme_list[0].id = "abc"
+        dfe_id = contig.dfe_list[0].id
+        assert dfe_id == "abc"
+        contig.dfe_list = ["a"]
+        assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
+        assert contig.dme_list == contig.dfe_list
+
     def test_dfe_list_aliasing(self):
         chr_id = "chr2"
         species = stdpopsim.get_species("HomSap")
@@ -44,45 +76,20 @@ class TestContig(object):
             mutation_types=[stdpopsim.MutationType() for _ in range(2)],
         )
 
-        contig1 = stdpopsim.Contig(
-            recombination_map=chrom.recombination_map,
-            mutation_rate=1e-8,
-            dfe_list=[self.example_dfe],
-        )
-        assert contig1.dme_list[0].id == self.example_dfe.id
-        assert len(contig1.dfe_list) == 2
-        assert len(contig1.dme_list) == 2
+        list_of_dfe_lists = [
+            [],
+            [self.example_dfe],
+            [self.example_dfe, example_dfe2]
+        ]
 
-        contig2 = stdpopsim.Contig(
-            recombination_map=chrom.recombination_map,
-            mutation_rate=1e-8,
-            dfe_list=[],
-        )
-        assert len(contig2.dfe_list) == 1
-        assert len(contig2.dme_list) == 1
+        for dfe_list in list_of_dfe_lists:
 
-        contig3 = stdpopsim.Contig(
-            recombination_map=chrom.recombination_map,
-            mutation_rate=1e-8,
-            dfe_list=[self.example_dfe, example_dfe2],
-        )
-        assert len(contig3.dfe_list) == 3
-        assert len(contig3.dme_list) == 3
-        assert contig3.dfe_list[0].id == "abc"
-        assert contig3.dfe_list[1].id == "abc2"
-
-        for contig in [contig1, contig2, contig3]:
+            contig = stdpopsim.Contig(
+                recombination_map=chrom.recombination_map,
+                mutation_rate=1e-8,
+                dfe_list=dfe_list,
+            )
             assert contig.dfe_list == contig.dme_list
-            contig.dfe_list[0].id = "def"
-            assert contig.dme_list[0].id == "def"
-            contig.dme_list[0].id = "abc"
-            dfe_id = contig.dfe_list[0].id
-            assert dfe_id == "abc"
-            contig.dfe_list = ["a"]
-            assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
-            assert contig.dfe_list == contig.dme_list
-            with pytest.raises(AttributeError):
-                contig._dfe_list
 
     def test_dfe_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -23,7 +23,7 @@ class TestContig(object):
         species = stdpopsim.get_species("HomSap")
         genmap = "HapMapII_GRCh38"
         chrom = species.get_contig(chr_id, genetic_map=genmap)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot specify both"):
             stdpopsim.Contig(
                 recombination_map=chrom.recombination_map,
                 mutation_rate=1e-8,
@@ -36,26 +36,58 @@ class TestContig(object):
         species = stdpopsim.get_species("HomSap")
         genmap = "HapMapII_GRCh38"
         chrom = species.get_contig(chr_id, genetic_map=genmap)
-        contig = stdpopsim.Contig(
+        example_dfe2 = stdpopsim.DFE(
+            id="abc2",
+            description="another example DFE",
+            long_description="test test beep boop beep again",
+            proportions=[0.8, 0.2],
+            mutation_types=[stdpopsim.MutationType() for _ in range(2)],
+        )
+
+        contig1 = stdpopsim.Contig(
             recombination_map=chrom.recombination_map,
             mutation_rate=1e-8,
             dfe_list=[self.example_dfe],
         )
-        assert contig.dme_list[0].id == self.example_dfe.id
-        contig.dfe_list[0].id = "def"
-        assert contig.dme_list[0].id == "def"
-        contig.dme_list[0].id = "abc"
-        dfe_id = contig.dfe_list[0].id
-        assert dfe_id == "abc"
-        contig.dfe_list = ["a"]
-        assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
+        assert contig1.dme_list[0].id == self.example_dfe.id
+        assert len(contig1.dfe_list) == 2
+        assert len(contig1.dme_list) == 2
+
+        contig2 = stdpopsim.Contig(
+            recombination_map=chrom.recombination_map,
+            mutation_rate=1e-8,
+            dfe_list=[],
+        )
+        assert len(contig2.dfe_list) == 1
+        assert len(contig2.dme_list) == 1
+
+        contig3 = stdpopsim.Contig(
+            recombination_map=chrom.recombination_map,
+            mutation_rate=1e-8,
+            dfe_list=[self.example_dfe, example_dfe2],
+        )
+        assert len(contig3.dfe_list) == 3
+        assert len(contig3.dme_list) == 3
+        assert contig3.dfe_list[0].id == "abc"
+        assert contig3.dfe_list[1].id == "abc2"
+
+        for contig in [contig1, contig2, contig3]:
+            assert contig.dfe_list == contig.dme_list
+            contig.dfe_list[0].id = "def"
+            assert contig.dme_list[0].id == "def"
+            contig.dme_list[0].id = "abc"
+            dfe_id = contig.dfe_list[0].id
+            assert dfe_id == "abc"
+            contig.dfe_list = ["a"]
+            assert len(contig.dme_list) == 1 and contig.dme_list[0] == "a"
+            assert contig.dfe_list == contig.dme_list
 
     def test_dfe_breakpoints(self):
         contig = stdpopsim.Contig.basic_contig(length=100)
         dfe_res1, dfe_res2 = contig.dfe_breakpoints()
         dme_res1, dme_res2 = contig.dme_breakpoints()
-        assert np.allclose(dfe_res1, dme_res1)
-        assert np.allclose(dfe_res2, dme_res2)
+        assert all(dfe_res1 == dme_res1)
+        assert all(dfe_res2 == dme_res2)
 
     def test_clear_dfes(self):
         contig = stdpopsim.Contig.basic_contig(length=100)

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -211,7 +211,7 @@ class TestAPI:
                 # need selected mutations so that SLiM produces some
                 contig.add_dme(
                     intervals=np.array([[0, contig.length / 2]], dtype="int"),
-                    DFE=stdpopsim.DFE(
+                    DME=stdpopsim.DFE(
                         id="test",
                         description="test",
                         long_description="test",
@@ -391,7 +391,7 @@ class TestAPI:
         contig = species.get_contig("5", left=0, right=100000)
         contig.add_dme(
             intervals=[[0, contig.length // 2]],
-            DFE=stdpopsim.DFE(
+            DME=stdpopsim.DFE(
                 id="test",
                 description="test",
                 long_description="test",
@@ -1723,7 +1723,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         )
         contig.add_dme(
             intervals=np.array([[0, contig.length]], dtype="int"),
-            DFE=stdpopsim.DFE(
+            DME=stdpopsim.DFE(
                 id="neutral_sel",
                 description="neutral with some selected",
                 long_description="test",
@@ -2057,7 +2057,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         )
         contig.add_dme(
             intervals=np.array([[100, 101]], dtype="int"),
-            DFE=dfe,
+            DME=dfe,
         )
         engine = stdpopsim.get_engine("slim")
         with pytest.raises(ValueError, match="must contain a single mutation type"):
@@ -2120,7 +2120,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         )
         contig.add_dme(
             intervals=np.array([[100, 101], [103, 104]], dtype="int"),
-            DFE=dfe,
+            DME=dfe,
         )
         engine = stdpopsim.get_engine("slim")
         with pytest.raises(ValueError, match="refers to a DFE with intervals"):
@@ -2156,7 +2156,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         )
         contig.add_dme(
             intervals=np.array([[100, 102]], dtype="int"),
-            DFE=dfe,
+            DME=dfe,
         )
         engine = stdpopsim.get_engine("slim")
         with pytest.raises(ValueError, match="refers to a DFE with intervals"):
@@ -3035,7 +3035,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
         contig = get_test_contig()
         contig.add_dme(
             intervals=np.array([[0, contig.length // 2]], dtype="int"),
-            DFE=stdpopsim.DFE(
+            DME=stdpopsim.DFE(
                 id="BGS",
                 description="deleterious",
                 long_description="mutations",

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -209,7 +209,7 @@ class TestAPI:
             for proportion, seed in zip((0, 1), (1234, 2345)):
                 contig = species.get_contig(length=50818)
                 # need selected mutations so that SLiM produces some
-                contig.add_dfe(
+                contig.add_dme(
                     intervals=np.array([[0, contig.length / 2]], dtype="int"),
                     DFE=stdpopsim.DFE(
                         id="test",
@@ -389,7 +389,7 @@ class TestAPI:
         engine = stdpopsim.get_engine("slim")
         species = stdpopsim.get_species("AraTha")
         contig = species.get_contig("5", left=0, right=100000)
-        contig.add_dfe(
+        contig.add_dme(
             intervals=[[0, contig.length // 2]],
             DFE=stdpopsim.DFE(
                 id="test",
@@ -1216,7 +1216,7 @@ class TestRecombinationMap(PiecewiseConstantSizeMixin):
         dfe = species.get_dfe("GammaAdditive_H18")
         exons = species.get_annotations("araport_11_exons")
         exon_intervals = exons.get_chromosome_annotations("1")
-        contig.add_dfe(intervals=exon_intervals, DFE=dfe)
+        contig.add_dme(intervals=exon_intervals, DME=dfe)
 
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
@@ -1317,7 +1317,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         for j, dfe in enumerate(dfes):
             interval = [breaks[j], breaks[j + 1]]
             print(j, interval)
-            contig.add_dfe(intervals=np.array([interval], dtype="int"), DFE=dfe)
+            contig.add_dme(intervals=np.array([interval], dtype="int"), DME=dfe)
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             demographic_model=self.model,
@@ -1373,7 +1373,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         slim_ends = mut_rate_metadata["ends"]
         Q = self.slim_metadata_key0(ts.metadata["SLiM"]["user_metadata"], "Q")
 
-        for dfe, intervals in zip(contig.dfe_list, contig.interval_list):
+        for dfe, intervals in zip(contig.dme_list, contig.interval_list):
             prop_nonneutral = 0.0
             for mt, p in zip(dfe.mutation_types, dfe.proportions):
                 if not mt.is_neutral:
@@ -1444,8 +1444,8 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         slim_mt_info = ts.metadata["SLiM"]["user_metadata"]["mutationTypes"][0]
         has_recap = metadata_ids[-1] == "recapitation"
         slim_to_mt_map = {}
-        assert len(contig.dfe_list) + has_recap == len(ts.metadata["stdpopsim"]["DFEs"])
-        for dfe, ts_metadata in zip(contig.dfe_list, ts.metadata["stdpopsim"]["DFEs"]):
+        assert len(contig.dme_list) + has_recap == len(ts.metadata["stdpopsim"]["DFEs"])
+        for dfe, ts_metadata in zip(contig.dme_list, ts.metadata["stdpopsim"]["DFEs"]):
             assert dfe.id == ts_metadata["id"]
             assert len(dfe.mutation_types) == len(ts_metadata["mutation_types"])
             for mt, md in zip(dfe.mutation_types, ts_metadata["mutation_types"]):
@@ -1473,9 +1473,9 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         )
         self.verify_dfes_metadata(ts, ge_types)
         self.verify_discretized_dominance(contig, ts)
-        assert len(contig.dfe_list) == len(ge_types)
+        assert len(contig.dme_list) == len(ge_types)
         for j, (dfe, intervals) in enumerate(
-            zip(contig.dfe_list, contig.interval_list)
+            zip(contig.dme_list, contig.interval_list)
         ):
             assert str(j) in ge_types
             ge = self.slim_metadata_key0(ge_types, str(j))
@@ -1535,8 +1535,8 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
 
     def test_no_dfe(self):
         contig = get_test_contig()
-        contig.clear_dfes()
-        assert len(contig.dfe_list) == 0
+        contig.clear_dmes()
+        assert len(contig.dme_list) == 0
         engine = stdpopsim.get_engine("slim")
         with pytest.raises(ValueError):
             _ = engine.simulate(
@@ -1547,7 +1547,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
 
     def test_default_dfe(self):
         contig = get_test_contig()
-        assert len(contig.dfe_list) == 1
+        assert len(contig.dme_list) == 1
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             demographic_model=self.model,
@@ -1564,10 +1564,10 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         L = contig.length
         example_dfes = self.get_example_dfes()
         for j, dfe in enumerate(example_dfes):
-            contig.add_dfe(
+            contig.add_dme(
                 np.array([[10 * (j + 1), 100 * (10 - j)], [L / 2, L]], dtype="int"), dfe
             )
-        assert len(contig.dfe_list) == 1 + len(example_dfes)
+        assert len(contig.dme_list) == 1 + len(example_dfes)
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             demographic_model=self.model,
@@ -1583,9 +1583,9 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         # test that even if a DFE ends up being unused then it'll still be there
         contig = get_test_contig()
         example_dfes = self.get_example_dfes()
-        contig.add_dfe(np.array([[0, contig.length]], dtype="int"), example_dfes[0])
-        contig.add_dfe(np.array([[0, contig.length]], dtype="int"), example_dfes[3])
-        assert len(contig.dfe_list) == 3
+        contig.add_dme(np.array([[0, contig.length]], dtype="int"), example_dfes[0])
+        contig.add_dme(np.array([[0, contig.length]], dtype="int"), example_dfes[3])
+        assert len(contig.dme_list) == 3
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             demographic_model=self.model,
@@ -1616,11 +1616,11 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             proportions=[0.2, 0.8],
             mutation_types=[m for _, m in self.example_mut_types[7:9]],
         )
-        contig.add_dfe(np.array([[0, 0.5 * L]], dtype="int"), dfe0)
-        contig.add_dfe(np.array([[0.2 * L, 0.4 * L]], dtype="int"), dfe0)
-        contig.add_dfe(np.array([[0.45 * L, L]], dtype="int"), dfe1)
-        contig.add_dfe(np.array([[0.7 * L, 0.9 * L]], dtype="int"), dfe0)
-        assert len(contig.dfe_list) == 5
+        contig.add_dme(np.array([[0, 0.5 * L]], dtype="int"), dfe0)
+        contig.add_dme(np.array([[0.2 * L, 0.4 * L]], dtype="int"), dfe0)
+        contig.add_dme(np.array([[0.45 * L, L]], dtype="int"), dfe1)
+        contig.add_dme(np.array([[0.7 * L, 0.9 * L]], dtype="int"), dfe0)
+        assert len(contig.dme_list) == 5
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             demographic_model=self.model,
@@ -1648,7 +1648,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             ],
             proportions=[0.5, 0.5],
         )
-        contig.add_dfe(np.array([[0, contig.length]], dtype="int"), dfe)
+        contig.add_dme(np.array([[0, contig.length]], dtype="int"), dfe)
         ts = engine.simulate(
             demographic_model=self.model,
             contig=contig,
@@ -1679,12 +1679,12 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         assert ts.num_sites == 0
         self.verify_genomic_elements(contig, ts)
         self.verify_mutation_rates(contig, ts)
-        assert len(ts.metadata["stdpopsim"]["DFEs"]) == len(contig.dfe_list)
+        assert len(ts.metadata["stdpopsim"]["DFEs"]) == len(contig.dme_list)
 
-        contig.dfe_list[0].mutation_types = [
+        contig.dme_list[0].mutation_types = [
             stdpopsim.MutationType() for i in range(10)
         ]
-        contig.dfe_list[0].proportions = [1 / 10 for i in range(10)]
+        contig.dme_list[0].proportions = [1 / 10 for i in range(10)]
         ts = engine.simulate(
             demographic_model=self.model,
             contig=contig,
@@ -1721,7 +1721,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         assert np.allclose(
             ts.metadata["SLiM"]["user_metadata"]["mutationRates"][0]["rates"], [0.0 * Q]
         )
-        contig.add_dfe(
+        contig.add_dme(
             intervals=np.array([[0, contig.length]], dtype="int"),
             DFE=stdpopsim.DFE(
                 id="neutral_sel",
@@ -1771,7 +1771,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             proportions=[0.5, 0.5],
         )
         with pytest.warns(UserWarning, match="No intervals remain"):
-            contig.add_dfe(np.array([[1e6, 1.1e6]], dtype="int"), dfe)
+            contig.add_dme(np.array([[1e6, 1.1e6]], dtype="int"), dfe)
         assert contig.interval_list[1].shape[0] == 0
 
     def test_chromosomal_segment(self):
@@ -1782,12 +1782,12 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
         L = contig.length
         example_dfes = self.get_example_dfes()
         for j, dfe in enumerate(example_dfes):
-            contig.add_dfe(
+            contig.add_dme(
                 left
                 + np.array([[10 * (j + 1), 100 * (10 - j)], [L / 2, L]], dtype="int"),
                 dfe,
             )
-        assert len(contig.dfe_list) == 1 + len(example_dfes)
+        assert len(contig.dme_list) == 1 + len(example_dfes)
         engine = stdpopsim.get_engine("slim")
         ts = engine.simulate(
             demographic_model=self.model,
@@ -1807,15 +1807,15 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
 
         # check that default DFE is clipped to [left, right]
         contig = homsap.get_contig("chr22", left=left, right=right)
-        dfe_breaks, dfe_type = contig.dfe_breakpoints()
+        dfe_breaks, dfe_type = contig.dme_breakpoints()
         assert dfe_breaks.size == 4 and dfe_type.size == 3
         assert dfe_breaks[1] == left and dfe_breaks[2] == right
         assert dfe_type[0] == dfe_type[2] == -1 and dfe_type[1] == 0
 
         # check that added DFE is clipped to [left, right]
         dfe = homsap.get_dfe("Gamma_K17")
-        contig.add_dfe(np.array([[0, contig.length]], dtype="int"), dfe)
-        dfe_breaks, dfe_type = contig.dfe_breakpoints()
+        contig.add_dme(np.array([[0, contig.length]], dtype="int"), dfe)
+        dfe_breaks, dfe_type = contig.dme_breakpoints()
         assert dfe_breaks.size == 4 and dfe_type.size == 3
         assert dfe_breaks[1] == left and dfe_breaks[2] == right
         assert dfe_type[0] == dfe_type[2] == -1 and dfe_type[1] == 1
@@ -1863,11 +1863,11 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             proportions=[0.2, 0.7, 0.1],
             mutation_types=emts,
         )
-        contig.add_dfe(np.array([[0, 0.5 * L]], dtype="int"), dfe0)
-        contig.add_dfe(np.array([[0.2 * L, 0.4 * L]], dtype="int"), dfe0)
-        contig.add_dfe(np.array([[0.45 * L, L]], dtype="int"), dfe1)
-        contig.add_dfe(np.array([[0.7 * L, 0.9 * L]], dtype="int"), dfe0)
-        assert len(contig.dfe_list) == 5
+        contig.add_dme(np.array([[0, 0.5 * L]], dtype="int"), dfe0)
+        contig.add_dme(np.array([[0.2 * L, 0.4 * L]], dtype="int"), dfe0)
+        contig.add_dme(np.array([[0.45 * L, L]], dtype="int"), dfe1)
+        contig.add_dme(np.array([[0.7 * L, 0.9 * L]], dtype="int"), dfe0)
+        assert len(contig.dme_list) == 5
         engine = stdpopsim.get_engine("slim")
         contig.mutation_rate *= 10
         ts = engine.simulate(
@@ -1877,7 +1877,7 @@ class TestGenomicElementTypes(PiecewiseConstantSizeMixin):
             verbosity=3,  # to get metadata output
             seed=260,
         )
-        assert len(ts.metadata["stdpopsim"]["DFEs"]) == len(contig.dfe_list) + 1
+        assert len(ts.metadata["stdpopsim"]["DFEs"]) == len(contig.dme_list) + 1
         # slim mutation type IDs with dominance coeff lists:
         mut_id_haslist = {}
         for dfe in ts.metadata["stdpopsim"]["DFEs"]:
@@ -2022,7 +2022,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
         ]
         contig = get_test_contig()
         contig.add_single_site(id=self.mut_id, coordinate=100)
-        contig.dfe_list[1].mutation_types = []
+        contig.dme_list[1].mutation_types = []
         engine = stdpopsim.get_engine("slim")
         with pytest.raises(ValueError, match="must contain a single mutation type"):
             engine.simulate(
@@ -2055,7 +2055,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             description="test test",
             long_description="test test test",
         )
-        contig.add_dfe(
+        contig.add_dme(
             intervals=np.array([[100, 101]], dtype="int"),
             DFE=dfe,
         )
@@ -2085,7 +2085,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             distribution_args=[1.0, 2.0],
             convert_to_substitution=False,
         )
-        contig.dfe_list[1].mutation_types[0] = mt
+        contig.dme_list[1].mutation_types[0] = mt
         engine = stdpopsim.get_engine("slim")
         with pytest.raises(ValueError, match="instead of a fixed fitness coefficient"):
             engine.simulate(
@@ -2118,7 +2118,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             description="test test",
             long_description="test test test",
         )
-        contig.add_dfe(
+        contig.add_dme(
             intervals=np.array([[100, 101], [103, 104]], dtype="int"),
             DFE=dfe,
         )
@@ -2154,7 +2154,7 @@ class TestDrawMutation(PiecewiseConstantSizeMixin):
             description="test test",
             long_description="test test test",
         )
-        contig.add_dfe(
+        contig.add_dme(
             intervals=np.array([[100, 102]], dtype="int"),
             DFE=dfe,
         )
@@ -3033,7 +3033,7 @@ class TestSelectiveSweep(PiecewiseConstantSizeMixin):
         engine = stdpopsim.get_engine("slim")
         model = self._get_island_model()
         contig = get_test_contig()
-        contig.add_dfe(
+        contig.add_dme(
             intervals=np.array([[0, contig.length // 2]], dtype="int"),
             DFE=stdpopsim.DFE(
                 id="BGS",
@@ -3108,7 +3108,7 @@ class TestSelectionCoeffFromMutation:
     def test_stacked(self):
         engine = stdpopsim.get_engine("slim")
         contig = self.species.get_contig(length=20, mutation_rate=1e-2)
-        contig.add_dfe(np.array([[0, contig.length // 2]]), self.dfe)
+        contig.add_dme(np.array([[0, contig.length // 2]]), self.dfe)
         while True:
             ts = engine.simulate(
                 demographic_model=self.model,


### PR DESCRIPTION
Proposed fix for #1822 - swaps DFEs for DMEs, and preserves backwards compatibility in most places.

Two minor notes to add per @jeffspence:
- in `__str__` and `mutation_types` we break backwards compatibility by replacing "dfe_id" and "dfe_list" (appearing in the string representation) by "dme_id" and "dme_list".  Should we worry about this?
- Do we want to update `add_single_site` to allow a trait effect?