### PR TITLE
switch to building multitrait slim

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         # we may need to bump the cache key above.
         shell: bash -l {0}
         run: |
-          git clone https://github.com/messerlab/SLiM.git
+          git clone -b multitrait https://github.com/messerlab/SLiM.git
           mkdir -p SLiM/Release
           cd SLiM/Release
           cmake -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
In #1840 I switched us to building SLiM from source, and *meant* to get the "multitrait" feeatures, but missed that I needed to be building it from this branch.


TODO:

- [ ] update min slim version (see e.g. `test_assert_min_version` in `test_slim_engine.py`)