### PR TITLE
update codecov action to fix gpg missing error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
             tests
 
       - name: upload coverage report to codecov
-        uses: codecov/codecov-action@v5.1.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           fail_ci_if_error: true
           env_vars: OS,PYTHON


### PR DESCRIPTION
From https://status.codecov.com/ :
```
[Codecov uploaders (Action/Orb/Step) fail gpg verification](https://status.codecov.com/incidents/3tyvhnpyxnk8)
Resolved - On Saturday, June 6th, the Codecov gpg public key located at keybase.io/codecovsecurity was absent. This caused widespread outages for users uploading with the Codecov
- GitHub Action
- CircleCI Orb
- Bitrise Step

In order to quickly move and prevent further outages, the Codecov team deleted the `codecovsecurity` account and created `codecovsecops` with the same public gpg key. This key can be verified against any pre-existing CLI to prove it is the same key and also at about.codecov.io/security. The key location was updated in all of the above uploaders on the latest versions.
```