### PR TITLE
start at declaring traits in the slim code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Install development SLiM
       # This should be COMMENTED OUT for release versions,
       # since this builds SLiM from github head.
+      # Also note that this checks out the multitrait branch!!
         if: (matrix.os == 'macos-latest' || matrix.os == 'ubuntu-24.04') && steps.cache.outputs.cache-hit != 'true'
         # If we want to re-build slim from a new commit to the slim repo
         # we may need to bump the cache key above.
@@ -76,6 +77,7 @@ jobs:
           git clone https://github.com/messerlab/SLiM.git
           mkdir -p SLiM/Release
           cd SLiM/Release
+          git checkout multitrait
           cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j 2
 

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -878,7 +878,7 @@ def _add_dfes_to_metadata(ts, contig):
     tables = ts.dump_tables()
     schema = tables.metadata_schema.asdict()
     metadata = tables.metadata
-    schema["properties"].update(_raw_stdpopsim_top_level_schema)
+    schema["json"]["properties"].update(_raw_stdpopsim_top_level_schema)
     dfes = _get_json(contig.dme_list)
     dfe_to_mtypes = _dfe_to_mtypes(contig)
     for i, d, ints in _enum_dfe_and_intervals(contig):
@@ -946,6 +946,9 @@ def slim_makescript(
     logfile=None,
     logfile_interval=1,
 ):
+
+    if traits_model is None:
+        traits_model = stdpopsim.TraitsModel()
 
     _check_traits_model_contig_consistency(contig, traits_model)
 

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -698,6 +698,22 @@ _slim_debug_output = """
     }
 }
 
+// Save trait information in tree sequence metadata
+// This is for development purposes, and the format of this metadata
+// is subject to change or may even be removed!
+1 first() {
+    if (verbosity >= 3) {
+        trait_dict = Dictionary();
+        for (t in sim.traits) {
+            trait_dict.setValue(t.name,
+                Dictionary("type", t.type)
+            );
+        }
+        metadata.setValue(
+            "traits", trait_dict
+        );
+    }
+}
 """
 
 _raw_stdpopsim_top_level_schema = {
@@ -916,6 +932,7 @@ def slim_makescript(
     demographic_model,
     contig,
     samples,
+    traits_model,
     extended_events,
     scaling_factor,
     burn_in,
@@ -1248,6 +1265,13 @@ def slim_makescript(
 
         return "".join(s)
 
+    # Traits
+    for t in traits_model.traits:
+        printsc(
+            f'initializeTrait("{t.id}T", "{t.type}", '
+            f"directFitnessEffect = {'T' if t.id == 'fitness' else 'F'});"
+        )
+
     # Genomic element types.
     mutation_callbacks = {}
     dfe_mtypes = _dfe_to_mtypes(contig)
@@ -1533,6 +1557,7 @@ def slim_makescript(
         )
     printsc(_slim_debug_output)
 
+    # TODO REMOVE THIS MONKEY PATCH MAYBE???
     return epochs[0]
 
 
@@ -1578,6 +1603,7 @@ class _SLiMEngine(stdpopsim.Engine):
         contig,
         samples,
         *,
+        traits_model=None,
         seed=None,
         extended_events=None,
         slim_path=None,
@@ -1603,6 +1629,7 @@ class _SLiMEngine(stdpopsim.Engine):
             will use a two-sex Wright-Fisher model (instead of the default
             hermaphroditic WF model)
 
+        TODO: document ``traits_model``, a TraitsModel
         :param seed: The seed for the random number generator.
         :type seed: int
         :param extended_events: A list of :class:`ExtendedEvents` to be
@@ -1704,6 +1731,7 @@ class _SLiMEngine(stdpopsim.Engine):
                 demographic_model,
                 contig,
                 sample_sets,
+                traits_model,
                 extended_events,
                 slim_scaling_factor,
                 slim_burn_in,
@@ -2000,6 +2028,7 @@ class _SLiMEngine(stdpopsim.Engine):
         demographic_model,
         contig,
         samples,
+        traits_model=None,
         extended_events=None,
         slim_scaling_factor=1.0,
         seed=None,
@@ -2050,6 +2079,7 @@ class _SLiMEngine(stdpopsim.Engine):
                 demographic_model,
                 contig,
                 sample_sets,
+                traits_model,
                 extended_events,
                 slim_scaling_factor,
                 1,

--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -926,6 +926,12 @@ def msprime_rm_to_slim_rm(recombination_map):
     return rates, ends[1:]
 
 
+def _check_traits_model_contig_consistency(contig, traits_model):
+    # TODO: check that all traits utilized in the mutation types
+    # are actually defined in the traits model
+    assert True
+
+
 def slim_makescript(
     script_file,
     trees_file,
@@ -940,6 +946,8 @@ def slim_makescript(
     logfile=None,
     logfile_interval=1,
 ):
+
+    _check_traits_model_contig_consistency(contig, traits_model)
 
     pop_names = [pop.name for pop in demographic_model.model.populations]
     # Use copies of these so that the time frobbing below doesn't have
@@ -1274,6 +1282,7 @@ def slim_makescript(
 
     # Genomic element types.
     mutation_callbacks = {}
+    multivar_muts = {}
     dfe_mtypes = _dfe_to_mtypes(contig)
     for j, d, ints in _enum_dfe_and_intervals(contig):
         # Mutation types and proportions.
@@ -1321,7 +1330,8 @@ def slim_makescript(
                 mut_props_list.append(p)
                 printsc(
                     f"    initializeMutationType({mid}, {h}, "
-                    f'"{mt.distribution_type}", {distrib_args});'
+                    # f'"{mt.distribution_type}", {distrib_args});'
+                    '"f", 0.0);'  # TODO: set direct effects to zero always??
                 )
                 if not mt.convert_to_substitution:
                     # T is the default for WF simulations.
@@ -1331,6 +1341,15 @@ def slim_makescript(
                 # and individual
                 # printsc(f"    mt{mid}.mutationStackGroup = 0;")
                 # printsc(f"    mt{mid}.mutationStackPolicy = 'l';")
+                if len(mt.trait_ids) == 1:  # this only applies to ONE trait
+                    printsc(
+                        f"m{mid}.setEffectSizeDistributionForTrait("
+                        f'"{mt.trait_ids[0]}T", '
+                        f'"{mt.distribution_type}", {distrib_args});'
+                    )
+                else:
+                    # add multivariate mutations to a list to deal with later
+                    multivar_muts[mid] = mt
                 first_mt = False
         mut_types = ", ".join([str(mt) for mt in mut_type_list])
         mut_props = ", ".join(map(str, mut_props_list))
@@ -1545,9 +1564,46 @@ def slim_makescript(
         + ");"
     )
 
+    # finish the initialize() block
     printsc(_slim_lower)
+
+    # do the callbacks
+    for mid, mt in multivar_muts.items():
+        assert mt.distribution_type == "mvn"  # for now
+        effect_means = map(str, mt.distribution_args[0])
+        effect_covar = mt.distribution_args[1]
+        printsc(f"mutation(m{mid}) {{")
+        printsc("    effects = rmvnorm(1, c(" + ", ".join(effect_means) + "), ")
+        printsc(f"                         {matrix2str(effect_covar)});")
+        for j, tid in enumerate(mt.trait_ids):
+            printsc(f'    mut.setEffectSizeForTrait("{tid}T", effects[{j}]);')
+        printsc("    return T;")
+        printsc("}")
+
+    # print out other things
     printsc(_slim_functions)
     printsc(_slim_main)
+
+    # print out the trait stuff
+    printsc("late() {" "inds = sim.subpopulations.individuals;")
+    for t in traits_model.traits:
+        printsc(f'sim.demandPhenotype(NULL, "{t.id}T");')
+        printsc(f'x = inds.phenotypeForTrait("{t.id}T");')
+        if t.transform == "threshold":
+            thresh = t.transform_args[0]
+            printsc(
+                f'inds.setPhenotypeForTrait("{t.id}T", ifelse(x > {thresh}, 1, 0));'
+            )
+        elif t.transform == "liability":
+            center, slope = t.transform_args
+            printsc(f"p = 1 / (1 + exp(-(x - {center}) * {slope}));")
+            printsc(f'inds.setPhenotypeForTrait("{t.id}T", rbinom(size(x), 1, p));')
+        else:
+            assert t.transform == "identity"
+
+    # END print out the trait stuff
+    printsc("}")
+
     if logfile is not None:
         printsc(
             string.Template(_slim_logfile).substitute(
@@ -1726,16 +1782,16 @@ class _SLiMEngine(stdpopsim.Engine):
             script_file, script_filename, ts_filename = st
 
             recap_epoch = slim_makescript(
-                script_file,
-                ts_filename,
-                demographic_model,
-                contig,
-                sample_sets,
-                traits_model,
-                extended_events,
-                slim_scaling_factor,
-                slim_burn_in,
-                slim_rate_map,
+                script_file=script_file,
+                trees_file=ts_filename,
+                demographic_model=demographic_model,
+                contig=contig,
+                samples=sample_sets,
+                traits_model=traits_model,
+                extended_events=extended_events,
+                scaling_factor=slim_scaling_factor,
+                burn_in=slim_burn_in,
+                slim_rate_map=slim_rate_map,
                 logfile=logfile,
                 logfile_interval=logfile_interval,
             )

--- a/stdpopsim/traits.py
+++ b/stdpopsim/traits.py
@@ -29,27 +29,33 @@ def _check_trait_ids(trait_ids):
 
 
 class TraitsModel(object):
-    def __init__(self, traits):
+    def __init__(self, traits=None):
         """
         A list of genetically determined ``traits``,
         linked together by possibly shared effects of ``environments``
         and by ``fitness_functions`` that depend on their values.
+
+        A TraitsModel always includes a multiplicative trait called "fitness". This is
+        automatically included, so this should *not* be included in ``traits``.
 
         On initialization ``environments`` and ``fitness_functions``
         are empty and can be added with :meth:`.add_environment`
         and :meth:`.add_fitness_function`.
         These must all have unique IDs.
 
-        :ivar traits: List of :class:`Trait` objects, with unique IDs.
+        :ivar traits: List of :class:`Trait` objects, with unique IDs,
+            or ``None``.
         :vartype traits: list
         """
-        pids = [p.id for p in traits]
+        # we'll put fitness first, BUT DO NOT RELY ON THIS
+        self.traits = [Trait(id="fitness", type="multiplicative")]
+        if traits is not None:
+            self.traits.extend(traits)
+
+        pids = [p.id for p in self.traits]
         if len(set(pids)) != len(pids):
             raise ValueError("Trait IDs must be unique.")
 
-        # let's put fitness first, BUT NOT RELY ON THIS
-        self.traits = [Trait(id="fitness", type="multiplicative")]
-        self.traits.extend(traits)
         # TODO: check that the names of traits are unique!!
         self.environments = []
         self.fitness_functions = []

--- a/stdpopsim/traits.py
+++ b/stdpopsim/traits.py
@@ -47,7 +47,10 @@ class TraitsModel(object):
         if len(set(pids)) != len(pids):
             raise ValueError("Trait IDs must be unique.")
 
-        self.traits = traits
+        # let's put fitness first, BUT NOT RELY ON THIS
+        self.traits = [Trait(id="fitness", type="multiplicative")]
+        self.traits.extend(traits)
+        # TODO: check that the names of traits are unique!!
         self.environments = []
         self.fitness_functions = []
         # We *could* take in Environment and FitnessFunction objects
@@ -499,6 +502,7 @@ class MutationType(object):
             "n": [0, 1],  # mean and sd
             "w": [0],  # scale
             "s": [],  # script types should just printout arguments
+            "mvn": [],  # TODO
         }
         assert self.distribution_type in scaling_factor_index_lookup
         self.Q_scaled_index = scaling_factor_index_lookup[self.distribution_type]
@@ -559,6 +563,7 @@ class DistributionOfMutationEffects(object):
     :vartype long_description: str
     """
 
+    # TODO: what about id and description and stuff???
     mutation_types = attr.ib(default=None)
     proportions = attr.ib(default=None)
 
@@ -595,6 +600,11 @@ class DistributionOfMutationEffects(object):
                 raise ValueError(
                     "mutation_types must be a list of MutationType objects."
                 )
+
+    @property
+    def is_neutral(self):
+        # TODO
+        return False
 
 
 @attr.s(kw_only=True)

--- a/tests/test_slim_engine.py
+++ b/tests/test_slim_engine.py
@@ -3386,3 +3386,28 @@ class TestSpeciesProperties:
         contig2 = stdpopsim.Contig.basic_contig(length=1000, ploidy=2)
         ts = engine.simulate(model, contig2, samples={"pop_0": 3}, seed=7)
         assert ts.metadata["SLiM"]["separate_sexes"] is False
+
+
+class TestTraits:
+
+    def test_traits_defined(self):
+        traits = [
+            stdpopsim.Trait(id="add", type="additive"),
+            stdpopsim.Trait(id="mult", type="multiplicative"),
+        ]
+        tm = stdpopsim.TraitsModel(
+            traits=traits,
+        )
+        model = stdpopsim.PiecewiseConstantSize(10)
+        engine = stdpopsim.get_engine("slim")
+        species = stdpopsim.get_species("AnaPla")
+        contig = species.get_contig("chr1", left=1e7, right=1e7 + 1e4)
+        ts = engine.simulate(
+            model, contig, samples={"pop_0": 3}, traits_model=tm, seed=7
+        )
+        slim_traits = ts.metadata["SLiM"]["user_metadata"]["traits"]
+        assert len(traits) == len(slim_traits)
+        for t, tid in zip(traits, slim_traits):
+            assert t.id == tid
+            st = slim_traits[tid]
+            assert t.type == st["type"]


### PR DESCRIPTION
This is a start at things - and maybe not a good start! Just trying things out.

*edit:* This PR has code to the following:

1. run tests using (development) multitrait SLiM [(here)](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR80)
2. [initializes traits](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1279)
3. sets up [mutation types](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1332) and [effect size distributions for traits](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1346)
4. as well as the [mutation callback](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1575) for multivariate traits (currently just mvn)
5. sets individual phenotypes and implements [transforms](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1595)

TODOs: should be done or have an issue opened to track

- [ ] provide [consistency check](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR930) for traits and trait model
- [ ] clarify how "fitness" is going to work? currently there's [a trait called "fitness"](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-3e1c6050c108f23af4908d64fb80d312896c6fd1caecfc9145a938908697c536R51) which has direct effects on fitness; is this what we want? this shoudl be documented somewhere? Right now the code has the effects of [new mutations 0 here](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1334) but then later sets the effect size distrn for trait [here](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1346); is this doing the right thing?
- [ ] make the indentation in the SLiM script consistent
- [ ] remove [this monkey patch](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1617) maybe?
- [ ] write docstring for [traits model argument](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-971e0c3ab37a1dafcaa06c7ff25e52b2fd5803b10a2f1cec3a469bcd903c7e7dR1688) to `simulate`
- [ ] write [`is_neutral`](https://github.com/popsim-consortium/stdpopsim/pull/1842/changes#diff-3e1c6050c108f23af4908d64fb80d312896c6fd1caecfc9145a938908697c536R606)