### PR TITLE
drop Python 3.10 support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install deps
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-latest, windows-latest]
-        python: ["3.10", "3.12"]
+        python: ["3.11", "3.12"]
     env:
       CONDA_ENV_NAME: stdpopsim
       OS: ${{ matrix.os }}

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,7 +25,7 @@ Requirements
 Library requirements for ``stdpopsim`` should be installed automatically when using
 either conda or pip.
 
-``stdpopsim`` requires Python 3.10 or later.
+``stdpopsim`` requires Python 3.11 or later.
 
 
 .. _sec_installation_conda:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
@@ -30,7 +29,7 @@ project_urls =
 packages = stdpopsim
 zip_safe = False
 include_package_data = True
-python_requires = >=3.10
+python_requires = >=3.11
 install_requires =
     msprime >= 1.0.4
     attrs >= 19.1.0


### PR DESCRIPTION
Drops Python 3.10 support so the dependabot bumps can be merged. A lot of our dependencies now require >= 3.11 so I guess it's time